### PR TITLE
Tidying up some doxygen niggles

### DIFF
--- a/doxygen/queso.dox.in
+++ b/doxygen/queso.dox.in
@@ -130,7 +130,7 @@ STRIP_FROM_INC_PATH    =
 # (but less readable) file names. This can be useful is your file systems 
 # doesn't support long names like on DOS, Mac, or CD-ROM.
 
-SHORT_NAMES            = NO
+SHORT_NAMES            = YES
 
 # If the JAVADOC_AUTOBRIEF tag is set to YES then Doxygen 
 # will interpret the first line (until the first dot) of a JavaDoc-style 
@@ -766,7 +766,7 @@ ALPHABETICAL_INDEX     = YES
 # the COLS_IN_ALPHA_INDEX tag can be used to specify the number of columns 
 # in which this list will be split (can be a number in the range [1..20])
 
-COLS_IN_ALPHA_INDEX    = 5
+COLS_IN_ALPHA_INDEX    = 2
 
 # In case all classes in a project start with a common prefix, all 
 # classes will be put under the same header in the alphabetical index. 


### PR DESCRIPTION
1. Use fewer columns.  Horizontal scrolling on anything but a Mac is a disaster
2. Use short names for the html doxygen pages.  These names are not stable,
   but GitHub doesn't like the long names because a lot of them lead with an
   underscore

For online documentation, see [here](http://libqueso.github.io/queso/docs/html).
