### PR TITLE
Fix for cobra test for VPATH builds

### DIFF
--- a/test/test_Regression/test_cobra_samples_diff.sh.in
+++ b/test/test_Regression/test_cobra_samples_diff.sh.in
@@ -10,10 +10,10 @@ RUNDIR=`pwd`
 
 . $COMMONDIR/verify.sh
 
-SOLDIR="$srcdir/test_gpmsa_cobra_output"
-EXE="$srcdir/test_gpmsa_cobra"  # executable name
-SOLREFS="$srcdir/test_Regression"
-INFILE="$srcdir/test_Regression/gpmsa_cobra_input.txt"
+SOLDIR="@builddir@/test_gpmsa_cobra_output"
+EXE="@builddir@/test_gpmsa_cobra"  # executable name
+SOLREFS="@builddir@/test_Regression"
+INFILE="@builddir@/test_Regression/gpmsa_cobra_input.txt"
 TESTNAME='Test Cobra GPMSA'
 
 rm -f $SOLDIR/*.m


### PR DESCRIPTION
Cobra test was failing for VPATH (out-of-source builds). This fixes that for me.
