### PR TITLE
Fix typo in optimisation API

### DIFF
--- a/examples/gravity/src/gravity_compute.C
+++ b/examples/gravity/src/gravity_compute.C
@@ -4,7 +4,7 @@
 // QUESO - a library to support the Quantification of Uncertainty
 // for Estimation, Simulation and Optimization
 //
-// Copyright (C) 2008,2009,2010,2011,2012,2013 The PECOS Development Team
+// Copyright (C) 2008-2015 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the Version 2.1 GNU Lesser General

--- a/examples/gravity/src/gravity_compute.h
+++ b/examples/gravity/src/gravity_compute.h
@@ -4,7 +4,7 @@
 // QUESO - a library to support the Quantification of Uncertainty
 // for Estimation, Simulation and Optimization
 //
-// Copyright (C) 2008,2009,2010,2011,2012,2013 The PECOS Development Team
+// Copyright (C) 2008-2015 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the Version 2.1 GNU Lesser General

--- a/examples/gravity/src/gravity_likelihood.C
+++ b/examples/gravity/src/gravity_likelihood.C
@@ -4,7 +4,7 @@
 // QUESO - a library to support the Quantification of Uncertainty
 // for Estimation, Simulation and Optimization
 //
-// Copyright (C) 2008,2009,2010,2011,2012,2013 The PECOS Development Team
+// Copyright (C) 2008-2015 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the Version 2.1 GNU Lesser General

--- a/examples/gravity/src/gravity_likelihood.h
+++ b/examples/gravity/src/gravity_likelihood.h
@@ -4,7 +4,7 @@
 // QUESO - a library to support the Quantification of Uncertainty
 // for Estimation, Simulation and Optimization
 //
-// Copyright (C) 2008,2009,2010,2011,2012,2013 The PECOS Development Team
+// Copyright (C) 2008-2015 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the Version 2.1 GNU Lesser General

--- a/examples/gravity/src/gravity_qoi.C
+++ b/examples/gravity/src/gravity_qoi.C
@@ -4,7 +4,7 @@
 // QUESO - a library to support the Quantification of Uncertainty
 // for Estimation, Simulation and Optimization
 //
-// Copyright (C) 2008,2009,2010,2011,2012,2013 The PECOS Development Team
+// Copyright (C) 2008-2015 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the Version 2.1 GNU Lesser General

--- a/examples/gravity/src/gravity_qoi.h
+++ b/examples/gravity/src/gravity_qoi.h
@@ -4,7 +4,7 @@
 // QUESO - a library to support the Quantification of Uncertainty
 // for Estimation, Simulation and Optimization
 //
-// Copyright (C) 2008,2009,2010,2011,2012,2013 The PECOS Development Team
+// Copyright (C) 2008-2015 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the Version 2.1 GNU Lesser General

--- a/src/core/src/GslOptimizer.C
+++ b/src/core/src/GslOptimizer.C
@@ -242,7 +242,7 @@ GslOptimizer::minimizer() const
       case(POLAK_RIBIERE_CG):
       case(BFGS):
       case(BFGS2):
-      case(STEEPEST_DECENT):
+      case(STEEPEST_DESCENT):
         {
           gradient_needed = true;
           break;
@@ -288,7 +288,7 @@ GslOptimizer::minimizer() const
       case(BFGS2):
         type = gsl_multimin_fdfminimizer_vector_bfgs2;
         break;
-      case(STEEPEST_DECENT):
+      case(STEEPEST_DESCENT):
         type = gsl_multimin_fdfminimizer_steepest_descent;
         break;
       case(NELDER_MEAD):
@@ -386,7 +386,7 @@ GslOptimizer::minimizer() const
       case(POLAK_RIBIERE_CG):
       case(BFGS):
       case(BFGS2):
-      case(STEEPEST_DECENT):
+      case(STEEPEST_DESCENT):
       default:
         // Wat?!
         queso_error();
@@ -485,7 +485,7 @@ GslOptimizer::minimizer() const
     else if( solver == std::string("bfgs2") )
       solver_type = BFGS2;
     else if( solver == std::string("steepest_decent") )
-      solver_type = STEEPEST_DECENT;
+      solver_type = STEEPEST_DESCENT;
     else if( solver == std::string("nelder_mead") )
       solver_type = NELDER_MEAD;
     else if( solver == std::string("nelder_mead2") )

--- a/test/test_optimizer/test_gsloptimizer.C
+++ b/test/test_optimizer/test_gsloptimizer.C
@@ -76,7 +76,7 @@ int main(int argc, char ** argv) {
 
   double tol = 1.0e-10;
   optimizer.setTolerance(tol);
-  optimizer.set_solver_type(QUESO::GslOptimizer::STEEPEST_DECENT);
+  optimizer.set_solver_type(QUESO::GslOptimizer::STEEPEST_DESCENT);
 
   QUESO::OptimizerMonitor monitor(env);
   monitor.set_display_output(true,true);


### PR DESCRIPTION
Fixes #304 and addresses [this](https://github.com/libqueso/queso/commit/e4673050538fcc3c4ec8ff7495f0f7cdcf35ed08#commitcomment-9188280) comment.

Also took the opportunity to update some outdated licence headers that were missed in #303.