### PR TITLE
Fix various compilation errors

### DIFF
--- a/src/misc/inc/ArrayOfOneDGrids.h
+++ b/src/misc/inc/ArrayOfOneDGrids.h
@@ -93,6 +93,12 @@ public:
   //@{
   //! Prints the values of the array of grids (points). 
   void      print          (std::ostream& os) const;
+  friend std::ostream& operator<< (std::ostream& os,
+      const ArrayOfOneDGrids<V,M>& obj)
+  {
+    obj.print(os);
+    return os;
+  }
   //@}
   
 private:

--- a/src/misc/inc/OneDGrid.h
+++ b/src/misc/inc/OneDGrid.h
@@ -74,6 +74,12 @@ public:
   //@{
   //! Prints the values of the grid points.  
   void         print         (std::ostream& ofsvar) const;
+  friend std::ostream& operator<< (std::ostream& os,
+      const BaseOneDGrid<T>& obj)
+  {
+    obj.print(os);
+    return os;
+  }
   //@}
 
 protected:

--- a/src/misc/src/ArrayOfOneDGrids.C
+++ b/src/misc/src/ArrayOfOneDGrids.C
@@ -27,7 +27,10 @@
 //--------------------------------------------------------------------------
 
 #include <queso/OneDGrid.h>
+#include <queso/UniformOneDGrid.h>
 #include <queso/ArrayOfOneDGrids.h>
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
 
 namespace QUESO {
 
@@ -163,11 +166,6 @@ ArrayOfOneDGrids<V,M>::print(std::ostream& os) const
   return;
 }
 
-template <class V, class M>
-std::ostream& operator<< (std::ostream& os, const ArrayOfOneDGrids<V,M>& obj)
-{
-  obj.print(os);
-  return os;
-}
-
 }  // End namespace QUESO
+
+template class QUESO::ArrayOfOneDGrids<QUESO::GslVector, QUESO::GslMatrix>;

--- a/src/misc/src/ArrayOfOneDTables.C
+++ b/src/misc/src/ArrayOfOneDTables.C
@@ -27,6 +27,8 @@
 //--------------------------------------------------------------------------
 
 #include <queso/ArrayOfOneDTables.h>
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
 
 namespace QUESO {
 
@@ -127,3 +129,5 @@ std::ostream& operator<< (std::ostream& os, const ArrayOfOneDTables<V,M>& obj)
 }
 
 }  // End namespace QUESO
+
+template class QUESO::ArrayOfOneDTables<QUESO::GslVector, QUESO::GslMatrix>;

--- a/src/misc/src/OneDGrid.C
+++ b/src/misc/src/OneDGrid.C
@@ -75,11 +75,6 @@ BaseOneDGrid<T>::print(std::ostream& os) const
   return;
 }
 
-template <class T>
-std::ostream& operator<< (std::ostream& os, const BaseOneDGrid<T>& obj)
-{
-  obj.print(os);
-  return os;
-}
-
 }  // End namespace QUESO
+
+template class QUESO::BaseOneDGrid<double>;

--- a/src/misc/src/UniformOneDGrid.C
+++ b/src/misc/src/UniformOneDGrid.C
@@ -103,3 +103,5 @@ UniformOneDGrid<T>::findIntervalId(const T& paramValue) const
 }
 
 }  // End namespace QUESO
+
+template class QUESO::UniformOneDGrid<double>;


### PR DESCRIPTION
After pulling out a bunch of implementation code from the header files, some
compilation errors resulted.  To fix them, some explicit instantions were added
and the implementation of operator<< was friended and put inline in the header.
