### PR TITLE
warning/error fixes for icpc 13.1

### DIFF
--- a/src/core/src/InfiniteDimensionalMCMCSampler.C
+++ b/src/core/src/InfiniteDimensionalMCMCSampler.C
@@ -270,6 +270,9 @@ hid_t InfiniteDimensionalMCMCSampler::_create_scalar_dataset(const std::string &
 
     return dset;
   }
+
+  hid_t dummy;
+  return dummy;
 }
 
 void InfiniteDimensionalMCMCSampler::_append_scalar_dataset(hid_t dset, double data)
@@ -284,7 +287,7 @@ void InfiniteDimensionalMCMCSampler::_append_scalar_dataset(hid_t dset, double d
 
     // Extend the dataset
     // Set dims to be the *new* dimension of the extended dataset
-    dims[0] = { this->_iteration / this->m_ov->m_save_freq };
+    dims[0] = this->_iteration / this->m_ov->m_save_freq;
     err = H5Dset_extent(dset, dims);
 
     // Select hyperslab on file dataset


### PR DESCRIPTION
I've seen functions with undefined return values lead to runtime
corruption in the past, although intel only gives us a warning about
it.

Trying to use aggregate initialization for a copy, on the other hand,
gives me a compile-time error.
