### PR TITLE
Fix for make distcheck

### DIFF
--- a/test/t03_sequence/Makefile.am
+++ b/test/t03_sequence/Makefile.am
@@ -31,7 +31,7 @@ if HDF5_ENABLED
   LIBS += $(HDF5_LIBS)
 endif
 
-EXTRA_DIST     = regression rtest03.sh
+EXTRA_DIST     = rtest03.sh
 check_PROGRAMS = SequenceExample_gsl
 
 ### Leaving disabled for now, need to check with Ernesto


### PR DESCRIPTION
regression seems to be a turd. Removing it from EXTRA_DIST gets make distcheck passing for me in Linux.
