### PR TITLE
Switching from VTK output to ExodusII output

### DIFF
--- a/examples/infinite_dim/gaussian_fields/gaussian_random_field.C
+++ b/examples/infinite_dim/gaussian_fields/gaussian_random_field.C
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
   for (i = 0; i < 5; i++) {
     std::ostringstream number;
     number << i;
-    mu.draw()->save_function("rand_draw" + number.str() + ".e");
+    mu.draw()->save_function("rand_draw" + number.str() + ".e", 0);
   }
 }
 

--- a/examples/infinite_dim/gaussian_fields/gaussian_random_field_genmesh.C
+++ b/examples/infinite_dim/gaussian_fields/gaussian_random_field_genmesh.C
@@ -48,7 +48,7 @@ int main(int argc, char **argv)
   for (i = 0; i < 5; i++) {
     std::ostringstream number;
     number << i;
-    mu.draw()->save_function("rand_draw" + number.str() + ".e");
+    mu.draw()->save_function("rand_draw" + number.str() + ".e", 0);
   }
 }
 

--- a/src/core/inc/FunctionBase.h
+++ b/src/core/inc/FunctionBase.h
@@ -78,8 +78,8 @@ public:
    */
   virtual boost::shared_ptr<FunctionBase> zero_clone() const = 0;
 
-  //! Save the current function to a file \c filename
-  virtual void save_function(const std::string & filename) const = 0;
+  //! Save the current function to an Exodus file called \c filename.  \c time is the time to attach to the function and is usually the iteration number
+  virtual void save_function(const std::string & filename, double time) const = 0;
 };
 
 }  // End namespace QUESO

--- a/src/core/inc/LibMeshFunction.h
+++ b/src/core/inc/LibMeshFunction.h
@@ -73,8 +73,8 @@ public:
   //! Will print mesh-related libMesh foo to \c std::cerr
   void print_info() const;
 
-  //! Save the current function to an Exodus file called \c filename
-  virtual void save_function(const std::string & filename) const;
+  //! Save the current function to an Exodus file called \c filename.  \c time is the time to attach to the function and is usually the iteration number
+  virtual void save_function(const std::string & filename, double time) const;
 
   //! Execute \c this += \c scale * \c rhs
   virtual void add(double scale, const FunctionBase & rhs);

--- a/src/core/src/InfiniteDimensionalMCMCSampler.C
+++ b/src/core/src/InfiniteDimensionalMCMCSampler.C
@@ -327,20 +327,17 @@ void InfiniteDimensionalMCMCSampler::_write_state()
   std::ostringstream curr_iter;
   curr_iter << this->iteration();
 
-  std::string sample_name(basename.str() + "sample_");
+  std::string sample_name(basename.str() + "sample.e-s.");
   sample_name += curr_iter.str();
-  sample_name += ".vtk";
-  this->current_physical_state->save_function(sample_name);
+  this->current_physical_state->save_function(sample_name, this->iteration());
 
-  std::string mean_name(basename.str() + "mean_");
+  std::string mean_name(basename.str() + "mean.e-s.");
   mean_name += curr_iter.str();
-  mean_name += ".vtk";
-  this->current_physical_mean->save_function(mean_name);
+  this->current_physical_mean->save_function(mean_name, this->iteration());
 
-  std::string var_name(basename.str() + "var_");
+  std::string var_name(basename.str() + "var.e-s.");
   var_name += curr_iter.str();
-  var_name += ".vtk";
-  this->current_physical_var->save_function(var_name);
+  this->current_physical_var->save_function(var_name, this->iteration());
 }
 
 boost::shared_ptr<InfiniteDimensionalMCMCSampler> InfiniteDimensionalMCMCSampler::clone_and_reset() const

--- a/src/core/src/LibMeshFunction.C
+++ b/src/core/src/LibMeshFunction.C
@@ -36,7 +36,6 @@
 #include <libmesh/explicit_system.h>
 #include <libmesh/system_norm.h>
 #include <libmesh/exodusII_io.h>
-#include <libmesh/vtk_io.h>
 
 // Define the Finite Element object.
 #include <libmesh/fe.h>
@@ -85,10 +84,13 @@ void LibMeshFunction::print_info() const
   this->equation_systems->get_mesh().print_info(std::cerr);
 }
 
-void LibMeshFunction::save_function(const std::string & filename) const
+void LibMeshFunction::save_function(const std::string & filename, double time) const
 {
-  libMesh::VTKIO(this->equation_systems->get_mesh()).write_equation_systems(
-      filename, *this->equation_systems);
+  // The "1" is hardcoded for the number of time steps because the ExodusII
+  // manual states that it should be the number of timesteps within the file.
+  // Here, we are explicitly only doing one timestep per file.
+  libMesh::ExodusII_IO(this->equation_systems->get_mesh()).write_timestep(
+      filename, *this->equation_systems, 1, time);
 }
 
 void LibMeshFunction::add(double scale, const FunctionBase & rhs) {


### PR DESCRIPTION
Fixes #86.  `make distcheck` passes and the files open in paraview in sequence as expected.
