### PR TITLE
Added rng method for getting a pointer to the gsl_rng object

### DIFF
--- a/src/core/src/RngGsl.C
+++ b/src/core/src/RngGsl.C
@@ -115,4 +115,10 @@ RngGsl::gammaSample(double a, double b) const
   return gsl_ran_gamma(m_rng,a,b);
 }
 
+const gsl_rng* 
+RngGsl::rng() const
+{
+  return m_rng;
+}
+
 }  // End namespace QUESO


### PR DESCRIPTION
The RngGsl.C file lacks the method rng(), although it is prototyped in RngGsl.h (this gave me some nice undefined reference errors from the linker today). I fixed this by adding a proper rng() method to the .C file. All it does is return a constant pointer to the internal gsl_rng object.  
