### PR TITLE
C++11 cpp string concatenation rules differ

### DIFF
--- a/m4/common/config_environment.m4
+++ b/m4/common/config_environment.m4
@@ -58,7 +58,7 @@ AC_DEFINE_UNQUOTED([BUILD_ARCH],     "${BUILD_ARCH}",     [Architecture of the b
 AC_DEFINE_UNQUOTED([BUILD_HOST],     "${BUILD_HOST}",     [Build host name])
 AC_DEFINE_UNQUOTED([BUILD_VERSION],  "${BUILD_VERSION}",  [SVN revision])
 AC_DEFINE_UNQUOTED([BUILD_DEVSTATUS],"${BUILD_DEVSTATUS}",[Dev/Release build])
-AC_DEFINE(         [BUILD_DATE],     __DATE__" "__TIME__, [Build date])
+AC_DEFINE(         [BUILD_DATE],     __DATE__ " " __TIME__, [Build date])
 
 AC_SUBST(BUILD_USER)
 AC_SUBST(BUILD_ARCH)

--- a/m4/common/config_git_environment.m4
+++ b/m4/common/config_git_environment.m4
@@ -57,7 +57,7 @@ AC_DEFINE_UNQUOTED([BUILD_ARCH],     "${BUILD_ARCH}",     [Architecture of the b
 AC_DEFINE_UNQUOTED([BUILD_HOST],     "${BUILD_HOST}",     [Build host name])
 AC_DEFINE_UNQUOTED([BUILD_VERSION],  "${BUILD_VERSION}",  [git revision])
 AC_DEFINE_UNQUOTED([BUILD_DEVSTATUS],"${BUILD_DEVSTATUS}",[Dev/Release build])
-AC_DEFINE(         [BUILD_DATE],     __DATE__" "__TIME__, [Build date])
+AC_DEFINE(         [BUILD_DATE],     __DATE__ " " __TIME__, [Build date])
 
 AC_SUBST(BUILD_USER)
 AC_SUBST(BUILD_ARCH)


### PR DESCRIPTION
This fixes a warning with new gcc, may fix an error some day.
