### PR TITLE
Fix sign in log uniform pdf

### DIFF
--- a/src/stats/src/UniformJointPdf.C
+++ b/src/stats/src/UniformJointPdf.C
@@ -112,7 +112,7 @@ UniformJointPdf<V,M>::lnValue(
     volume = 1.;
   }
 
-  return log(volume); // No need to add m_logOfNormalizationFactor [PDF-04]
+  return -log(volume);
 }
 //--------------------------------------------------
 template<class V, class M>


### PR DESCRIPTION
Queso was returning the wrong value for log of a uniform pdf.  While this doesn't change the solution for sampling or minimisation, it was very confusing when debugging when I observed a sign change in my objective function that shouldn't have happened.  `actualValue` returns the correct value, only `lnValue` was incorrect.