### PR TITLE
Forgot to add some #includes

### DIFF
--- a/src/core/inc/InfiniteDimensionalMCMCSampler.h
+++ b/src/core/inc/InfiniteDimensionalMCMCSampler.h
@@ -22,6 +22,8 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/Defines.h>
+
 #ifdef QUESO_HAVE_HDF5
 
 #ifndef QUESO_INFINITE_SAMPLER_H

--- a/src/core/inc/LibMeshFunction.h
+++ b/src/core/inc/LibMeshFunction.h
@@ -22,6 +22,8 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/Defines.h>
+
 #ifdef QUESO_HAVE_LIBMESH
 
 #ifndef QUESO_LIBMESHFUNCTION_H

--- a/src/core/inc/LibMeshNegativeLaplacianOperator.h
+++ b/src/core/inc/LibMeshNegativeLaplacianOperator.h
@@ -22,6 +22,8 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/Defines.h>
+
 #ifdef QUESO_HAVE_LIBMESH
 
 #ifndef QUESO_LIBMESHNEGATIVELAPLACIANOPERATOR_H

--- a/src/core/inc/LibMeshOperatorBase.h
+++ b/src/core/inc/LibMeshOperatorBase.h
@@ -22,6 +22,8 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/Defines.h>
+
 #ifdef QUESO_HAVE_LIBMESH
 
 #ifndef QUESO_LIBMESHOPERATOR_BASE_H

--- a/src/core/src/InfiniteDimensionalMCMCSampler.C
+++ b/src/core/src/InfiniteDimensionalMCMCSampler.C
@@ -21,6 +21,8 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/Defines.h>
+
 #ifdef QUESO_HAVE_HDF5
 
 #include <cmath>

--- a/src/core/src/LibMeshFunction.C
+++ b/src/core/src/LibMeshFunction.C
@@ -22,6 +22,8 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/Defines.h>
+
 #ifdef QUESO_HAVE_LIBMESH
 
 #include <iostream>

--- a/src/core/src/LibMeshNegativeLaplacianOperator.C
+++ b/src/core/src/LibMeshNegativeLaplacianOperator.C
@@ -22,6 +22,8 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/Defines.h>
+
 #ifdef QUESO_HAVE_LIBMESH
 
 #include <set>

--- a/src/core/src/LibMeshOperatorBase.C
+++ b/src/core/src/LibMeshOperatorBase.C
@@ -22,6 +22,8 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/Defines.h>
+
 #ifdef QUESO_HAVE_LIBMESH
 
 #include <iostream>


### PR DESCRIPTION
This just makes sure we `#include<Defines.h>` in the relevant places so that `QUESO_HAVE_LIBMESH` is defined when it's needed.
