### PR TITLE
Implement canned Gaussian likelihoods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,5 +169,7 @@ test/test_gpmsa_cobra_output/
 test/test_logitadaptedcov
 test/test_scalarCovariance
 test/test_diagonalCovariance
+test/test_fullCovariance
+test/test_blockDiagonalCovariance
 test/test_output_gaussian_likelihoods
 test/test_gaussian_likelihoods/queso_input.txt

--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,9 @@ examples/outputData
 examples/template_eg
 examples/template_example/outputData
 examples/template_example/template_example
+examples/scalarCovariance
+examples/diagonalCovariance
+examples/fullCovariance
 
 src/core/inc/queso.h
 src/libqueso.la

--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ examples/template_example/template_example
 examples/scalarCovariance
 examples/diagonalCovariance
 examples/fullCovariance
+examples/blockDiagonalCovariance
 
 src/core/inc/queso.h
 src/libqueso.la

--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,5 @@ test/test_Regression/test_jeffreys_samples_diff.sh
 test/test_adaptedcov_output/
 test/test_gpmsa_cobra_output/
 test/test_logitadaptedcov
+test/test_scalarCovariance
+test/test_output_gaussian_likelihoods

--- a/.gitignore
+++ b/.gitignore
@@ -173,3 +173,4 @@ test/test_fullCovariance
 test/test_blockDiagonalCovariance
 test/test_output_gaussian_likelihoods
 test/test_gaussian_likelihoods/queso_input.txt
+test/test_GslBlockMatrixInvertMultiply

--- a/.gitignore
+++ b/.gitignore
@@ -168,4 +168,6 @@ test/test_adaptedcov_output/
 test/test_gpmsa_cobra_output/
 test/test_logitadaptedcov
 test/test_scalarCovariance
+test/test_diagonalCovariance
 test/test_output_gaussian_likelihoods
+test/test_gaussian_likelihoods/queso_input.txt

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,9 @@ QUESO: Quantification of Uncertainty for Estimation,
 Simulation, and Optimization.
 -----------------------------------------------------
 
+Version 0.52.0
+  * Add canned Gaussian likelihoods
+
 Version 0.51.0
   * Add canned likelihood for scalar GPMSA use-case a la Higdon et al
   * Add a logit-transformed transition kernel for more efficient proposals

--- a/configure.ac
+++ b/configure.ac
@@ -208,6 +208,7 @@ AC_CONFIG_FILES([
   test/test_Regression/jeffreys_input.txt
   test/test_Regression/test_jeffreys_samples.m
   test/test_Regression/adaptedcov_input.txt
+  test/test_gaussian_likelihoods/queso_input.txt
   doxygen/Makefile
   doxygen/queso.dox
   doxygen/txt_common/about_vpath.page

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -371,11 +371,16 @@ gpmsa_scalar_CPPFLAGS = -I$(top_srcdir)/examples/gp/scalar $(QUESO_CPPFLAGS)
 # Canned Gaussian likelihood examples #
 #######################################
 scalarCovariancedir = $(prefix)/examples/gaussian_likelihoods
-
 scalarCovariance_PROGRAMS = scalarCovariance
 scalarCovariance_SOURCES = gaussian_likelihoods/scalarCovariance.C
 scalarCovariance_LDADD = $(top_builddir)/src/libqueso.la
 scalarCovariance_CPPFLAGS = -I$(top_srcdir)/examples/gaussian_likelihoods/scalarCovariance $(QUESO_CPPFLAGS)
+
+diagonalCovariancedir = $(prefix)/examples/gaussian_likelihoods
+diagonalCovariance_PROGRAMS = diagonalCovariance
+diagonalCovariance_SOURCES = gaussian_likelihoods/diagonalCovariance.C
+diagonalCovariance_LDADD = $(top_builddir)/src/libqueso.la
+diagonalCovariance_CPPFLAGS = -I$(top_srcdir)/examples/gaussian_likelihoods/diagonalCovariance $(QUESO_CPPFLAGS)
 
 dist_gpmsa_scalar_DATA =
 dist_gpmsa_scalar_DATA += ${gpmsa_scalar_SOURCES}

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -388,6 +388,12 @@ fullCovariance_SOURCES = gaussian_likelihoods/fullCovariance.C
 fullCovariance_LDADD = $(top_builddir)/src/libqueso.la
 fullCovariance_CPPFLAGS = -I$(top_srcdir)/examples/gaussian_likelihoods/fullCovariance $(QUESO_CPPFLAGS)
 
+blockDiagonalCovariancedir = $(prefix)/examples/gaussian_likelihoods
+blockDiagonalCovariance_PROGRAMS = blockDiagonalCovariance
+blockDiagonalCovariance_SOURCES = gaussian_likelihoods/blockDiagonalCovariance.C
+blockDiagonalCovariance_LDADD = $(top_builddir)/src/libqueso.la
+blockDiagonalCovariance_CPPFLAGS = -I$(top_srcdir)/examples/gaussian_likelihoods/blockDiagonalCovariance $(QUESO_CPPFLAGS)
+
 dist_gpmsa_scalar_DATA =
 dist_gpmsa_scalar_DATA += ${gpmsa_scalar_SOURCES}
 

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -382,6 +382,12 @@ diagonalCovariance_SOURCES = gaussian_likelihoods/diagonalCovariance.C
 diagonalCovariance_LDADD = $(top_builddir)/src/libqueso.la
 diagonalCovariance_CPPFLAGS = -I$(top_srcdir)/examples/gaussian_likelihoods/diagonalCovariance $(QUESO_CPPFLAGS)
 
+fullCovariancedir = $(prefix)/examples/gaussian_likelihoods
+fullCovariance_PROGRAMS = fullCovariance
+fullCovariance_SOURCES = gaussian_likelihoods/fullCovariance.C
+fullCovariance_LDADD = $(top_builddir)/src/libqueso.la
+fullCovariance_CPPFLAGS = -I$(top_srcdir)/examples/gaussian_likelihoods/fullCovariance $(QUESO_CPPFLAGS)
+
 dist_gpmsa_scalar_DATA =
 dist_gpmsa_scalar_DATA += ${gpmsa_scalar_SOURCES}
 

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -367,6 +367,16 @@ gpmsa_scalar_SOURCES = gp/scalar/gpmsa_scalar.C
 gpmsa_scalar_LDADD = $(top_builddir)/src/libqueso.la
 gpmsa_scalar_CPPFLAGS = -I$(top_srcdir)/examples/gp/scalar $(QUESO_CPPFLAGS)
 
+#######################################
+# Canned Gaussian likelihood examples #
+#######################################
+scalarCovariancedir = $(prefix)/examples/gaussian_likelihoods
+
+scalarCovariance_PROGRAMS = scalarCovariance
+scalarCovariance_SOURCES = gaussian_likelihoods/scalarCovariance.C
+scalarCovariance_LDADD = $(top_builddir)/src/libqueso.la
+scalarCovariance_CPPFLAGS = -I$(top_srcdir)/examples/gaussian_likelihoods/scalarCovariance $(QUESO_CPPFLAGS)
+
 dist_gpmsa_scalar_DATA =
 dist_gpmsa_scalar_DATA += ${gpmsa_scalar_SOURCES}
 

--- a/examples/gaussian_likelihoods/blockDiagonalCovariance.C
+++ b/examples/gaussian_likelihoods/blockDiagonalCovariance.C
@@ -81,14 +81,6 @@ int main(int argc, char ** argv) {
   QUESO::UniformVectorRV<QUESO::GslVector, QUESO::GslMatrix> priorRv("prior_",
       paramDomain);
 
-  // Set up block sizes for observation covariance matrix
-  std::vector<unsigned int> blockSizes(2);
-  blockSizes[0] = 1;  // First block is 1x1 (scalar)
-  blockSizes[1] = 2;  // Second block is 2x2
-
-  // Set up block matrix with specified block sizes
-  QUESO::GslBlockMatrix covariance(env, blockSizes, 1.0);  // Identity matrix
-
   // Set up observation space
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> obsSpace(env,
       "obs_", 3, NULL);
@@ -98,6 +90,14 @@ int main(int argc, char ** argv) {
   observations[0] = 1.0;
   observations[1] = 1.0;
   observations[2] = 1.0;
+
+  // Set up block sizes for observation covariance matrix
+  std::vector<unsigned int> blockSizes(2);
+  blockSizes[0] = 1;  // First block is 1x1 (scalar)
+  blockSizes[1] = 2;  // Second block is 2x2
+
+  // Set up block matrix (identity matrix) with specified block sizes
+  QUESO::GslBlockMatrix covariance(blockSizes, observations, 1.0);
 
   // Pass in observations to Gaussian likelihood object
   Likelihood<QUESO::GslVector, QUESO::GslMatrix> lhood("llhd_", paramDomain,

--- a/examples/gaussian_likelihoods/blockDiagonalCovariance.C
+++ b/examples/gaussian_likelihoods/blockDiagonalCovariance.C
@@ -1,0 +1,127 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/GslBlockMatrix.h>
+#include <queso/VectorSet.h>
+#include <queso/BoxSubset.h>
+#include <queso/UniformVectorRV.h>
+#include <queso/GenericVectorRV.h>
+#include <queso/GaussianLikelihoodBlockDiagonalCovariance.h>
+#include <queso/StatisticalInverseProblem.h>
+
+template<class V, class M>
+class Likelihood : public QUESO::GaussianLikelihoodBlockDiagonalCovariance<V, M>
+{
+public:
+
+  Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domain,
+      const V & observations, const QUESO::GslBlockMatrix & covariance)
+    : QUESO::GaussianLikelihoodBlockDiagonalCovariance<V, M>(prefix, domain,
+        observations, covariance)
+  {
+  }
+
+  virtual ~Likelihood()
+  {
+  }
+
+  virtual void evaluateModel(const V & domainVector, const V * domainDirection,
+      V & modelOutput, V * gradVector, M * hessianMatrix,
+      V * hessianEffect) const
+  {
+    // Evaluate model and fill up the m_modelOutput member variable
+    for (unsigned int i = 0; i < modelOutput.sizeLocal(); i++) {
+      modelOutput[i] = 1.0;
+    }
+  }
+};
+
+int main(int argc, char ** argv) {
+  MPI_Init(&argc, &argv);
+
+  QUESO::FullEnvironment env(MPI_COMM_WORLD, argv[1], "", NULL);
+
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
+      "param_", 1, NULL);
+
+  double min_val = 0.0;
+  double max_val = 1.0;
+
+  QUESO::GslVector paramMins(paramSpace.zeroVector());
+  paramMins.cwSet(min_val);
+  QUESO::GslVector paramMaxs(paramSpace.zeroVector());
+  paramMaxs.cwSet(max_val);
+
+  QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix> paramDomain("param_",
+      paramSpace, paramMins, paramMaxs);
+
+  QUESO::UniformVectorRV<QUESO::GslVector, QUESO::GslMatrix> priorRv("prior_",
+      paramDomain);
+
+  // Set up block sizes for observation covariance matrix
+  std::vector<unsigned int> blockSizes(2);
+  blockSizes[0] = 1;  // First block is 1x1 (scalar)
+  blockSizes[1] = 2;  // Second block is 2x2
+
+  // Set up block matrix with specified block sizes
+  QUESO::GslBlockMatrix covariance(env, blockSizes, 1.0);  // Identity matrix
+
+  // Set up observation space
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> obsSpace(env,
+      "obs_", 3, NULL);
+
+  // Fill up observation vector
+  QUESO::GslVector observations(obsSpace.zeroVector());
+  observations[0] = 1.0;
+  observations[1] = 1.0;
+  observations[2] = 1.0;
+
+  // Pass in observations to Gaussian likelihood object
+  Likelihood<QUESO::GslVector, QUESO::GslMatrix> lhood("llhd_", paramDomain,
+      observations, covariance);
+
+  QUESO::GenericVectorRV<QUESO::GslVector, QUESO::GslMatrix>
+    postRv("post_", paramSpace);
+
+  QUESO::StatisticalInverseProblem<QUESO::GslVector, QUESO::GslMatrix>
+    ip("", NULL, priorRv, lhood, postRv);
+
+  QUESO::GslVector paramInitials(paramSpace.zeroVector());
+
+  paramInitials[0] = 0.0;
+
+  QUESO::GslMatrix proposalCovMatrix(paramSpace.zeroVector());
+
+  for (unsigned int i = 0; i < 1; i++) {
+    proposalCovMatrix(i, i) = 0.1;
+  }
+
+  ip.solveWithBayesMetropolisHastings(NULL, paramInitials, &proposalCovMatrix);
+
+  MPI_Finalize();
+
+  return 0;
+}

--- a/examples/gaussian_likelihoods/diagonalCovariance.C
+++ b/examples/gaussian_likelihoods/diagonalCovariance.C
@@ -1,0 +1,123 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/VectorSet.h>
+#include <queso/BoxSubset.h>
+#include <queso/UniformVectorRV.h>
+#include <queso/GenericVectorRV.h>
+#include <queso/GaussianLikelihoodDiagonalCovariance.h>
+#include <queso/StatisticalInverseProblem.h>
+
+template<class V, class M>
+class Likelihood : public QUESO::GaussianLikelihoodDiagonalCovariance<V, M>
+{
+public:
+
+  Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domain,
+      const V & observations, const V & covariance)
+    : QUESO::GaussianLikelihoodDiagonalCovariance<V, M>(prefix, domain,
+        observations, covariance)
+  {
+  }
+
+  virtual ~Likelihood()
+  {
+  }
+
+  virtual void evaluateModel(const V & domainVector, const V * domainDirection,
+      V & modelOutput, V * gradVector, M * hessianMatrix,
+      V * hessianEffect) const
+  {
+    // Evaluate model and fill up the m_modelOutput member variable
+    for (unsigned int i = 0; i < modelOutput.sizeLocal(); i++) {
+      modelOutput[i] = 1.0;
+    }
+  }
+};
+
+int main(int argc, char ** argv) {
+  MPI_Init(&argc, &argv);
+
+  QUESO::FullEnvironment env(MPI_COMM_WORLD, argv[1], "", NULL);
+
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
+      "param_", 1, NULL);
+
+  double min_val = 0.0;
+  double max_val = 1.0;
+
+  QUESO::GslVector paramMins(paramSpace.zeroVector());
+  paramMins.cwSet(min_val);
+  QUESO::GslVector paramMaxs(paramSpace.zeroVector());
+  paramMaxs.cwSet(max_val);
+
+  QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix> paramDomain("param_",
+      paramSpace, paramMins, paramMaxs);
+
+  QUESO::UniformVectorRV<QUESO::GslVector, QUESO::GslMatrix> priorRv("prior_",
+      paramDomain);
+
+  // Set up observation space
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> obsSpace(env,
+      "obs_", 2, NULL);
+
+  // Fill up observation vector
+  QUESO::GslVector observations(obsSpace.zeroVector());
+  observations[0] = 1.0;
+  observations[1] = 1.0;
+
+  // Fill up covariance 'matrix'
+  QUESO::GslVector covariance(obsSpace.zeroVector());
+  covariance[0] = 1.0;
+  covariance[1] = 1.0;
+
+  // Pass in observations to Gaussian likelihood object
+  Likelihood<QUESO::GslVector, QUESO::GslMatrix> lhood("llhd_", paramDomain,
+      observations, covariance);
+
+  QUESO::GenericVectorRV<QUESO::GslVector, QUESO::GslMatrix>
+    postRv("post_", paramSpace);
+
+  QUESO::StatisticalInverseProblem<QUESO::GslVector, QUESO::GslMatrix>
+    ip("", NULL, priorRv, lhood, postRv);
+
+  QUESO::GslVector paramInitials(paramSpace.zeroVector());
+
+  paramInitials[0] = 0.0;
+
+  QUESO::GslMatrix proposalCovMatrix(paramSpace.zeroVector());
+
+  for (unsigned int i = 0; i < 1; i++) {
+    proposalCovMatrix(i, i) = 0.1;
+  }
+
+  ip.solveWithBayesMetropolisHastings(NULL, paramInitials, &proposalCovMatrix);
+
+  MPI_Finalize();
+
+  return 0;
+}
+

--- a/examples/gaussian_likelihoods/fullCovariance.C
+++ b/examples/gaussian_likelihoods/fullCovariance.C
@@ -1,0 +1,124 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/VectorSet.h>
+#include <queso/BoxSubset.h>
+#include <queso/UniformVectorRV.h>
+#include <queso/GenericVectorRV.h>
+#include <queso/GaussianLikelihoodFullCovariance.h>
+#include <queso/StatisticalInverseProblem.h>
+
+template<class V, class M>
+class Likelihood : public QUESO::GaussianLikelihoodFullCovariance<V, M>
+{
+public:
+
+  Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domain,
+      const V & observations, const M & covariance)
+    : QUESO::GaussianLikelihoodFullCovariance<V, M>(prefix, domain,
+        observations, covariance)
+  {
+  }
+
+  virtual ~Likelihood()
+  {
+  }
+
+  virtual void evaluateModel(const V & domainVector, const V * domainDirection,
+      V & modelOutput, V * gradVector, M * hessianMatrix,
+      V * hessianEffect) const
+  {
+    // Evaluate model and fill up the m_modelOutput member variable
+    for (unsigned int i = 0; i < modelOutput.sizeLocal(); i++) {
+      modelOutput[i] = 1.0;
+    }
+  }
+};
+
+int main(int argc, char ** argv) {
+  MPI_Init(&argc, &argv);
+
+  QUESO::FullEnvironment env(MPI_COMM_WORLD, argv[1], "", NULL);
+
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
+      "param_", 1, NULL);
+
+  double min_val = 0.0;
+  double max_val = 1.0;
+
+  QUESO::GslVector paramMins(paramSpace.zeroVector());
+  paramMins.cwSet(min_val);
+  QUESO::GslVector paramMaxs(paramSpace.zeroVector());
+  paramMaxs.cwSet(max_val);
+
+  QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix> paramDomain("param_",
+      paramSpace, paramMins, paramMaxs);
+
+  QUESO::UniformVectorRV<QUESO::GslVector, QUESO::GslMatrix> priorRv("prior_",
+      paramDomain);
+
+  // Set up observation space
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> obsSpace(env,
+      "obs_", 2, NULL);
+
+  // Fill up observation vector
+  QUESO::GslVector observations(obsSpace.zeroVector());
+  observations[0] = 1.0;
+  observations[1] = 1.0;
+
+  // Fill up covariance 'matrix'
+  QUESO::GslMatrix covariance(obsSpace.zeroVector());
+  covariance(0, 0) = 1.0;
+  covariance(0, 1) = 0.0;
+  covariance(1, 0) = 0.0;
+  covariance(1, 1) = 1.0;
+
+  // Pass in observations to Gaussian likelihood object
+  Likelihood<QUESO::GslVector, QUESO::GslMatrix> lhood("llhd_", paramDomain,
+      observations, covariance);
+
+  QUESO::GenericVectorRV<QUESO::GslVector, QUESO::GslMatrix>
+    postRv("post_", paramSpace);
+
+  QUESO::StatisticalInverseProblem<QUESO::GslVector, QUESO::GslMatrix>
+    ip("", NULL, priorRv, lhood, postRv);
+
+  QUESO::GslVector paramInitials(paramSpace.zeroVector());
+
+  paramInitials[0] = 0.0;
+
+  QUESO::GslMatrix proposalCovMatrix(paramSpace.zeroVector());
+
+  for (unsigned int i = 0; i < 1; i++) {
+    proposalCovMatrix(i, i) = 0.1;
+  }
+
+  ip.solveWithBayesMetropolisHastings(NULL, paramInitials, &proposalCovMatrix);
+
+  MPI_Finalize();
+
+  return 0;
+}

--- a/examples/gaussian_likelihoods/scalarCovariance.C
+++ b/examples/gaussian_likelihoods/scalarCovariance.C
@@ -1,0 +1,117 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/VectorSet.h>
+#include <queso/BoxSubset.h>
+#include <queso/UniformVectorRV.h>
+#include <queso/GenericVectorRV.h>
+#include <queso/GaussianLikelihoodScalarCovariance.h>
+#include <queso/StatisticalInverseProblem.h>
+
+template<class V, class M>
+class Likelihood : public QUESO::GaussianLikelihoodScalarCovariance<V, M>
+{
+public:
+
+  Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domain,
+      const std::vector<double> & observations, double variance)
+    : QUESO::GaussianLikelihoodScalarCovariance<V, M>(prefix, domain,
+        observations, variance),
+      m_modelOutput(observations.size())
+  {
+  }
+
+  virtual ~Likelihood()
+  {
+  }
+
+  virtual const std::vector<double> & evaluateModel(const V & domainVector,
+      const V * domainDirection, V * gradVector, M * hessianMatrix,
+      V * hessianEffect) const
+  {
+    // Evaluate model and fill up the m_modelOutput member variable
+    for (unsigned int i = 0; i < this->m_modelOutput.size(); i++) {
+      this->m_modelOutput[i] = 1.0;
+    }
+
+    return this->m_modelOutput;
+  }
+
+private:
+  mutable std::vector<double> m_modelOutput;
+};
+
+int main(int argc, char ** argv) {
+  MPI_Init(&argc, &argv);
+
+  QUESO::FullEnvironment env(MPI_COMM_WORLD, argv[1], "", NULL);
+
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
+      "param_", 1, NULL);
+
+  double min_val = 0.0;
+  double max_val = 1.0;
+
+  QUESO::GslVector paramMins(paramSpace.zeroVector());
+  paramMins.cwSet(min_val);
+  QUESO::GslVector paramMaxs(paramSpace.zeroVector());
+  paramMaxs.cwSet(max_val);
+
+  QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix> paramDomain("param_",
+      paramSpace, paramMins, paramMaxs);
+
+  QUESO::UniformVectorRV<QUESO::GslVector, QUESO::GslMatrix> priorRv("prior_",
+      paramDomain);
+
+  std::vector<double> observations(2);
+  observations[0] = 1.0;
+  observations[1] = 1.0;
+  Likelihood<QUESO::GslVector, QUESO::GslMatrix> lhood("llhd_", paramDomain,
+      observations, 1.0);
+
+  QUESO::GenericVectorRV<QUESO::GslVector, QUESO::GslMatrix>
+    postRv("post_", paramSpace);
+
+  QUESO::StatisticalInverseProblem<QUESO::GslVector, QUESO::GslMatrix>
+    ip("", NULL, priorRv, lhood, postRv);
+
+  QUESO::GslVector paramInitials(paramSpace.zeroVector());
+
+  paramInitials[0] = 0.0;
+
+  QUESO::GslMatrix proposalCovMatrix(paramSpace.zeroVector());
+
+  for (unsigned int i = 0; i < 1; i++) {
+    proposalCovMatrix(i, i) = 0.1;
+  }
+
+  ip.solveWithBayesMetropolisHastings(NULL, paramInitials, &proposalCovMatrix);
+
+  MPI_Finalize();
+
+  return 0;
+}
+

--- a/inc/queso/Makefile.am
+++ b/inc/queso/Makefile.am
@@ -106,6 +106,7 @@ BUILT_SOURCES += GammaVectorRV.h
 BUILT_SOURCES += GammaVectorRealizer.h
 BUILT_SOURCES += GaussianJointPdf.h
 BUILT_SOURCES += GaussianLikelihood.h
+BUILT_SOURCES += GaussianLikelihoodDiagonalCovariance.h
 BUILT_SOURCES += GaussianLikelihoodScalarCovariance.h
 BUILT_SOURCES += GaussianVectorCdf.h
 BUILT_SOURCES += GaussianVectorMdf.h
@@ -377,6 +378,8 @@ GammaVectorRealizer.h: $(top_srcdir)/src/stats/inc/GammaVectorRealizer.h
 GaussianJointPdf.h: $(top_srcdir)/src/stats/inc/GaussianJointPdf.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 GaussianLikelihood.h: $(top_srcdir)/src/stats/inc/GaussianLikelihood.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+GaussianLikelihoodDiagonalCovariance.h: $(top_srcdir)/src/stats/inc/GaussianLikelihoodDiagonalCovariance.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 GaussianLikelihoodScalarCovariance.h: $(top_srcdir)/src/stats/inc/GaussianLikelihoodScalarCovariance.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@

--- a/inc/queso/Makefile.am
+++ b/inc/queso/Makefile.am
@@ -107,6 +107,7 @@ BUILT_SOURCES += GammaVectorRV.h
 BUILT_SOURCES += GammaVectorRealizer.h
 BUILT_SOURCES += GaussianJointPdf.h
 BUILT_SOURCES += GaussianLikelihood.h
+BUILT_SOURCES += GaussianLikelihoodBlockDiagonalCovariance.h
 BUILT_SOURCES += GaussianLikelihoodDiagonalCovariance.h
 BUILT_SOURCES += GaussianLikelihoodFullCovariance.h
 BUILT_SOURCES += GaussianLikelihoodScalarCovariance.h
@@ -382,6 +383,8 @@ GammaVectorRealizer.h: $(top_srcdir)/src/stats/inc/GammaVectorRealizer.h
 GaussianJointPdf.h: $(top_srcdir)/src/stats/inc/GaussianJointPdf.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 GaussianLikelihood.h: $(top_srcdir)/src/stats/inc/GaussianLikelihood.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+GaussianLikelihoodBlockDiagonalCovariance.h: $(top_srcdir)/src/stats/inc/GaussianLikelihoodBlockDiagonalCovariance.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 GaussianLikelihoodDiagonalCovariance.h: $(top_srcdir)/src/stats/inc/GaussianLikelihoodDiagonalCovariance.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@

--- a/inc/queso/Makefile.am
+++ b/inc/queso/Makefile.am
@@ -105,6 +105,8 @@ BUILT_SOURCES += GammaJointPdf.h
 BUILT_SOURCES += GammaVectorRV.h
 BUILT_SOURCES += GammaVectorRealizer.h
 BUILT_SOURCES += GaussianJointPdf.h
+BUILT_SOURCES += GaussianLikelihood.h
+BUILT_SOURCES += GaussianLikelihoodScalarCovariance.h
 BUILT_SOURCES += GaussianVectorCdf.h
 BUILT_SOURCES += GaussianVectorMdf.h
 BUILT_SOURCES += GaussianVectorRV.h
@@ -373,6 +375,10 @@ GammaVectorRV.h: $(top_srcdir)/src/stats/inc/GammaVectorRV.h
 GammaVectorRealizer.h: $(top_srcdir)/src/stats/inc/GammaVectorRealizer.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 GaussianJointPdf.h: $(top_srcdir)/src/stats/inc/GaussianJointPdf.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+GaussianLikelihood.h: $(top_srcdir)/src/stats/inc/GaussianLikelihood.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+GaussianLikelihoodScalarCovariance.h: $(top_srcdir)/src/stats/inc/GaussianLikelihoodScalarCovariance.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 GaussianVectorCdf.h: $(top_srcdir)/src/stats/inc/GaussianVectorCdf.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@

--- a/inc/queso/Makefile.am
+++ b/inc/queso/Makefile.am
@@ -36,6 +36,7 @@ BUILT_SOURCES += Environment.h
 BUILT_SOURCES += EnvironmentOptions.h
 BUILT_SOURCES += FunctionBase.h
 BUILT_SOURCES += FunctionOperatorBuilder.h
+BUILT_SOURCES += GslBlockMatrix.h
 BUILT_SOURCES += GslMatrix.h
 BUILT_SOURCES += GslOptimizer.h
 BUILT_SOURCES += GslVector.h
@@ -239,6 +240,8 @@ EnvironmentOptions.h: $(top_srcdir)/src/core/inc/EnvironmentOptions.h
 FunctionBase.h: $(top_srcdir)/src/core/inc/FunctionBase.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 FunctionOperatorBuilder.h: $(top_srcdir)/src/core/inc/FunctionOperatorBuilder.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+GslBlockMatrix.h: $(top_srcdir)/src/core/inc/GslBlockMatrix.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 GslMatrix.h: $(top_srcdir)/src/core/inc/GslMatrix.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@

--- a/inc/queso/Makefile.am
+++ b/inc/queso/Makefile.am
@@ -107,6 +107,7 @@ BUILT_SOURCES += GammaVectorRealizer.h
 BUILT_SOURCES += GaussianJointPdf.h
 BUILT_SOURCES += GaussianLikelihood.h
 BUILT_SOURCES += GaussianLikelihoodDiagonalCovariance.h
+BUILT_SOURCES += GaussianLikelihoodFullCovariance.h
 BUILT_SOURCES += GaussianLikelihoodScalarCovariance.h
 BUILT_SOURCES += GaussianVectorCdf.h
 BUILT_SOURCES += GaussianVectorMdf.h
@@ -380,6 +381,8 @@ GaussianJointPdf.h: $(top_srcdir)/src/stats/inc/GaussianJointPdf.h
 GaussianLikelihood.h: $(top_srcdir)/src/stats/inc/GaussianLikelihood.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 GaussianLikelihoodDiagonalCovariance.h: $(top_srcdir)/src/stats/inc/GaussianLikelihoodDiagonalCovariance.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+GaussianLikelihoodFullCovariance.h: $(top_srcdir)/src/stats/inc/GaussianLikelihoodFullCovariance.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 GaussianLikelihoodScalarCovariance.h: $(top_srcdir)/src/stats/inc/GaussianLikelihoodScalarCovariance.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -92,6 +92,7 @@ libqueso_la_SOURCES += core/src/InfiniteDimensionalMCMCSampler.C
 libqueso_la_SOURCES += core/src/InfiniteDimensionalMCMCSamplerOptions.C
 libqueso_la_SOURCES += core/src/InfiniteDimensionalLikelihoodBase.C
 libqueso_la_SOURCES += core/src/FunctionOperatorBuilder.C
+libqueso_la_SOURCES += core/src/GslBlockMatrix.C
 
 
 # Sources from core/src with gsl conditional
@@ -302,6 +303,7 @@ libqueso_include_HEADERS += core/inc/InfiniteDimensionalMCMCSampler.h
 libqueso_include_HEADERS += core/inc/InfiniteDimensionalMCMCSamplerOptions.h
 libqueso_include_HEADERS += core/inc/InfiniteDimensionalLikelihoodBase.h
 libqueso_include_HEADERS += core/inc/FunctionOperatorBuilder.h
+libqueso_include_HEADERS += core/inc/GslBlockMatrix.h
 
 # Headers to install from misc/inc
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -9,12 +9,12 @@ if GRVY_ENABLED
   AM_CPPFLAGS += $(GRVY_CFLAGS)
 endif
 
-if GLPK_ENABLED	
+if GLPK_ENABLED
   AM_CPPFLAGS += $(GLPK_CFLAGS)
 endif
 
-if HDF5_ENABLED	
-  AM_CPPFLAGS += $(HDF5_CFLAGS) 
+if HDF5_ENABLED
+  AM_CPPFLAGS += $(HDF5_CFLAGS)
 endif
 
 if LIBMESH_ENABLED
@@ -31,16 +31,16 @@ endif
 lib_LTLIBRARIES      = libqueso.la
 libqueso_includedir  = $(prefix)/include/queso
 libqueso_la_LDFLAGS  = $(all_libraries) -release $(GENERIC_RELEASE)
-libqueso_la_LDFLAGS += $(GSL_LIBS) 
+libqueso_la_LDFLAGS += $(GSL_LIBS)
 libqueso_la_LDFLAGS += $(BOOST_PROGRAM_OPTIONS_LDFLAGS) $(BOOST_PROGRAM_OPTIONS_LIBS)
 libqueso_la_LDFLAGS += $(ANN_LIBS)
 libqueso_la_LDFLAGS += $(HDF5_LIBS) $(HDF5_CXXLIBS)
 
-if GRVY_ENABLED	
+if GRVY_ENABLED
   libqueso_la_LDFLAGS += $(GRVY_LIBS)
 endif
 
-if GLPK_ENABLED	
+if GLPK_ENABLED
   libqueso_la_LDFLAGS += $(GLPK_LIBS)
 endif
 
@@ -94,7 +94,7 @@ libqueso_la_SOURCES += core/src/InfiniteDimensionalLikelihoodBase.C
 libqueso_la_SOURCES += core/src/FunctionOperatorBuilder.C
 
 
-# Sources from core/src with gsl conditional 
+# Sources from core/src with gsl conditional
 
 if UQBT_GSL
 libqueso_la_SOURCES += core/src/GslVector.C
@@ -340,7 +340,7 @@ libqueso_include_HEADERS += basic/inc/IntersectionSubset.h
 libqueso_include_HEADERS += basic/inc/GenericVectorFunction.h
 libqueso_include_HEADERS += basic/inc/ConstantVectorFunction.h
 
-# Headers to install from stats/inc 
+# Headers to install from stats/inc
 
 libqueso_include_HEADERS += stats/inc/FiniteDistribution.h
 libqueso_include_HEADERS += stats/inc/JointPdf.h
@@ -423,7 +423,7 @@ libqueso_include_HEADERS += stats/inc/VectorGaussianRandomField.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihood.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodScalarCovariance.h
 
-# Headers to install from gp/inc 
+# Headers to install from gp/inc
 
 libqueso_include_HEADERS += gp/inc/ExperimentModel.h
 libqueso_include_HEADERS += gp/inc/ExperimentModelOptions.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -241,6 +241,7 @@ libqueso_la_SOURCES += stats/src/GaussianLikelihood.C
 libqueso_la_SOURCES += stats/src/GaussianLikelihoodScalarCovariance.C
 libqueso_la_SOURCES += stats/src/GaussianLikelihoodDiagonalCovariance.C
 libqueso_la_SOURCES += stats/src/GaussianLikelihoodFullCovariance.C
+libqueso_la_SOURCES += stats/src/GaussianLikelihoodBlockDiagonalCovariance.C
 
 # Sources from gp/src
 
@@ -428,6 +429,7 @@ libqueso_include_HEADERS += stats/inc/GaussianLikelihood.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodScalarCovariance.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodDiagonalCovariance.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodFullCovariance.h
+libqueso_include_HEADERS += stats/inc/GaussianLikelihoodBlockDiagonalCovariance.h
 
 # Headers to install from gp/inc
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -239,6 +239,7 @@ libqueso_la_SOURCES += stats/src/WignerVectorRV.C
 libqueso_la_SOURCES += stats/src/GaussianLikelihood.C
 libqueso_la_SOURCES += stats/src/GaussianLikelihoodScalarCovariance.C
 libqueso_la_SOURCES += stats/src/GaussianLikelihoodDiagonalCovariance.C
+libqueso_la_SOURCES += stats/src/GaussianLikelihoodFullCovariance.C
 
 # Sources from gp/src
 
@@ -424,6 +425,7 @@ libqueso_include_HEADERS += stats/inc/VectorGaussianRandomField.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihood.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodScalarCovariance.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodDiagonalCovariance.h
+libqueso_include_HEADERS += stats/inc/GaussianLikelihoodFullCovariance.h
 
 # Headers to install from gp/inc
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -236,6 +236,8 @@ libqueso_la_SOURCES += stats/src/JeffreysVectorRV.C
 libqueso_la_SOURCES += stats/src/LogNormalVectorRV.C
 libqueso_la_SOURCES += stats/src/UniformVectorRV.C
 libqueso_la_SOURCES += stats/src/WignerVectorRV.C
+libqueso_la_SOURCES += stats/src/GaussianLikelihood.C
+libqueso_la_SOURCES += stats/src/GaussianLikelihoodScalarCovariance.C
 
 # Sources from gp/src
 
@@ -418,6 +420,8 @@ libqueso_include_HEADERS += stats/inc/ExponentialMatrixCovarianceFunction.h
 libqueso_include_HEADERS += stats/inc/GenericMatrixCovarianceFunction.h
 libqueso_include_HEADERS += stats/inc/ScalarGaussianRandomField.h
 libqueso_include_HEADERS += stats/inc/VectorGaussianRandomField.h
+libqueso_include_HEADERS += stats/inc/GaussianLikelihood.h
+libqueso_include_HEADERS += stats/inc/GaussianLikelihoodScalarCovariance.h
 
 # Headers to install from gp/inc 
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -238,6 +238,7 @@ libqueso_la_SOURCES += stats/src/UniformVectorRV.C
 libqueso_la_SOURCES += stats/src/WignerVectorRV.C
 libqueso_la_SOURCES += stats/src/GaussianLikelihood.C
 libqueso_la_SOURCES += stats/src/GaussianLikelihoodScalarCovariance.C
+libqueso_la_SOURCES += stats/src/GaussianLikelihoodDiagonalCovariance.C
 
 # Sources from gp/src
 
@@ -422,6 +423,7 @@ libqueso_include_HEADERS += stats/inc/ScalarGaussianRandomField.h
 libqueso_include_HEADERS += stats/inc/VectorGaussianRandomField.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihood.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodScalarCovariance.h
+libqueso_include_HEADERS += stats/inc/GaussianLikelihoodDiagonalCovariance.h
 
 # Headers to install from gp/inc
 

--- a/src/core/inc/GslBlockMatrix.h
+++ b/src/core/inc/GslBlockMatrix.h
@@ -101,7 +101,6 @@ public:
   //@}
 
 private:
-  const BaseEnvironment & m_env;
   std::vector<VectorSpace<GslVector, GslMatrix> *> m_vectorSpaces;
   std::vector<GslMatrix *> m_blocks;
 };

--- a/src/core/inc/GslBlockMatrix.h
+++ b/src/core/inc/GslBlockMatrix.h
@@ -30,7 +30,11 @@
  * \brief QUESO matrix class using GSL.
  */
 
-#include <queso/Matrix.h>
+#include <vector>
+#include <queso/Environment.h>
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/VectorSpace.h>
 
 namespace QUESO {
 
@@ -43,21 +47,21 @@ namespace QUESO {
  * by an encapsulated gsl_matrix structure.
  */
 
-class GslBlockMatrix : public Matrix
+class GslBlockMatrix
 {
 public:
   //! @name Constructor/Destructor methods
   //@{
   //! Shaped Constructor: creates a square matrix with size \c v.sizeLocal() and diagonal values all equal to \c diagValue.
-  GslBlockMatrix(const std::vector<unsigned int> & blockSizes,
-      double diagValue);
+  GslBlockMatrix(const FullEnvironment & env,
+      const std::vector<unsigned int> & blockSizes, double diagValue);
 
   //! Destructor
   ~GslBlockMatrix();
   //@}
 
   //! Return block \c i in the block diagonal matrix
-  GslBlockMatrix & getBlock(unsigned int i) const;
+  GslMatrix & getBlock(unsigned int i) const;
 
   //! Return the number of blocks in the block diagonal matrix
   unsigned int numBlocks() const;
@@ -67,7 +71,7 @@ public:
    * It checks for a previous LU decomposition of \c this matrix and does not
    * recompute it if m_MU != NULL.
    */
-  void invertMultiply (const GslVector & b, GslVector & x) const;
+  void invertMultiply(const GslVector & b, GslVector & x) const;
 
   //! @name I/O methods
   //@{
@@ -76,10 +80,9 @@ public:
   //@}
 
 private:
-
-  //! Default Constructor
-  /*! Creates an empty matrix vector of no dimension. It should not be used by user.*/
-  GslBlockMatrix();
+  const FullEnvironment & m_env;
+  std::vector<VectorSpace<GslVector, GslMatrix> *> m_vectorSpaces;
+  std::vector<GslMatrix *> m_blocks;
 };
 
 std::ostream & operator<<(std::ostream & os, const GslBlockMatrix & obj);

--- a/src/core/inc/GslBlockMatrix.h
+++ b/src/core/inc/GslBlockMatrix.h
@@ -1,0 +1,89 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef UQ_GSL_BLOCK_MATRIX_H
+#define UQ_GSL_BLOCK_MATRIX_H
+
+/*!
+ * \file GslBlockMatrix.h
+ * \brief QUESO matrix class using GSL.
+ */
+
+#include <queso/Matrix.h>
+
+namespace QUESO {
+
+/*!
+ * \class GslBlockMatrix
+ * \brief Class for matrix operations using GSL library.
+ *
+ * This class creates and provides basic support for matrices of templated
+ * type as a specialization of Matrix using GSL matrices, which are defined
+ * by an encapsulated gsl_matrix structure.
+ */
+
+class GslBlockMatrix : public Matrix
+{
+public:
+  //! @name Constructor/Destructor methods
+  //@{
+  //! Shaped Constructor: creates a square matrix with size \c v.sizeLocal() and diagonal values all equal to \c diagValue.
+  GslBlockMatrix(const std::vector<unsigned int> & blockSizes,
+      double diagValue);
+
+  //! Destructor
+  ~GslBlockMatrix();
+  //@}
+
+  //! Return block \c i in the block diagonal matrix
+  GslBlockMatrix & getBlock(unsigned int i) const;
+
+  //! Return the number of blocks in the block diagonal matrix
+  unsigned int numBlocks() const;
+
+  //! This function calculates the inverse of \c this matrix, multiplies it with vector \c b and stores the result in vector \c x.
+  /*!
+   * It checks for a previous LU decomposition of \c this matrix and does not
+   * recompute it if m_MU != NULL.
+   */
+  void invertMultiply (const GslVector & b, GslVector & x) const;
+
+  //! @name I/O methods
+  //@{
+  //! Print method. Defines the behavior of operator<< inherited from the Object class.
+  void print (std::ostream & os) const;
+  //@}
+
+private:
+
+  //! Default Constructor
+  /*! Creates an empty matrix vector of no dimension. It should not be used by user.*/
+  GslBlockMatrix();
+};
+
+std::ostream & operator<<(std::ostream & os, const GslBlockMatrix & obj);
+
+}  // End namespace QUESO
+
+#endif // UQ_GSL_BLOCK_MATRIX_H

--- a/src/core/inc/GslBlockMatrix.h
+++ b/src/core/inc/GslBlockMatrix.h
@@ -27,7 +27,7 @@
 
 /*!
  * \file GslBlockMatrix.h
- * \brief QUESO matrix class using GSL.
+ * \brief QUESO block matrix class using GSL.
  */
 
 #include <vector>
@@ -40,11 +40,10 @@ namespace QUESO {
 
 /*!
  * \class GslBlockMatrix
- * \brief Class for matrix operations using GSL library.
+ * \brief Class for representing block matrices using GSL library.
  *
- * This class creates and provides basic support for matrices of templated
- * type as a specialization of Matrix using GSL matrices, which are defined
- * by an encapsulated gsl_matrix structure.
+ * This class provides basic 'invertMultiply' support for matrices of block
+ * diagonal structure.  Each block is implemented as a GslMatrix object.
  */
 
 class GslBlockMatrix
@@ -52,7 +51,10 @@ class GslBlockMatrix
 public:
   //! @name Constructor/Destructor methods
   //@{
-  //! Shaped Constructor: creates a square matrix with size \c v.sizeLocal() and diagonal values all equal to \c diagValue.
+  //! Creates a square matrix with size defined by \c blockSizes and diagonal values all equal to \c diagValue.
+  /*!
+   * The \c blockSizes array must contain the sizes of each (square) block.
+   */
   GslBlockMatrix(const FullEnvironment & env,
       const std::vector<unsigned int> & blockSizes, double diagValue);
 
@@ -68,8 +70,8 @@ public:
 
   //! This function calculates the inverse of \c this matrix, multiplies it with vector \c b and stores the result in vector \c x.
   /*!
-   * It checks for a previous LU decomposition of \c this matrix and does not
-   * recompute it if m_MU != NULL.
+   * It checks for a previous LU decomposition of each block matrix and does
+   * not recompute it if m_MU != NULL for each block.
    */
   void invertMultiply(const GslVector & b, GslVector & x) const;
 

--- a/src/core/inc/GslBlockMatrix.h
+++ b/src/core/inc/GslBlockMatrix.h
@@ -32,6 +32,7 @@
 
 #include <vector>
 #include <queso/Environment.h>
+#include <queso/Matrix.h>
 #include <queso/GslVector.h>
 #include <queso/GslMatrix.h>
 #include <queso/VectorSpace.h>
@@ -46,21 +47,39 @@ namespace QUESO {
  * diagonal structure.  Each block is implemented as a GslMatrix object.
  */
 
-class GslBlockMatrix
+class GslBlockMatrix : Matrix
 {
 public:
   //! @name Constructor/Destructor methods
   //@{
-  //! Creates a square matrix with size defined by \c blockSizes and diagonal values all equal to \c diagValue.
+  //! Creates a square matrix with size defined by \c v and diagonal values all equal to \c diagValue.
   /*!
-   * The \c blockSizes array must contain the sizes of each (square) block.
+   * The \c blockSizes array determines the sizes of each (square) block.
    */
-  GslBlockMatrix(const FullEnvironment & env,
-      const std::vector<unsigned int> & blockSizes, double diagValue);
+  GslBlockMatrix(const std::vector<unsigned int> & blockSizes,
+      const GslVector & v, double diagValue);
 
   //! Destructor
   ~GslBlockMatrix();
   //@}
+
+  //! Not implemented yet
+  virtual unsigned int numRowsLocal() const;
+
+  //! Not implemented yet
+  virtual unsigned int numRowsGlobal() const;
+
+  //! Not implemented yet
+  virtual unsigned int numCols() const;
+
+  //! Not implemented yet
+  virtual int chol();
+
+  //! Not implemented yet
+  virtual void zeroLower(bool includeDiagonal=false);
+
+  //! Not implemented yet
+  virtual void zeroUpper(bool includeDiagonal=false);
 
   //! Return block \c i in the block diagonal matrix
   GslMatrix & getBlock(unsigned int i) const;
@@ -78,11 +97,11 @@ public:
   //! @name I/O methods
   //@{
   //! Print method. Defines the behavior of operator<< inherited from the Object class.
-  void print (std::ostream & os) const;
+  virtual void print (std::ostream & os) const;
   //@}
 
 private:
-  const FullEnvironment & m_env;
+  const BaseEnvironment & m_env;
   std::vector<VectorSpace<GslVector, GslMatrix> *> m_vectorSpaces;
   std::vector<GslMatrix *> m_blocks;
 };

--- a/src/core/inc/GslMatrix.h
+++ b/src/core/inc/GslMatrix.h
@@ -38,9 +38,9 @@ namespace QUESO {
 
 /*! \class GslMatrix
     \brief Class for matrix operations using GSL library.
-    
-    This class creates and provides basic support for matrices of templated 
-    type as a specialization of Matrix using GSL matrices, which are defined 
+
+    This class creates and provides basic support for matrices of templated
+    type as a specialization of Matrix using GSL matrices, which are defined
     by an encapsulated gsl_matrix structure.
 */
 
@@ -48,153 +48,153 @@ class GslMatrix : public Matrix
 {
 public:
  //! @name Constructor/Destructor methods
-  //@{ 
+  //@{
 
   //! Default Constructor
   /*! Creates an empty matrix vector of no dimension. It should not be used by user.*/
   GslMatrix();
-  
-  //! Shaped Constructor: creates a shaped matrix with \c numCols columns.  
+
+  //! Shaped Constructor: creates a shaped matrix with \c numCols columns.
   GslMatrix(const BaseEnvironment& env,
                    const Map&             map,
                    unsigned int                  numCols);
-  
-  //! Shaped Constructor: creates a square matrix with size \c map.NumGlobalElements() and diagonal values all equal to \c diagValue.  
+
+  //! Shaped Constructor: creates a square matrix with size \c map.NumGlobalElements() and diagonal values all equal to \c diagValue.
   GslMatrix(const BaseEnvironment& env,
                    const Map&             map,
                    double                        diagValue); // MATLAB eye
-  
-  //! Shaped Constructor: creates a square matrix with size \c v.sizeLocal() and diagonal values all equal to \c diagValue.  
+
+  //! Shaped Constructor: creates a square matrix with size \c v.sizeLocal() and diagonal values all equal to \c diagValue.
   GslMatrix(const GslVector&       v,
                    double                        diagValue); // MATLAB eye
-  
-  //! Shaped Constructor: creates a square matrix with size \c v.sizeLocal().  
-  /*! The diagonal values of this matrix are the elements in vector \c v. */  
+
+  //! Shaped Constructor: creates a square matrix with size \c v.sizeLocal().
+  /*! The diagonal values of this matrix are the elements in vector \c v. */
   GslMatrix(const GslVector&       v);         // MATLAB diag
-  
-  //! Shaped Constructor: creates a matrix with  \c B.numCols() columns and \c B.numRowsLocal() rows.  
-  /*! \c This matrix is a copy of matrix \c B. */  
+
+  //! Shaped Constructor: creates a matrix with  \c B.numCols() columns and \c B.numRowsLocal() rows.
+  /*! \c This matrix is a copy of matrix \c B. */
   GslMatrix(const GslMatrix&       B);
-  
+
   //! Destructor
   ~GslMatrix();
   //@}
 
 
   //! @name Set methods
-  //@{ 
-  //! 	Copies values from matrix \c rhs to \c this. 
+  //@{
+  //! 	Copies values from matrix \c rhs to \c this.
   GslMatrix& operator= (const GslMatrix& rhs);
-  
+
   //! Stores in \c this the coordinate-wise multiplication of \c this and \c a.
   GslMatrix& operator*=(double a);
-  
+
   //! Stores in \c this the coordinate-wise division of \c this by \c a.
   GslMatrix& operator/=(double a);
-  
+
   //! Stores in \c this the coordinate-wise addition of \c this and \c rhs.
   GslMatrix& operator+=(const GslMatrix& rhs);
-  
+
   //! Stores in \c this the coordinate-wise subtraction of \c this by \c rhs.
   GslMatrix& operator-=(const GslMatrix& rhs);
   //@}
-  
-  
+
+
   //! @name Accessor methods
   //@{
   //! Element access method (non-const).
   double& operator()(unsigned int i, unsigned int j);
-            
-  //! Element access method (const).  
+
+  //! Element access method (const).
   const double& operator()(unsigned int i, unsigned int j) const;
-  
- 
+
+
   //@}
 
   //! @name Attribute methods
-  //@{ 
+  //@{
   //! Returns the local row dimension of \c this matrix.
   unsigned int      numRowsLocal              () const;
-        
+
   //! Returns the global row dimension of \c this matrix.
   unsigned int      numRowsGlobal             () const;
-        
+
   //! Returns the column dimension of \c this matrix.
   unsigned int      numCols                   () const;
-  
+
   //! Returns the maximum element value of the matrix.
   double            max                       () const;
-  
-  //! This function returns the number of singular values of \c this matrix (rank). 
+
+  //! This function returns the number of singular values of \c this matrix (rank).
   /*! The rank function provides an estimate of the number of linearly independent rows or columns of a full matrix. */
   unsigned int      rank                      (double absoluteZeroThreshold, double relativeZeroThreshold) const;
-  
+
      //! This function calculated the transpose of \c this matrix  (square).
   GslMatrix  transpose                 () const;
-	
+
   //! This function calculated the inverse of \c this matrix (square).
   GslMatrix  inverse                   () const;
-  
-    
+
+
   //! Calculates the determinant of \c this matrix.
   double            determinant               () const;
-	
+
   //! Calculates the ln(determinant) of \c this matrix.
   double            lnDeterminant             () const;
-  
+
   //@}
-  
+
   //! @name Norm methods
-  //@{ 
+  //@{
   //! Returns the Frobenius norm of \c this matrix.
   double            normFrob                  () const;
-  
+
   //! Returns the Frobenius norm of \c this matrix.
   double            normMax                   () const;
   //@}
-       
-  
-  
-  
-  
-  //! @name Mathematical methods
-  //@{ 
 
-  //! Computes Cholesky factorization of a real symmetric positive definite matrix \c this. 
+
+
+
+
+  //! @name Mathematical methods
+  //@{
+
+  //! Computes Cholesky factorization of a real symmetric positive definite matrix \c this.
   /*! In case \this fails to be symmetric and positive definite, an error will be returned. */
   int               chol                      ();
-	
-//! Checks for the dimension of \c this matrix, \c matU, \c VecS and \c matVt, and calls the protected routine \c internalSvd to compute the singular values of \c this. 
+
+//! Checks for the dimension of \c this matrix, \c matU, \c VecS and \c matVt, and calls the protected routine \c internalSvd to compute the singular values of \c this.
   int               svd                       (GslMatrix& matU, GslVector& vecS, GslMatrix& matVt) const;
-        
-  //! This function calls private member GslMatrix::internalSvd() to set a M-by-N orthogonal matrix U of the singular value decomposition (svd) of a general rectangular M-by-N matrix A. 
+
+  //! This function calls private member GslMatrix::internalSvd() to set a M-by-N orthogonal matrix U of the singular value decomposition (svd) of a general rectangular M-by-N matrix A.
   /*! A general rectangular M-by-N matrix A has a singular value decomposition (svd) into the product of an M-by-N orthogonal matrix U, an N-by-N diagonal matrix of singular values S and the transpose of an N-by-N orthogonal square matrix V,  A = U S V^T.  */
   const GslMatrix& svdMatU                   () const;
-  
-  //! This function calls private member  GslMatrix::internalSvd() to set a N-by-N orthogonal square matrix V of the singular value decomposition (svd) of a general rectangular M-by-N matrix A. 
+
+  //! This function calls private member  GslMatrix::internalSvd() to set a N-by-N orthogonal square matrix V of the singular value decomposition (svd) of a general rectangular M-by-N matrix A.
   /*! A general rectangular M-by-N matrix A has a singular value decomposition (svd) into the product of an M-by-N orthogonal matrix U, an N-by-N diagonal matrix of singular values S and the transpose of an N-by-N orthogonal square matrix V,  A = U S V^T.  */
   const GslMatrix& svdMatV                   () const;
-  
-  //! This function solves the system A x = b using the singular value decomposition (U, S, V) of A which must have been computed previously with GslMatrix::svd (x=solVec, b=rhsVec). 
+
+  //! This function solves the system A x = b using the singular value decomposition (U, S, V) of A which must have been computed previously with GslMatrix::svd (x=solVec, b=rhsVec).
   int               svdSolve                  (const GslVector& rhsVec, GslVector& solVec) const;
-        
+
   //! This function solves the system A x = b using the singular value decomposition (U, S, V) of A which must have been computed previously with GslMatrix::svd (x=solMat, b=rhsMat).
-  int               svdSolve                  (const GslMatrix& rhsMat, GslMatrix& solMat) const;        
-  
+  int               svdSolve                  (const GslMatrix& rhsMat, GslMatrix& solMat) const;
+
 
 
   //! This function multiplies \c this matrix by vector \c x and returns the resulting vector.
   GslVector  multiply                  (const GslVector& x) const;
 
-  //! This function calculates the inverse of \c this matrix and multiplies it with vector \c b. 
+  //! This function calculates the inverse of \c this matrix and multiplies it with vector \c b.
   /*! It calls void GslMatrix::invertMultiply(const GslVector& b, GslVector& x) internally.*/
   GslVector  invertMultiply            (const GslVector& b) const;
-	
+
   //! This function calculates the inverse of \c this matrix, multiplies it with vector \c b and stores the result in vector \c x.
   /*! It checks for a previous LU decomposition of \c this matrix and does not recompute it
    if m_MU != NULL .*/
   void              invertMultiply            (const GslVector& b, GslVector& x) const;
-	
+
   //! This function calculates the inverse of \c this matrix and multiplies it with matrix \c B.
   /*! It calls void GslMatrix::invertMultiply(const GslMatrix& B, GslMatrix& X) const internally.*/
   GslMatrix  invertMultiply            (const GslMatrix& B) const;
@@ -203,124 +203,124 @@ public:
   /*! It checks for a previous LU decomposition of \c this matrix and does not recompute it
    if m_MU != NULL .*/
   void              invertMultiply            (const GslMatrix& B, GslMatrix& X) const;
-  
-  //! This function calculates the inverse of \c this matrix and multiplies it with vector \c b. 
+
+  //! This function calculates the inverse of \c this matrix and multiplies it with vector \c b.
   /*! It calls void GslMatrix::InvertMultiplyForceLU(const GslVector& b, GslVector& x) const;(const GslVector& b,
 GslVector& x) internally.*/
   GslVector  invertMultiplyForceLU     (const GslVector& b) const;
-	
+
   //! This function calculates the inverse of \c this matrix, multiplies it with vector \c b and stores the result in vector \c x.
-  /*! It recalculates the LU decomposition of \c this matrix.*/	
+  /*! It recalculates the LU decomposition of \c this matrix.*/
   void              invertMultiplyForceLU     (const GslVector& b, GslVector& x) const;
-  
+
     //! This function gets the column_num-th column of \c this matrix and stores it into vector \c column.
   void              getColumn                 (const unsigned int column_num, GslVector& column) const;
-  
+
   //! This function gets the column_num-th column of \c this matrix.
   GslVector  getColumn                 (const unsigned int column_num) const;
-  
-  //! This function copies vector \c column into the column_num-th column of \c this matrix. 
+
+  //! This function copies vector \c column into the column_num-th column of \c this matrix.
   void              setColumn                 (const unsigned int column_num, const GslVector& column);
-  
+
   //! This function gets the row_num-th column of \c this matrix and stores it into vector \c row.
   void              getRow                    (const unsigned int row_num, GslVector& row) const;
-  
+
   //! This function gets the row_num-th column of \c this matrix.
   GslVector  getRow                    (const unsigned int row_num) const;
-  
-  //! This function copies vector \c row into the row_num-th column of \c this matrix. 
+
+  //! This function copies vector \c row into the row_num-th column of \c this matrix.
   void              setRow                    (const unsigned int row_num, const GslVector& row);
-  
+
   //! This function computes the eigenvalues of a real symmetric matrix.
   void              eigen                     (GslVector& eigenValues, GslMatrix* eigenVectors) const;
-	
+
   //! This function finds largest eigenvalue, namely \c eigenValue, of \c this matrix and its corresponding eigenvector, namely \c eigenVector.
   void              largestEigen              (double& eigenValue, GslVector& eigenVector) const;
- 
+
   //! This function finds smallest eigenvalue, namely \c eigenValue, of \c this matrix and its corresponding eigenvector, namely \c eigenVector.
   void              smallestEigen             (double& eigenValue, GslVector& eigenVector) const;
 
- 
-  //@} 
-  
+
+  //@}
+
   //! @name Get/Set methods
-  //@{  
-  
+  //@{
+
   //! Component-wise set all values to \c this with value.
   void              cwSet                     (double value);
-        
+
   //! Set the components of \c which positions are greater than (rowId,colId) with the value of mat(rowId,colId).
   void              cwSet                     (unsigned int rowId, unsigned int colId, const GslMatrix& mat);
-  
+
   void              cwExtract                 (unsigned int rowId, unsigned int colId, GslMatrix& mat) const;
-  
+
    //! This function sets all the entries bellow the main diagonal of \c this matrix to zero.
-  /*! If \c includeDiagonal = false, then only the entries bellow the main diagonal are set to zero; 
+  /*! If \c includeDiagonal = false, then only the entries bellow the main diagonal are set to zero;
   if \c includeDiagonal = true, then the elements of the matrix diagonal are also set to zero.*/
   void              zeroLower                 (bool includeDiagonal = false);
-	
+
   //! This function sets all the entries above the main diagonal of \c this matrix to zero.
-  /*! If \c includeDiagonal = false, then only the entries above the main diagonal are set to zero; 
+  /*! If \c includeDiagonal = false, then only the entries above the main diagonal are set to zero;
   if \c includeDiagonal = true, then the elements of the matrix diagonal are also set to zero.*/
   void              zeroUpper                 (bool includeDiagonal = false);
-  
+
   //! This function sets to zero (filters) all entries of \c this matrix which are smaller than \c thresholdValue.
   /*! If \c thresholdValue < 0 then no values will be filtered.*/
   void              filterSmallValues         (double thresholdValue);
-  
+
   //! This function sets to zero (filters) all entries of \c this matrix which are greater than \c thresholdValue.
-  /*! If \c thresholdValue < 0 then no values will be filtered.*/	
+  /*! If \c thresholdValue < 0 then no values will be filtered.*/
   void              filterLargeValues         (double thresholdValue);
-  
+
   //! This function stores the transpose of \c this matrix into \c this matrix.
   void              fillWithTranspose         (unsigned int            rowId,
                                                unsigned int            colId,
                                                const GslMatrix& mat,
                                                bool                    checkForExactNumRowsMatching,
                                                bool                    checkForExactNumColsMatching);
-  
+
   //! This function fills \c this matrix diagonally with const block  matrices.
   void              fillWithBlocksDiagonally  (unsigned int                                 rowId,
                                                unsigned int                                 colId,
                                                const std::vector<const GslMatrix* >& matrices,
                                                bool                                         checkForExactNumRowsMatching,
                                                bool                                         checkForExactNumColsMatching);
-  
+
   //! This function fills \c this matrix diagonally with block matrices.
   void              fillWithBlocksDiagonally  (unsigned int                                 rowId,
                                                unsigned int                                 colId,
                                                const std::vector<      GslMatrix* >& matrices,
                                                bool                                         checkForExactNumRowsMatching,
                                                bool                                         checkForExactNumColsMatching);
-  
+
   //! This function fills \c this matrix horizontally with const block matrices.
   void              fillWithBlocksHorizontally(unsigned int                                 rowId,
                                                unsigned int                                 colId,
                                                const std::vector<const GslMatrix* >& matrices,
                                                bool                                         checkForExactNumRowsMatching,
                                                bool                                         checkForExactNumColsMatching);
-  
-  //! This function fills \c this matrix horizontally with const block 
+
+  //! This function fills \c this matrix horizontally with const block
   void              fillWithBlocksHorizontally(unsigned int                                 rowId,
                                                unsigned int                                 colId,
                                                const std::vector<      GslMatrix* >& matrices,
                                                bool                                         checkForExactNumRowsMatching,
                                                bool                                         checkForExactNumColsMatching);
-  
+
   //! This function fills \c this matrix vertically with const block matrices.
   void              fillWithBlocksVertically  (unsigned int                                 rowId,
                                                unsigned int                                 colId,
                                                const std::vector<const GslMatrix* >& matrices,
                                                bool                                         checkForExactNumRowsMatching,
                                                bool                                         checkForExactNumColsMatching);
-  
+
   //! This function fills \c this matrix vertically with block matrices.
   void              fillWithBlocksVertically  (unsigned int                                 rowId,
                                                unsigned int                                 colId,
                                                const std::vector<      GslMatrix* >& matrices,
                                                bool                                         checkForExactNumRowsMatching,
                                                bool                                         checkForExactNumColsMatching);
-	
+
   //! This function calculates the tensor product of matrices \c mat1 and \c mat2 and stores it in \c this matrix.
   void              fillWithTensorProduct     (unsigned int            rowId,
                                                unsigned int            colId,
@@ -336,33 +336,33 @@ GslVector& x) internally.*/
                                                const GslVector& vec2,
                                                bool                    checkForExactNumRowsMatching,
                                                bool                    checkForExactNumColsMatching);
-  //@}	
+  //@}
 
- 
+
   //! @name Miscellaneous methods
   //@{
-  //! Returns \c this matrix.  
+  //! Returns \c this matrix.
   gsl_matrix*       data                      ();
-     
+
   void              mpiSum                    (const MpiComm& comm, GslMatrix& M_global) const;
-  
+
   void              matlabLinearInterpExtrap  (const GslVector& x1Vec, const GslMatrix& y1Mat, const GslVector& x2Vec);
   //@}
-	
-        
-	
+
+
+
   //! @name I/O methods
   //@{
-    
-  //! Print method. Defines the behavior of the ostream << operator inherited from the Object class.   
+
+  //! Print method. Defines the behavior of the ostream << operator inherited from the Object class.
   void              print                     (std::ostream& os) const;
-  
+
   //! Write contents of subenvironment in file \c fileName.
   void              subWriteContents          (const std::string&            varNamePrefix,
                                                const std::string&            fileName,
                                                const std::string&            fileType,
                                                const std::set<unsigned int>& allowedSubEnvIds) const;
-					  
+
   //! Read contents of subenvironment from file \c fileName.
   void              subReadContents           (const std::string&            fileName,
                                                const std::string&            fileType,
@@ -372,71 +372,71 @@ GslVector& x) internally.*/
 private:
   //! In this function \c this matrix receives a copy of matrix \c src.
   void              copy                      (const GslMatrix& src);
-  
+
   //! In this function resets the LU decomposition of \c this matrix, as well as deletes the private member pointers, if existing.
   void              resetLU                   ();
-	
+
   //! This function multiplies \c this matrix by vector \c x and stores the resulting vector in \c y.
   void              multiply                  (const GslVector& x, GslVector& y) const;
-        
+
   //! This function factorizes the M-by-N matrix A into the singular value decomposition A = U S V^T for M >= N. On output the matrix A is replaced by U.
   int               internalSvd               () const;
 
   //! GSL matrix, also referred to as \c this matrix.
           gsl_matrix*       m_mat;
-	  
-  //! GSL matrix for the LU decomposition of m_mat.	  
+
+  //! GSL matrix for the LU decomposition of m_mat.
   mutable gsl_matrix*       m_LU;
-  
+
   //! Inverse matrix of \c this.
   mutable GslMatrix* m_inverse;
-  
+
   //! Mapping for matrices involved in the singular value decomposition (svd) routine.
   mutable Map*       m_svdColMap;
-  
+
   //! m_svdUmat stores the M-by-N orthogonal matrix U after the singular value decomposition of a matrix.
-  /*! A general rectangular M-by-N matrix A has a singular value decomposition (svd) into the product of an 
-   * M-by-N orthogonal matrix U, an N-by-N diagonal matrix of singular values S 
+  /*! A general rectangular M-by-N matrix A has a singular value decomposition (svd) into the product of an
+   * M-by-N orthogonal matrix U, an N-by-N diagonal matrix of singular values S
    * and the transpose of an N-by-N orthogonal square matrix V,  A = U S V^T.  */
   mutable GslMatrix* m_svdUmat;
-  
+
   //! m_svdSvec stores the diagonal of the N-by-N diagonal matrix of singular values S after the singular value decomposition of a matrix.
-  /*! A general rectangular M-by-N matrix A has a singular value decomposition (svd) into the product of an 
-   * M-by-N orthogonal matrix U, an N-by-N diagonal matrix of singular values S 
+  /*! A general rectangular M-by-N matrix A has a singular value decomposition (svd) into the product of an
+   * M-by-N orthogonal matrix U, an N-by-N diagonal matrix of singular values S
    * and the transpose of an N-by-N orthogonal square matrix V,  A = U S V^T.  */
-  
+
   mutable GslVector* m_svdSvec;
-  
+
   //! m_svdVmat stores the N-by-N orthogonal square matrix V after the singular value decomposition of a matrix.
-  /*! A general rectangular M-by-N matrix A has a singular value decomposition (svd) into the product of an 
-   * M-by-N orthogonal matrix U, an N-by-N diagonal matrix of singular values S 
+  /*! A general rectangular M-by-N matrix A has a singular value decomposition (svd) into the product of an
+   * M-by-N orthogonal matrix U, an N-by-N diagonal matrix of singular values S
    * and the transpose of an N-by-N orthogonal square matrix V,  A = U S V^T.  */
   mutable GslMatrix* m_svdVmat;
-  
+
   //! m_svdVmatT stores the transpose of N-by-N orthogonal square matrix V, namely V^T, after the singular value decomposition of a matrix.
-  /*! A general rectangular M-by-N matrix A has a singular value decomposition (svd) into the product of an 
-   * M-by-N orthogonal matrix U, an N-by-N diagonal matrix of singular values S 
+  /*! A general rectangular M-by-N matrix A has a singular value decomposition (svd) into the product of an
+   * M-by-N orthogonal matrix U, an N-by-N diagonal matrix of singular values S
    * and the transpose of an N-by-N orthogonal square matrix V,  A = U S V^T.  */
   mutable GslMatrix* m_svdVTmat;
-  
+
   //! The determinant of \c this matrix.
   mutable double            m_determinant;
-  
+
   //! The natural logarithm of the determinant of \c this matrix.
   mutable double            m_lnDeterminant;
-  
+
   //! The permutation matrix of a LU decomposition.
-  /*! In the  LU decomposition PA = LU, the j-th column of the matrix P is given by 
-   * the k-th column of the identity matrix, where k = p_j the j-th element of the permutation vector. 
+  /*! In the  LU decomposition PA = LU, the j-th column of the matrix P is given by
+   * the k-th column of the identity matrix, where k = p_j the j-th element of the permutation vector.
    * A is the square matrix of interest and P is the permutation matrix.     */
   mutable gsl_permutation*  m_permutation;
-  
+
   //! m_signum stores the sign of the permutation of the LU decomposition PA = LU.
-  /*! In the  LU decomposition PA = LU, where A is the square matrix of interest 
-   * and P is the permutation matrix, m_signum has the value (-1)^n, 
+  /*! In the  LU decomposition PA = LU, where A is the square matrix of interest
+   * and P is the permutation matrix, m_signum has the value (-1)^n,
    * where n is the number of interchanges in the permutation.*/
   mutable int               m_signum;
-  
+
   //! Indicates whether or not \c this matrix is singular.
   mutable bool              m_isSingular;
 };

--- a/src/core/src/GslBlockMatrix.C
+++ b/src/core/src/GslBlockMatrix.C
@@ -26,9 +26,10 @@
 
 namespace QUESO {
 
-GslBlockMatrix::GslBlockMatrix(const FullEnvironment & env,
-    const std::vector<unsigned int> & blockSizes, double diagValue)
-  : m_env(env),
+GslBlockMatrix::GslBlockMatrix(const std::vector<unsigned int> & blockSizes,
+    const GslVector & v, double diagValue)
+  : Matrix(v.env(), v.map()),
+    m_env(v.env()),
     m_vectorSpaces(blockSizes.size()),
     m_blocks(blockSizes.size())
 {
@@ -47,6 +48,47 @@ GslBlockMatrix::~GslBlockMatrix()
     delete this->m_vectorSpaces[i];
   }
 }
+
+
+unsigned int
+GslBlockMatrix::numRowsLocal() const
+{
+  queso_not_implemented();
+}
+
+unsigned int
+GslBlockMatrix::numRowsGlobal() const
+{
+  queso_not_implemented();
+  return 0;
+}
+
+unsigned int
+GslBlockMatrix::numCols() const
+{
+  queso_not_implemented();
+  return 0;
+}
+
+int
+GslBlockMatrix::chol()
+{
+  queso_not_implemented();
+  return 0;
+}
+
+void
+GslBlockMatrix::zeroLower(bool includeDiagonal)
+{
+  queso_not_implemented();
+}
+
+void
+GslBlockMatrix::zeroUpper(bool includeDiagonal)
+{
+  queso_not_implemented();
+}
+
 
 GslMatrix &
 GslBlockMatrix::getBlock(unsigned int i) const

--- a/src/core/src/GslBlockMatrix.C
+++ b/src/core/src/GslBlockMatrix.C
@@ -1,0 +1,135 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslBlockMatrix.h>
+
+namespace QUESO {
+
+GslBlockMatrix::GslBlockMatrix()
+{
+}
+
+GslBlockMatrix::GslBlockMatrix(const std::vector<unsigned int> & blockSizes,
+    double diagValue)
+  : m_vectorSpaces(blockSizes.size()),
+    m_blocks(blockSizes.size())
+{
+  for (unsigned int i = 0; i < this->m_vectorSpaces.size(); i++) {
+    this->m_vectorSpaces[i] = new VectorSpace<GslVector, GslMatrix> paramSpace(
+        env, "block_param_", blockSizes[i], NULL);
+    this->m_blocks[i] = new GslMatrix(this->m_vectorSpaces[i]->zeroVector(),
+        diagValue);
+  }
+}
+
+GslBlockMatrix::~GslBlockMatrix()
+{
+  for (unsigned int i = 0; i < this->m_vectorSpaces.size(); i++) {
+    delete this->m_blocks[i];
+    delete this->m_vectorSpaces[i];
+  }
+}
+
+void
+GslBlockMatrix::invertMultiply(const GslVector & b, GslVector & x) const
+{
+  unsigned int totalCols = 0;
+
+  for (unsigned int i = 0; i < this->m_blocks.size(); i++) {
+    totalCols += this->m_blocks[i].numCols();
+  }
+
+  if (this->numCols() != b.sizeLocal()) {
+    queso_error_msg("block matrix and rhs have incompatible sizes");
+  }
+
+  if (x.sizeLocal() != b.sizeLocal()) {
+    queso_error_msg("solution and rhs have incompatible sizes");
+  }
+
+  unsigned int blockOffset = 0;
+  double totalMisfit = 0.0;
+
+  // Do an invertMultiply for each block
+  for (unsigned int i = 0; i < this->m_blocks.size(); i++) {
+    GslVector blockRHS(this->m_vectorSpaces[i].zeroVector());
+    GslVector blockSol(this->m_vectorSpaces[i].zeroVector());
+
+    // Be sure to copy over the RHS to the right sized vector
+    for (unsigned int j = 0; j < this->m_blocks[i].numCols(); j++) {
+      blockRHS[j] = b[blockOffset + j];
+    }
+
+    // Solve
+    this->m_block[i].invertMultiply(blockRHS, blockSol);
+
+    // Be sure to copy the block solution back to the global solution vector
+    for (unsigned int j = 0; j < this->m_blocks[i].numCols(); j++) {
+      x[blockOffset + j] = blockSol[j];
+    }
+
+    // Remember to increment the offset so we don't lose our place for the next
+    // block
+    blockOffset += this->m_blocks[i].numCols();
+  }
+}
+
+void
+GslBlockMatrix::print(std::ostream& os) const
+{
+  unsigned int nRows = this->numRowsLocal();
+  unsigned int nCols = this->numCols();
+
+  if (m_printHorizontally) {
+    for (unsigned int i = 0; i < nRows; ++i) {
+      for (unsigned int j = 0; j < nCols; ++j) {
+        os << (*this)(i,j)
+           << " ";
+      }
+      if (i != (nRows-1)) os << "; ";
+    }
+    //os << std::endl;
+  }
+  else {
+    for (unsigned int i = 0; i < nRows; ++i) {
+      for (unsigned int j = 0; j < nCols; ++j) {
+        os << (*this)(i,j)
+           << " ";
+      }
+      os << std::endl;
+    }
+  }
+
+  return;
+}
+
+std::ostream&
+operator<<(std::ostream& os, const GslBlockMatrix & obj)
+{
+  obj.print(os);
+
+  return os;
+}
+
+}  // End namespace QUESO

--- a/src/core/src/GslBlockMatrix.C
+++ b/src/core/src/GslBlockMatrix.C
@@ -29,7 +29,6 @@ namespace QUESO {
 GslBlockMatrix::GslBlockMatrix(const std::vector<unsigned int> & blockSizes,
     const GslVector & v, double diagValue)
   : Matrix(v.env(), v.map()),
-    m_env(v.env()),
     m_vectorSpaces(blockSizes.size()),
     m_blocks(blockSizes.size())
 {

--- a/src/core/src/GslBlockMatrix.C
+++ b/src/core/src/GslBlockMatrix.C
@@ -106,30 +106,9 @@ GslBlockMatrix::invertMultiply(const GslVector & b, GslVector & x) const
 void
 GslBlockMatrix::print(std::ostream& os) const
 {
-  // unsigned int nRows = this->numRowsLocal();
-  // unsigned int nCols = this->numCols();
-  //
-  // if (m_printHorizontally) {
-  //   for (unsigned int i = 0; i < nRows; ++i) {
-  //     for (unsigned int j = 0; j < nCols; ++j) {
-  //       os << (*this)(i,j)
-  //          << " ";
-  //     }
-  //     if (i != (nRows-1)) os << "; ";
-  //   }
-  //   //os << std::endl;
-  // }
-  // else {
-  //   for (unsigned int i = 0; i < nRows; ++i) {
-  //     for (unsigned int j = 0; j < nCols; ++j) {
-  //       os << (*this)(i,j)
-  //          << " ";
-  //     }
-  //     os << std::endl;
-  //   }
-  // }
-
-  return;
+  for (unsigned int i = 0; i < this->numBlocks(); i++) {
+    this->getBlock(i).print(os);
+  }
 }
 
 std::ostream&

--- a/src/core/src/GslMatrix.C
+++ b/src/core/src/GslMatrix.C
@@ -666,7 +666,7 @@ GslMatrix::internalSvd() const
     m_svdSvec   = new GslVector(m_env,*m_svdColMap);
     m_svdVmat   = new GslMatrix(*m_svdSvec);
     m_svdVTmat  = new GslMatrix(*m_svdSvec);
-    
+
     //std::cout << "In GslMatrix::internalSvd()"
     //          << ", calling gsl_linalg_SV_decomp_jacobi()..."
     //          << ": nRows = " << nRows
@@ -784,11 +784,11 @@ GslMatrix::filterSmallValues(double thresholdValue)
       if ((aux             < 0. ) &&
           (-thresholdValue < aux)) {
         (*this)(i,j) = 0.;
-      }      
+      }
       if ((aux            > 0. ) &&
           (thresholdValue > aux)) {
         (*this)(i,j) = 0.;
-      }      
+      }
     }
   }
 
@@ -807,11 +807,11 @@ GslMatrix::filterLargeValues(double thresholdValue)
       if ((aux             < 0. ) &&
           (-thresholdValue > aux)) {
         (*this)(i,j) = 0.;
-      }      
+      }
       if ((aux            > 0. ) &&
           (thresholdValue < aux)) {
         (*this)(i,j) = 0.;
-      }      
+      }
     }
   }
 
@@ -970,7 +970,7 @@ GslMatrix::fillWithBlocksDiagonally(
       for (unsigned int colId = 0; colId < nCols; ++colId) {
         (*this)(initialTargetRowId + cumulativeRowId + rowId, initialTargetColId + cumulativeColId + colId) = (*(matrices[i]))(rowId,colId);
       }
-    } 
+    }
     cumulativeRowId += nRows;
     cumulativeColId += nCols;
   }
@@ -1191,7 +1191,7 @@ GslMatrix::fillWithTensorProduct(
         }
       }
     }
-  } 
+  }
 
   return;
 }
@@ -1233,7 +1233,7 @@ GslMatrix::fillWithTensorProduct(
         }
       }
     }
-  } 
+  }
 
 
   return;
@@ -1299,7 +1299,7 @@ GslMatrix::determinant() const
                               << ": before 'gsl_linalg_LU_det()'"
                               << std::endl;
     }
-    m_determinant   = gsl_linalg_LU_det(m_LU,m_signum); 
+    m_determinant   = gsl_linalg_LU_det(m_LU,m_signum);
     if ((m_env.subDisplayFile()) && (m_env.displayVerbosity() >= 99)) {
       *m_env.subDisplayFile() << "In GslMatrix::determinant()"
                               << ": after 'gsl_linalg_LU_det()'"
@@ -1340,7 +1340,7 @@ GslMatrix::lnDeterminant() const
                               << ": before 'gsl_linalg_LU_det()'"
                               << std::endl;
     }
-    m_determinant   = gsl_linalg_LU_det(m_LU,m_signum); 
+    m_determinant   = gsl_linalg_LU_det(m_LU,m_signum);
     if ((m_env.subDisplayFile()) && (m_env.displayVerbosity() >= 99)) {
       *m_env.subDisplayFile() << "In GslMatrix::lnDeterminant()"
                               << ": after 'gsl_linalg_LU_det()'"
@@ -1504,14 +1504,14 @@ GslMatrix::invertMultiply(
                               << ": before 'gsl_linalg_LU_decomp()'"
                               << std::endl;
     }
-    iRC = gsl_linalg_LU_decomp(m_LU,m_permutation,&m_signum); 
+    iRC = gsl_linalg_LU_decomp(m_LU,m_permutation,&m_signum);
     if (iRC != 0) {
       std::cerr << "In GslMatrix::invertMultiply()"
                 << ", after gsl_linalg_LU_decomp()"
                 << ": iRC = " << iRC
                 << ", gsl error message = " << gsl_strerror(iRC)
                 << std::endl;
-    } 
+    }
     gsl_set_error_handler(oldHandler);
     if ((m_env.subDisplayFile()) && (m_env.displayVerbosity() >= 99)) {
       *m_env.subDisplayFile() << "In GslMatrix::invertMultiply()"
@@ -1539,7 +1539,7 @@ GslMatrix::invertMultiply(
                             << ": before 'gsl_linalg_LU_solve()'"
                             << std::endl;
   }
-  iRC = gsl_linalg_LU_solve(m_LU,m_permutation,b.data(),x.data()); 
+  iRC = gsl_linalg_LU_solve(m_LU,m_permutation,b.data(),x.data());
   if (iRC != 0) {
     m_isSingular = true;
     std::cerr << "In GslMatrix::invertMultiply()"
@@ -1547,7 +1547,7 @@ GslMatrix::invertMultiply(
               << ": iRC = " << iRC
               << ", gsl error message = " << gsl_strerror(iRC)
               << std::endl;
-  } 
+  }
   gsl_set_error_handler(oldHandler);
   if ((m_env.subDisplayFile()) && (m_env.displayVerbosity() >= 99)) {
     *m_env.subDisplayFile() << "In GslMatrix::invertMultiply()"
@@ -1581,10 +1581,10 @@ GslMatrix::invertMultiply(const GslMatrix& B) const
   return X;
 }
 
-void              
+void
 GslMatrix::invertMultiply(const GslMatrix& B, GslMatrix& X) const
 {
-  
+
   // Sanity Checks
   UQ_FATAL_RC_MACRO(((B.numRowsLocal() != X.numRowsLocal()) ||
 		     (B.numCols()      != X.numCols()     )),
@@ -1592,7 +1592,7 @@ GslMatrix::invertMultiply(const GslMatrix& B, GslMatrix& X) const
 		    "GslMatrix::invertMultiply()",
 		    "Matrices B and X are incompatible");
 
-  
+
   UQ_FATAL_RC_MACRO((this->numRowsLocal() != X.numRowsLocal()),
                     m_env.worldRank(),
 		    "GslMatrix::invertMultiply()",
@@ -1659,26 +1659,26 @@ GslMatrix::invertMultiplyForceLU(
 		      m_env.worldRank(),
 		      "GslMatrix::invertMultiplyForceLU()",
 		      "gsl_matrix_calloc() failed");
-  
+
   iRC = gsl_matrix_memcpy(m_LU, m_mat);
   UQ_FATAL_RC_MACRO(iRC,
 		    m_env.worldRank(),
 		    "GslMatrix::invertMultiplyForceLU()",
 		    "gsl_matrix_memcpy() failed");
-  
+
   if( m_permutation == NULL ) m_permutation = gsl_permutation_calloc(numCols());
   UQ_FATAL_TEST_MACRO((m_permutation == NULL),
 		      m_env.worldRank(),
 		      "GslMatrix::invertMultiplyForceLU()",
 		      "gsl_permutation_calloc() failed");
-  
-  iRC = gsl_linalg_LU_decomp(m_LU,m_permutation,&m_signum); 
+
+  iRC = gsl_linalg_LU_decomp(m_LU,m_permutation,&m_signum);
   UQ_FATAL_RC_MACRO(iRC,
 		    m_env.worldRank(),
 		    "GslMatrix::invertMultiplyForceLU()",
 		    "gsl_linalg_LU_decomp() failed");
 
-  iRC = gsl_linalg_LU_solve(m_LU,m_permutation,b.data(),x.data()); 
+  iRC = gsl_linalg_LU_solve(m_LU,m_permutation,b.data(),x.data());
   if (iRC != 0) {
     m_isSingular = true;
   }
@@ -1772,7 +1772,7 @@ GslMatrix::largestEigen(double& eigenValue, GslVector& eigenVector) const
       // Here we use the norm of the residual as our convergence check:
       // norm( A*x - \lambda*x )
       residual = ( (*this)*z - lambda*z ).norm2();
-      
+
       if( residual < tolerance )
 	{
 	  eigenValue = lambda;
@@ -1781,7 +1781,7 @@ GslMatrix::largestEigen(double& eigenValue, GslVector& eigenVector) const
 	  eigenVector = z;
 	  return;
 	}
-	
+
     }
 
   // If we reach this point, then we didn't converge. Print error message
@@ -1793,7 +1793,7 @@ GslMatrix::largestEigen(double& eigenValue, GslVector& eigenVector) const
                       "GslMatrix::largestEigen()",
                       "Maximum num iterations exceeded");
 
-  
+
   return;
 }
 
@@ -1844,13 +1844,13 @@ GslMatrix::smallestEigen(double& eigenValue, GslVector& eigenVector) const
       one_over_lambda = w[index];
 
       lambda = 1.0/one_over_lambda;
-      
+
       z = lambda * w;
 
       // Here we use the norm of the residual as our convergence check:
       // norm( A*x - \lambda*x )
       residual = ( (*this)*z - lambda*z ).norm2();
-      
+
       if( residual < tolerance )
 	{
 	  eigenValue = lambda;
@@ -1859,7 +1859,7 @@ GslMatrix::smallestEigen(double& eigenValue, GslVector& eigenVector) const
 	  eigenVector = z;
 	  return;
 	}
-	
+
     }
 
   // If we reach this point, then we didn't converge. Print error message
@@ -1953,7 +1953,7 @@ GslMatrix::getRow(unsigned int row_num ) const
   GslVector row(m_env, m_map);
 
   this->getRow( row_num, row );
-  
+
   return row;
 }
 
@@ -1966,7 +1966,7 @@ GslMatrix::getColumn(unsigned int column_num ) const
   GslVector column(m_env, m_map);
 
   this->getColumn( column_num, column );
-  
+
   return column;
 }
 
@@ -2043,7 +2043,7 @@ GslMatrix::mpiSum( const MpiComm& comm, GslMatrix& M_global ) const
       for( unsigned int j = 0; j < this->numCols(); j++ )
 	{
 	  k = i + j*M_global.numCols();
-	  
+
 	  local[k] = (*this)(i,j);
 	}
     }
@@ -2057,7 +2057,7 @@ GslMatrix::mpiSum( const MpiComm& comm, GslMatrix& M_global ) const
       for( unsigned int j = 0; j < this->numCols(); j++ )
 	{
 	  k = i + j*M_global.numCols();
-	  
+
 	  M_global(i,j) = global[k];
 	}
     }

--- a/src/stats/inc/GaussianLikelihood.h
+++ b/src/stats/inc/GaussianLikelihood.h
@@ -1,0 +1,79 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef UQ_GAUSSIAN_LLHD_H
+#define UQ_GAUSSIAN_LLHD_H
+
+#include <queso/ScalarFunction.h>
+
+namespace QUESO {
+
+/*!
+ * \file BaseGaussianLikelihood.h
+ *
+ * \class BaseGaussianLikelihood
+ * \brief Base class for canned Gaussian likelihoods
+ *
+ * This class is an abstract base class for 'canned' Gaussian likelihoods.  All
+ * this class does is add a pure virtual function called \c evaluateModel that
+ * the user will implement to interact with the forward code.
+ */
+
+template<class V, class M>
+class BaseGaussianLikelihood : public BaseScalarFunction<V, M> {
+public:
+  //! @name Constructor/Destructor methods.
+  //@{
+  //! Default constructor.
+  /*!
+   * The vector of observations must be passed.  This will be used when
+   * evaluating the likelihood functional
+   */
+  BaseGaussianLikelihood(const char * prefix,
+      const VectorSet<V, M> & domainSet, const double * observations);
+
+  //! Destructor
+  virtual ~BaseGaussianLikelihood();
+  //@}
+
+  //! Evaluates the user's model at the point \c domainVector
+  /*!
+   * This is pure virtual, so the user must implement this when subclassing a
+   * Gaussian likelihood class.  Note that, what is returned is not an object
+   * of type \c V, but an array of type \c double.  This represents a vector of
+   * synthetic observations that will be to compare to actual observations when
+   * computing the likelihood functional.
+   */
+  virtual double * evaluateModel(const V & domainVector,
+      const V * domainDirection, V * gradVector, M * hessianMatrix,
+      V * hessianEffect) const = 0;
+
+//protected:
+  double * m_modelOutput;
+  const double * m_observations;
+};
+
+}  // End namespace QUESO
+
+#endif  // UQ_GAUSSIAN_LLHD_H

--- a/src/stats/inc/GaussianLikelihood.h
+++ b/src/stats/inc/GaussianLikelihood.h
@@ -25,6 +25,7 @@
 #ifndef UQ_GAUSSIAN_LLHD_H
 #define UQ_GAUSSIAN_LLHD_H
 
+#include <vector>
 #include <queso/ScalarFunction.h>
 
 namespace QUESO {
@@ -51,7 +52,8 @@ public:
    * evaluating the likelihood functional
    */
   BaseGaussianLikelihood(const char * prefix,
-      const VectorSet<V, M> & domainSet, const double * observations);
+      const VectorSet<V, M> & domainSet,
+      const std::vector<double> & observations);
 
   //! Destructor
   virtual ~BaseGaussianLikelihood();
@@ -69,9 +71,9 @@ public:
       const V * domainDirection, V * gradVector, M * hessianMatrix,
       V * hessianEffect) const = 0;
 
-//protected:
+protected:
   double * m_modelOutput;
-  const double * m_observations;
+  const std::vector<double> & m_observations;
 };
 
 }  // End namespace QUESO

--- a/src/stats/inc/GaussianLikelihood.h
+++ b/src/stats/inc/GaussianLikelihood.h
@@ -62,10 +62,10 @@ public:
   //! Evaluates the user's model at the point \c domainVector
   /*!
    * This is pure virtual, so the user must implement this when subclassing a
-   * Gaussian likelihood class.  Note that, what is returned is not an object
-   * of type \c V, but an array of type \c double.  This represents a vector of
-   * synthetic observations that will be to compare to actual observations when
-   * computing the likelihood functional.
+   * Gaussian likelihood class.  Note that, what is returned is void.  The user
+   * will fill up the \c modelOutput vector with output from the model.
+   * This represents a vector of synthetic observations that will be to compare
+   * to actual observations when computing the likelihood functional.
    */
   virtual void evaluateModel(const V & domainVector, const V * domainDirection,
       V & modelOutput, V * gradVector, M * hessianMatrix,

--- a/src/stats/inc/GaussianLikelihood.h
+++ b/src/stats/inc/GaussianLikelihood.h
@@ -53,7 +53,7 @@ public:
    */
   BaseGaussianLikelihood(const char * prefix,
       const VectorSet<V, M> & domainSet,
-      const std::vector<double> & observations);
+      const V & observations);
 
   //! Destructor
   virtual ~BaseGaussianLikelihood();
@@ -67,12 +67,12 @@ public:
    * synthetic observations that will be to compare to actual observations when
    * computing the likelihood functional.
    */
-  virtual const std::vector<double> & evaluateModel(const V & domainVector,
-      const V * domainDirection, V * gradVector, M * hessianMatrix,
+  virtual void evaluateModel(const V & domainVector, const V * domainDirection,
+      V & modelOutput, V * gradVector, M * hessianMatrix,
       V * hessianEffect) const = 0;
 
 protected:
-  const std::vector<double> & m_observations;
+  const V & m_observations;
 };
 
 }  // End namespace QUESO

--- a/src/stats/inc/GaussianLikelihood.h
+++ b/src/stats/inc/GaussianLikelihood.h
@@ -67,12 +67,11 @@ public:
    * synthetic observations that will be to compare to actual observations when
    * computing the likelihood functional.
    */
-  virtual double * evaluateModel(const V & domainVector,
+  virtual const std::vector<double> & evaluateModel(const V & domainVector,
       const V * domainDirection, V * gradVector, M * hessianMatrix,
       V * hessianEffect) const = 0;
 
 protected:
-  std::vector<double> m_modelOutput;
   const std::vector<double> & m_observations;
 };
 

--- a/src/stats/inc/GaussianLikelihood.h
+++ b/src/stats/inc/GaussianLikelihood.h
@@ -72,7 +72,7 @@ public:
       V * hessianEffect) const = 0;
 
 protected:
-  double * m_modelOutput;
+  std::vector<double> m_modelOutput;
   const std::vector<double> & m_observations;
 };
 

--- a/src/stats/inc/GaussianLikelihoodBlockDiagonalCovariance.h
+++ b/src/stats/inc/GaussianLikelihoodBlockDiagonalCovariance.h
@@ -1,0 +1,74 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef UQ_GAUSSIAN_LIKELIHOOD_BLOCK_DIAG_COV_H
+#define UQ_GAUSSIAN_LIKELIHOOD_BLOCK_DIAG_COV_H
+
+#include <queso/GslBlockMatrix.h>
+#include <queso/GaussianLikelihood.h>
+
+namespace QUESO {
+
+/*!
+ * \file GaussianLikelihoodBlockDiagonalCovariance.h
+ *
+ * \class GaussianLikelihoodBlockDiagonalCovariance
+ * \brief A class representing a Gaussian likelihood with block-diagonal cov
+ */
+
+template<class V, class M>
+class GaussianLikelihoodBlockDiagonalCovariance : public BaseGaussianLikelihood<V, M> {
+public:
+  //! @name Constructor/Destructor methods.
+  //@{
+  //! Default constructor.
+  /*!
+   * Instantiates a Gaussian likelihood function, given a prefix, its domain, a
+   * set of observations and a block diagonal covariance matrix.  The diagonal
+   * covariance matrix is stored as a \c std::vector of \c GslMatrix objects
+   * representing each block matrix.
+   */
+  GaussianLikelihoodBlockDiagonalCovariance(const char * prefix,
+      const VectorSet<V, M> & domainSet, const V & observations,
+      const GslBlockMatrix & covariance);
+
+  //! Destructor
+  virtual ~GaussianLikelihoodBlockDiagonalCovariance();
+  //@}
+
+  //! Actual value of the scalar function.
+  virtual double actualValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const;
+
+  //! Logarithm of the value of the scalar function.
+  virtual double lnValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const;
+
+private:
+  const GslBlockMatrix & m_covariance;
+};
+
+}  // End namespace QUESO
+
+#endif  // UQ_GAUSSIAN_LIKELIHOOD_BLOCK_DIAG_COV_H

--- a/src/stats/inc/GaussianLikelihoodBlockDiagonalCovariance.h
+++ b/src/stats/inc/GaussianLikelihoodBlockDiagonalCovariance.h
@@ -34,7 +34,7 @@ namespace QUESO {
  * \file GaussianLikelihoodBlockDiagonalCovariance.h
  *
  * \class GaussianLikelihoodBlockDiagonalCovariance
- * \brief A class representing a Gaussian likelihood with block-diagonal cov
+ * \brief A class representing a Gaussian likelihood with block-diagonal covariance matrix
  */
 
 template<class V, class M>
@@ -45,9 +45,9 @@ public:
   //! Default constructor.
   /*!
    * Instantiates a Gaussian likelihood function, given a prefix, its domain, a
-   * set of observations and a block diagonal covariance matrix.  The diagonal
-   * covariance matrix is stored as a \c std::vector of \c GslMatrix objects
-   * representing each block matrix.
+   * vector of observations and a block diagonal covariance matrix.
+   * The diagonal covariance matrix is of type \c GslBlockMatrix.  Each block
+   * in the block diagonal matrix is an object of type \c GslMatrix.
    */
   GaussianLikelihoodBlockDiagonalCovariance(const char * prefix,
       const VectorSet<V, M> & domainSet, const V & observations,

--- a/src/stats/inc/GaussianLikelihoodDiagonalCovariance.h
+++ b/src/stats/inc/GaussianLikelihoodDiagonalCovariance.h
@@ -1,0 +1,72 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef UQ_GAUSSIAN_LIKELIHOOD_DIAG_COV_H
+#define UQ_GAUSSIAN_LIKELIHOOD_DIAG_COV_H
+
+#include <queso/GaussianLikelihood.h>
+
+namespace QUESO {
+
+/*!
+ * \file GaussianLikelihoodDiagonalCovariance.h
+ *
+ * \class GaussianLikelihoodDiagonalCovariance
+ * \brief A class that represents a Gaussian likelihood with scalar covariance
+ */
+
+template<class V, class M>
+class GaussianLikelihoodDiagonalCovariance : public BaseGaussianLikelihood<V, M> {
+public:
+  //! @name Constructor/Destructor methods.
+  //@{
+  //! Default constructor.
+  /*!
+   * Instantiates a Gaussian likelihood function, given a prefix, its domain,
+   * a set of observations and a diagonal covariance matrix.  The diagonal
+   * covariance matrix is stored as a vector in the \c covariance parameter.
+   */
+  GaussianLikelihoodDiagonalCovariance(const char * prefix,
+      const VectorSet<V, M> & domainSet, const V & observations,
+      const V & covariance);
+
+  //! Destructor
+  virtual ~GaussianLikelihoodDiagonalCovariance();
+  //@}
+
+  //! Actual value of the scalar function.
+  virtual double actualValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const;
+
+  //! Logarithm of the value of the scalar function.
+  virtual double lnValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const;
+
+private:
+  const V & m_covariance;
+};
+
+}  // End namespace QUESO
+
+#endif  // UQ_GAUSSIAN_LIKELIHOOD_DIAG_COV_H

--- a/src/stats/inc/GaussianLikelihoodDiagonalCovariance.h
+++ b/src/stats/inc/GaussianLikelihoodDiagonalCovariance.h
@@ -33,7 +33,7 @@ namespace QUESO {
  * \file GaussianLikelihoodDiagonalCovariance.h
  *
  * \class GaussianLikelihoodDiagonalCovariance
- * \brief A class that represents a Gaussian likelihood with scalar covariance
+ * \brief A class that represents a Gaussian likelihood with diagonal covariance matrix
  */
 
 template<class V, class M>

--- a/src/stats/inc/GaussianLikelihoodFullCovariance.h
+++ b/src/stats/inc/GaussianLikelihoodFullCovariance.h
@@ -1,0 +1,72 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef UQ_GAUSSIAN_LIKELIHOOD_FULL_COV_H
+#define UQ_GAUSSIAN_LIKELIHOOD_FULL_COV_H
+
+#include <queso/GaussianLikelihood.h>
+
+namespace QUESO {
+
+/*!
+ * \file GaussianLikelihoodFullCovariance.h
+ *
+ * \class GaussianLikelihoodFullCovariance
+ * \brief A class that represents a Gaussian likelihood with full covariance
+ */
+
+template<class V, class M>
+class GaussianLikelihoodFullCovariance : public BaseGaussianLikelihood<V, M> {
+public:
+  //! @name Constructor/Destructor methods.
+  //@{
+  //! Default constructor.
+  /*!
+   * Instantiates a Gaussian likelihood function, given a prefix, its domain,
+   * a set of observations and a full covariance matrix.  The full
+   * covariance matrix is stored as a matrix in the \c covariance parameter.
+   */
+  GaussianLikelihoodFullCovariance(const char * prefix,
+      const VectorSet<V, M> & domainSet, const V & observations,
+      const M & covariance);
+
+  //! Destructor
+  virtual ~GaussianLikelihoodFullCovariance();
+  //@}
+
+  //! Actual value of the scalar function.
+  virtual double actualValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const;
+
+  //! Logarithm of the value of the scalar function.
+  virtual double lnValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const;
+
+private:
+  const M & m_covariance;
+};
+
+}  // End namespace QUESO
+
+#endif  // UQ_GAUSSIAN_LIKELIHOOD_FULL_COV_H

--- a/src/stats/inc/GaussianLikelihoodScalarCovariance.h
+++ b/src/stats/inc/GaussianLikelihoodScalarCovariance.h
@@ -47,8 +47,8 @@ public:
    * a set of observations and a scalar variance
    */
   GaussianLikelihoodScalarCovariance(const char * prefix,
-      const VectorSet<V, M> & domainSet, const double * observations,
-      double variance);
+      const VectorSet<V, M> & domainSet,
+      const std::vector<double> & observations, double variance);
 
   //! Destructor
   virtual ~GaussianLikelihoodScalarCovariance();

--- a/src/stats/inc/GaussianLikelihoodScalarCovariance.h
+++ b/src/stats/inc/GaussianLikelihoodScalarCovariance.h
@@ -44,11 +44,11 @@ public:
   //! Default constructor.
   /*!
    * Instantiates a Gaussian likelihood function, given a prefix, its domain,
-   * a set of observations and a scalar variance
+   * a set of observations and a scalar covariance matrix.
    */
   GaussianLikelihoodScalarCovariance(const char * prefix,
       const VectorSet<V, M> & domainSet, const V & observations,
-      double variance);
+      double covariance);
 
   //! Destructor
   virtual ~GaussianLikelihoodScalarCovariance();
@@ -63,7 +63,7 @@ public:
       V * gradVector, M * hessianMatrix, V * hessianEffect) const;
 
 private:
-  double m_variance;
+  double m_covariance;
 };
 
 }  // End namespace QUESO

--- a/src/stats/inc/GaussianLikelihoodScalarCovariance.h
+++ b/src/stats/inc/GaussianLikelihoodScalarCovariance.h
@@ -47,8 +47,8 @@ public:
    * a set of observations and a scalar variance
    */
   GaussianLikelihoodScalarCovariance(const char * prefix,
-      const VectorSet<V, M> & domainSet,
-      const std::vector<double> & observations, double variance);
+      const VectorSet<V, M> & domainSet, const V & observations,
+      double variance);
 
   //! Destructor
   virtual ~GaussianLikelihoodScalarCovariance();

--- a/src/stats/inc/GaussianLikelihoodScalarCovariance.h
+++ b/src/stats/inc/GaussianLikelihoodScalarCovariance.h
@@ -1,0 +1,71 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef UQ_GAUSSIAN_LIKELIHOOD_SCALAR_COV_H
+#define UQ_GAUSSIAN_LIKELIHOOD_SCALAR_COV_H
+
+#include <queso/GaussianLikelihood.h>
+
+namespace QUESO {
+
+/*!
+ * \file GaussianLikelihoodScalarCovariance.h
+ *
+ * \class GaussianLikelihoodScalarCovariance
+ * \brief A class that represents a Gaussian likelihood with scalar covariance
+ */
+
+template<class V, class M>
+class GaussianLikelihoodScalarCovariance : public BaseGaussianLikelihood<V, M> {
+public:
+  //! @name Constructor/Destructor methods.
+  //@{
+  //! Default constructor.
+  /*!
+   * Instantiates a Gaussian likelihood function, given a prefix, its domain,
+   * a set of observations and a scalar variance
+   */
+  GaussianLikelihoodScalarCovariance(const char * prefix,
+      const VectorSet<V, M> & domainSet, const double * observations,
+      double variance);
+
+  //! Destructor
+  virtual ~GaussianLikelihoodScalarCovariance();
+  //@}
+
+  //! Actual value of the scalar function.
+  virtual double actualValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const;
+
+  //! Logarithm of the value of the scalar function.
+  virtual double lnValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const;
+
+private:
+  double m_variance;
+};
+
+}  // End namespace QUESO
+
+#endif  // UQ_GAUSSIAN_LIKELIHOOD_SCALAR_COV_H

--- a/src/stats/inc/GaussianLikelihoodScalarCovariance.h
+++ b/src/stats/inc/GaussianLikelihoodScalarCovariance.h
@@ -44,7 +44,8 @@ public:
   //! Default constructor.
   /*!
    * Instantiates a Gaussian likelihood function, given a prefix, its domain,
-   * a set of observations and a scalar covariance matrix.
+   * a set of observations and a scalar covariance matrix.  The scalar
+   * 'covariance matrix' is just passed as a \c double.
    */
   GaussianLikelihoodScalarCovariance(const char * prefix,
       const VectorSet<V, M> & domainSet, const V & observations,

--- a/src/stats/src/GaussianLikelihood.C
+++ b/src/stats/src/GaussianLikelihood.C
@@ -32,7 +32,7 @@ namespace QUESO {
 template<class V, class M>
 BaseGaussianLikelihood<V, M>::BaseGaussianLikelihood(
     const char * prefix, const VectorSet<V, M> & domainSet,
-    const std::vector<double> & observations)
+    const V & observations)
   : BaseScalarFunction<V, M>(prefix, domainSet),
     m_observations(observations)
 {

--- a/src/stats/src/GaussianLikelihood.C
+++ b/src/stats/src/GaussianLikelihood.C
@@ -34,7 +34,6 @@ BaseGaussianLikelihood<V, M>::BaseGaussianLikelihood(
     const char * prefix, const VectorSet<V, M> & domainSet,
     const std::vector<double> & observations)
   : BaseScalarFunction<V, M>(prefix, domainSet),
-    m_modelOutput(observations.size()),
     m_observations(observations)
 {
 }

--- a/src/stats/src/GaussianLikelihood.C
+++ b/src/stats/src/GaussianLikelihood.C
@@ -34,6 +34,7 @@ BaseGaussianLikelihood<V, M>::BaseGaussianLikelihood(
     const char * prefix, const VectorSet<V, M> & domainSet,
     const std::vector<double> & observations)
   : BaseScalarFunction<V, M>(prefix, domainSet),
+    m_modelOutput(observations.size()),
     m_observations(observations)
 {
 }

--- a/src/stats/src/GaussianLikelihood.C
+++ b/src/stats/src/GaussianLikelihood.C
@@ -32,7 +32,7 @@ namespace QUESO {
 template<class V, class M>
 BaseGaussianLikelihood<V, M>::BaseGaussianLikelihood(
     const char * prefix, const VectorSet<V, M> & domainSet,
-    const double * observations)
+    const std::vector<double> & observations)
   : BaseScalarFunction<V, M>(prefix, domainSet),
     m_observations(observations)
 {

--- a/src/stats/src/GaussianLikelihood.C
+++ b/src/stats/src/GaussianLikelihood.C
@@ -1,0 +1,48 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/VectorSet.h>
+#include <queso/GaussianLikelihood.h>
+
+namespace QUESO {
+
+template<class V, class M>
+BaseGaussianLikelihood<V, M>::BaseGaussianLikelihood(
+    const char * prefix, const VectorSet<V, M> & domainSet,
+    const double * observations)
+  : BaseScalarFunction<V, M>(prefix, domainSet),
+    m_observations(observations)
+{
+}
+
+template<class V, class M>
+BaseGaussianLikelihood<V, M>::~BaseGaussianLikelihood()
+{
+}
+
+}  // End namespace QUESO
+
+template class QUESO::BaseGaussianLikelihood<QUESO::GslVector, QUESO::GslMatrix>;

--- a/src/stats/src/GaussianLikelihoodBlockDiagonalCovariance.C
+++ b/src/stats/src/GaussianLikelihoodBlockDiagonalCovariance.C
@@ -1,0 +1,93 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/VectorSet.h>
+#include <queso/GaussianLikelihoodBlockDiagonalCovariance.h>
+
+namespace QUESO {
+
+template<class V, class M>
+GaussianLikelihoodBlockDiagonalCovariance<V, M>::GaussianLikelihoodBlockDiagonalCovariance(
+    const char * prefix, const VectorSet<V, M> & domainSet,
+    const V & observations, const GslBlockMatrix & covariance)
+  : BaseGaussianLikelihood<V, M>(prefix, domainSet, observations),
+    m_covariance(covariance)
+{
+  unsigned int totalDim = 0;
+
+  for (unsigned int i = 0; i < this->m_covariance.numBlocks(); i++) {
+    totalDim += this->m_covariance.getBlock(i).numRowsLocal();
+  }
+
+  if (totalDim != observations.sizeLocal()) {
+    queso_error_msg("Covariance matrix not same size as observation vector");
+  }
+}
+
+template<class V, class M>
+GaussianLikelihoodBlockDiagonalCovariance<V, M>::~GaussianLikelihoodBlockDiagonalCovariance()
+{
+}
+
+template<class V, class M>
+double
+GaussianLikelihoodBlockDiagonalCovariance<V, M>::actualValue(
+    const V & domainVector, const V * domainDirection, V * gradVector,
+    M * hessianMatrix, V * hessianEffect) const
+{
+  return std::exp(this->lnValue(domainVector, domainDirection, gradVector,
+        hessianMatrix, hessianEffect));
+}
+
+template<class V, class M>
+double
+GaussianLikelihoodBlockDiagonalCovariance<V, M>::lnValue(
+    const V & domainVector, const V * domainDirection, V * gradVector,
+    M * hessianMatrix, V * hessianEffect) const
+{
+  V modelOutput(this->m_observations, 0, 0);  // At least it's not a copy
+  V weightedMisfit(this->m_observations, 0, 0);  // At least it's not a copy
+
+  this->evaluateModel(domainVector, domainDirection, modelOutput, gradVector,
+      hessianMatrix, hessianEffect);
+
+  // Compute misfit G(x) - y
+  modelOutput -= this->m_observations;
+
+  // Solve \Sigma u = G(x) - y for u
+  this->m_covariance.invertMultiply(modelOutput, weightedMisfit);
+
+  // Compute (G(x) - y)^T \Sigma^{-1} (G(x) - y)
+  modelOutput *= weightedMisfit;
+
+  double norm2_squared = modelOutput.sumOfComponents();  // This is square of 2-norm
+
+  return -0.5 * norm2_squared;
+}
+
+}  // End namespace QUESO
+
+template class QUESO::GaussianLikelihoodBlockDiagonalCovariance<QUESO::GslVector, QUESO::GslMatrix>;

--- a/src/stats/src/GaussianLikelihoodBlockDiagonalCovariance.C
+++ b/src/stats/src/GaussianLikelihoodBlockDiagonalCovariance.C
@@ -43,7 +43,7 @@ GaussianLikelihoodBlockDiagonalCovariance<V, M>::GaussianLikelihoodBlockDiagonal
   }
 
   if (totalDim != observations.sizeLocal()) {
-    queso_error_msg("Covariance matrix not same size as observation vector");
+    queso_error_msg("Covariance matrix not same dimension as observation vector");
   }
 }
 

--- a/src/stats/src/GaussianLikelihoodDiagonalCovariance.C
+++ b/src/stats/src/GaussianLikelihoodDiagonalCovariance.C
@@ -1,0 +1,81 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/VectorSet.h>
+#include <queso/GaussianLikelihoodDiagonalCovariance.h>
+
+namespace QUESO {
+
+template<class V, class M>
+GaussianLikelihoodDiagonalCovariance<V, M>::GaussianLikelihoodDiagonalCovariance(
+    const char * prefix, const VectorSet<V, M> & domainSet,
+    const V & observations, const V & covariance)
+  : BaseGaussianLikelihood<V, M>(prefix, domainSet, observations),
+    m_covariance(covariance)
+{
+  if (covariance.sizeLocal() != observations.sizeLocal()) {
+    queso_error_msg("Covariance matrix not same size as observation vector");
+  }
+}
+
+template<class V, class M>
+GaussianLikelihoodDiagonalCovariance<V, M>::~GaussianLikelihoodDiagonalCovariance()
+{
+}
+
+template<class V, class M>
+double
+GaussianLikelihoodDiagonalCovariance<V, M>::actualValue(const V & domainVector,
+    const V * domainDirection, V * gradVector, M * hessianMatrix,
+    V * hessianEffect) const
+{
+  return std::exp(this->lnValue(domainVector, domainDirection, gradVector,
+        hessianMatrix, hessianEffect));
+}
+
+template<class V, class M>
+double
+GaussianLikelihoodDiagonalCovariance<V, M>::lnValue(const V & domainVector,
+    const V * domainDirection, V * gradVector, M * hessianMatrix,
+    V * hessianEffect) const
+{
+  V modelOutput(this->m_observations, 0, 0);  // At least it's not a copy
+
+  this->evaluateModel(domainVector, domainDirection, modelOutput, gradVector,
+      hessianMatrix, hessianEffect);
+
+  modelOutput -= this->m_observations;  // Compute misfit
+  modelOutput *= modelOutput;
+  modelOutput /= this->m_covariance;  // Multiply by inverse covriance matrix
+
+  double norm2_squared = modelOutput.sumOfComponents();  // This is square of 2-norm
+
+  return -0.5 * norm2_squared;
+}
+
+}  // End namespace QUESO
+
+template class QUESO::GaussianLikelihoodDiagonalCovariance<QUESO::GslVector, QUESO::GslMatrix>;

--- a/src/stats/src/GaussianLikelihoodFullCovariance.C
+++ b/src/stats/src/GaussianLikelihoodFullCovariance.C
@@ -1,0 +1,88 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/VectorSet.h>
+#include <queso/GaussianLikelihoodFullCovariance.h>
+
+namespace QUESO {
+
+template<class V, class M>
+GaussianLikelihoodFullCovariance<V, M>::GaussianLikelihoodFullCovariance(
+    const char * prefix, const VectorSet<V, M> & domainSet,
+    const V & observations, const M & covariance)
+  : BaseGaussianLikelihood<V, M>(prefix, domainSet, observations),
+    m_covariance(covariance)
+{
+  if (covariance.numRowsLocal() != observations.sizeLocal()) {
+    queso_error_msg("Covariance matrix not same size as observation vector");
+  }
+}
+
+template<class V, class M>
+GaussianLikelihoodFullCovariance<V, M>::~GaussianLikelihoodFullCovariance()
+{
+}
+
+template<class V, class M>
+double
+GaussianLikelihoodFullCovariance<V, M>::actualValue(const V & domainVector,
+    const V * domainDirection, V * gradVector, M * hessianMatrix,
+    V * hessianEffect) const
+{
+  return std::exp(this->lnValue(domainVector, domainDirection, gradVector,
+        hessianMatrix, hessianEffect));
+}
+
+template<class V, class M>
+double
+GaussianLikelihoodFullCovariance<V, M>::lnValue(const V & domainVector,
+    const V * domainDirection, V * gradVector, M * hessianMatrix,
+    V * hessianEffect) const
+{
+  V modelOutput(this->m_observations, 0, 0);  // At least it's not a copy
+  V weightedMisfit(this->m_observations, 0, 0);  // At least it's not a copy
+
+  this->evaluateModel(domainVector, domainDirection, modelOutput, gradVector,
+      hessianMatrix, hessianEffect);
+
+  // Compute misfit G(x) - y
+  modelOutput -= this->m_observations;
+
+  // Solve \Sigma u = G(x) - y for u
+  this->m_covariance.invertMultiply(modelOutput, weightedMisfit);
+
+  // Compute (G(x) - y)^T \Sigma^{-1} (G(x) - y)
+  modelOutput *= weightedMisfit;
+
+  // This is square of 2-norm
+  double norm2_squared = modelOutput.sumOfComponents();
+
+  return -0.5 * norm2_squared;
+}
+
+}  // End namespace QUESO
+
+template class QUESO::GaussianLikelihoodFullCovariance<QUESO::GslVector, QUESO::GslMatrix>;

--- a/src/stats/src/GaussianLikelihoodScalarCovariance.C
+++ b/src/stats/src/GaussianLikelihoodScalarCovariance.C
@@ -32,9 +32,9 @@ namespace QUESO {
 template<class V, class M>
 GaussianLikelihoodScalarCovariance<V, M>::GaussianLikelihoodScalarCovariance(
     const char * prefix, const VectorSet<V, M> & domainSet,
-    const V & observations, double variance)
+    const V & observations, double covariance)
   : BaseGaussianLikelihood<V, M>(prefix, domainSet, observations),
-    m_variance(variance)
+    m_covariance(covariance)
 {
 }
 
@@ -67,7 +67,7 @@ GaussianLikelihoodScalarCovariance<V, M>::lnValue(const V & domainVector,
   modelOutput -= this->m_observations;  // Compute misfit
   double norm2_squared = modelOutput.norm2Sq();  // Compute square of 2-norm
 
-  return -0.5 * norm2_squared / m_variance;
+  return -0.5 * norm2_squared / m_covariance;
 }
 
 }  // End namespace QUESO

--- a/src/stats/src/GaussianLikelihoodScalarCovariance.C
+++ b/src/stats/src/GaussianLikelihoodScalarCovariance.C
@@ -62,10 +62,11 @@ GaussianLikelihoodScalarCovariance<V, M>::lnValue(const V & domainVector,
   double misfit = 0.0;
 
   for (unsigned int i = 0; i < this->m_observations.size(); i++) {
-    misfit += this->m_modelOutput[i] - this->m_observations[i];
+    double diff = this->m_modelOutput[i] - this->m_observations[i];
+    misfit += diff * diff;
   }
 
-  return -0.5 * misfit * misfit / m_variance;
+  return -0.5 * misfit / m_variance;
 }
 
 }  // End namespace QUESO

--- a/src/stats/src/GaussianLikelihoodScalarCovariance.C
+++ b/src/stats/src/GaussianLikelihoodScalarCovariance.C
@@ -1,0 +1,74 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/VectorSet.h>
+#include <queso/GaussianLikelihoodScalarCovariance.h>
+
+namespace QUESO {
+
+template<class V, class M>
+GaussianLikelihoodScalarCovariance<V, M>::GaussianLikelihoodScalarCovariance(
+    const char * prefix, const VectorSet<V, M> & domainSet,
+    const double * observations, double variance)
+  : BaseGaussianLikelihood<V, M>(prefix, domainSet, observations),
+    m_variance(variance)
+{
+}
+
+template<class V, class M>
+GaussianLikelihoodScalarCovariance<V, M>::~GaussianLikelihoodScalarCovariance()
+{
+}
+
+template<class V, class M>
+double
+GaussianLikelihoodScalarCovariance<V, M>::actualValue(const V & domainVector,
+    const V * domainDirection, V * gradVector, M * hessianMatrix,
+    V * hessianEffect) const
+{
+  return std::exp(this->lnValue(domainVector, domainDirection, gradVector,
+        hessianMatrix, hessianEffect));
+}
+
+template<class V, class M>
+double
+GaussianLikelihoodScalarCovariance<V, M>::lnValue(const V & domainVector,
+    const V * domainDirection, V * gradVector, M * hessianMatrix,
+    V * hessianEffect) const
+{
+  double misfit = 0.0;
+  unsigned int obsLength = 10;  // FIXME: this is wrong
+
+  for (unsigned int i = 0; i < obsLength; i++) {
+    misfit += this->m_modelOutput[i] - this->m_observations[i];
+  }
+
+  return -0.5 * misfit * misfit / m_variance;
+}
+
+}  // End namespace QUESO
+
+template class QUESO::GaussianLikelihoodScalarCovariance<QUESO::GslVector, QUESO::GslMatrix>;

--- a/src/stats/src/GaussianLikelihoodScalarCovariance.C
+++ b/src/stats/src/GaussianLikelihoodScalarCovariance.C
@@ -32,7 +32,7 @@ namespace QUESO {
 template<class V, class M>
 GaussianLikelihoodScalarCovariance<V, M>::GaussianLikelihoodScalarCovariance(
     const char * prefix, const VectorSet<V, M> & domainSet,
-    const double * observations, double variance)
+    const std::vector<double> & observations, double variance)
   : BaseGaussianLikelihood<V, M>(prefix, domainSet, observations),
     m_variance(variance)
 {
@@ -60,9 +60,8 @@ GaussianLikelihoodScalarCovariance<V, M>::lnValue(const V & domainVector,
     V * hessianEffect) const
 {
   double misfit = 0.0;
-  unsigned int obsLength = 10;  // FIXME: this is wrong
 
-  for (unsigned int i = 0; i < obsLength; i++) {
+  for (unsigned int i = 0; i < this->m_observations.size(); i++) {
     misfit += this->m_modelOutput[i] - this->m_observations[i];
   }
 

--- a/src/stats/src/GaussianLikelihoodScalarCovariance.C
+++ b/src/stats/src/GaussianLikelihoodScalarCovariance.C
@@ -32,7 +32,7 @@ namespace QUESO {
 template<class V, class M>
 GaussianLikelihoodScalarCovariance<V, M>::GaussianLikelihoodScalarCovariance(
     const char * prefix, const VectorSet<V, M> & domainSet,
-    const std::vector<double> & observations, double variance)
+    const V & observations, double variance)
   : BaseGaussianLikelihood<V, M>(prefix, domainSet, observations),
     m_variance(variance)
 {
@@ -59,17 +59,15 @@ GaussianLikelihoodScalarCovariance<V, M>::lnValue(const V & domainVector,
     const V * domainDirection, V * gradVector, M * hessianMatrix,
     V * hessianEffect) const
 {
-  double misfit = 0.0;
+  V modelOutput(this->m_observations, 0, 0);  // At least it's not a copy
 
-  const std::vector<double> & modelOutput = this->evaluateModel(domainVector,
-    domainDirection, gradVector, hessianMatrix, hessianEffect);
+  this->evaluateModel(domainVector, domainDirection, modelOutput, gradVector,
+      hessianMatrix, hessianEffect);
 
-  for (unsigned int i = 0; i < this->m_observations.size(); i++) {
-    double diff = modelOutput[i] - this->m_observations[i];
-    misfit += diff * diff;
-  }
+  modelOutput -= this->m_observations;  // Compute misfit
+  double norm2_squared = modelOutput.norm2Sq();  // Compute square of 2-norm
 
-  return -0.5 * misfit / m_variance;
+  return -0.5 * norm2_squared / m_variance;
 }
 
 }  // End namespace QUESO

--- a/src/stats/src/GaussianLikelihoodScalarCovariance.C
+++ b/src/stats/src/GaussianLikelihoodScalarCovariance.C
@@ -61,8 +61,11 @@ GaussianLikelihoodScalarCovariance<V, M>::lnValue(const V & domainVector,
 {
   double misfit = 0.0;
 
+  const std::vector<double> & modelOutput = this->evaluateModel(domainVector,
+    domainDirection, gradVector, hessianMatrix, hessianEffect);
+
   for (unsigned int i = 0; i < this->m_observations.size(); i++) {
-    double diff = this->m_modelOutput[i] - this->m_observations[i];
+    double diff = modelOutput[i] - this->m_observations[i];
     misfit += diff * diff;
   }
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -37,6 +37,8 @@ check_PROGRAMS += test_seedwithmap_fd
 check_PROGRAMS += test_logitadaptedcov
 check_PROGRAMS += test_scalarCovariance
 check_PROGRAMS += test_diagonalCovariance
+check_PROGRAMS += test_fullCovariance
+check_PROGRAMS += test_blockDiagonalCovariance
 
 LDADD       = $(top_builddir)/src/libqueso.la
 
@@ -99,6 +101,8 @@ test_seedwithmap_fd_SOURCES = test_optimizer/test_seedwithmap_fd.C
 test_logitadaptedcov_SOURCES = test_Regression/test_logitadaptedcov.C
 test_scalarCovariance_SOURCES = test_gaussian_likelihoods/test_scalarCovariance.C
 test_diagonalCovariance_SOURCES = test_gaussian_likelihoods/test_diagonalCovariance.C
+test_fullCovariance_SOURCES = test_gaussian_likelihoods/test_fullCovariance.C
+test_blockDiagonalCovariance_SOURCES = test_gaussian_likelihoods/test_blockDiagonalCovariance.C
 
 # Files to freedom stamp
 srcstamp =
@@ -133,6 +137,8 @@ srcstamp += $(test_seedwithmap_fd_SOURCES)
 srcstamp += $(test_logitadaptedcov_SOURCES)
 srcstamp += $(test_scalarCovariance_SOURCES)
 srcstamp += $(test_diagonalCovariance_SOURCES)
+srcstamp += $(test_fullCovariance_SOURCES)
+srcstamp += $(test_blockDiagonalCovariance_SOURCES)
 
 TESTS =
 TESTS += $(top_builddir)/test/test_uqEnvironmentCopy
@@ -167,6 +173,8 @@ TESTS += $(top_builddir)/test/test_seedwithmap_fd
 TESTS += $(top_builddir)/test/test_logitadaptedcov
 TESTS += $(top_builddir)/test/test_scalarCovariance
 TESTS += $(top_builddir)/test/test_diagonalCovariance
+TESTS += $(top_builddir)/test/test_fullCovariance
+TESTS += $(top_builddir)/test/test_blockDiagonalCovariance
 
 XFAIL_TESTS = $(top_builddir)/test/test_SequenceOfVectorsErase
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -36,6 +36,7 @@ check_PROGRAMS += test_seedwithmap
 check_PROGRAMS += test_seedwithmap_fd
 check_PROGRAMS += test_logitadaptedcov
 check_PROGRAMS += test_scalarCovariance
+check_PROGRAMS += test_diagonalCovariance
 
 LDADD       = $(top_builddir)/src/libqueso.la
 
@@ -97,6 +98,7 @@ test_seedwithmap_SOURCES = test_optimizer/test_seedwithmap.C
 test_seedwithmap_fd_SOURCES = test_optimizer/test_seedwithmap_fd.C
 test_logitadaptedcov_SOURCES = test_Regression/test_logitadaptedcov.C
 test_scalarCovariance_SOURCES = test_gaussian_likelihoods/test_scalarCovariance.C
+test_diagonalCovariance_SOURCES = test_gaussian_likelihoods/test_diagonalCovariance.C
 
 # Files to freedom stamp
 srcstamp =
@@ -130,6 +132,7 @@ srcstamp += $(test_seedwithmap_SOURCES)
 srcstamp += $(test_seedwithmap_fd_SOURCES)
 srcstamp += $(test_logitadaptedcov_SOURCES)
 srcstamp += $(test_scalarCovariance_SOURCES)
+srcstamp += $(test_diagonalCovariance_SOURCES)
 
 TESTS =
 TESTS += $(top_builddir)/test/test_uqEnvironmentCopy
@@ -163,6 +166,7 @@ TESTS += $(top_builddir)/test/test_seedwithmap
 TESTS += $(top_builddir)/test/test_seedwithmap_fd
 TESTS += $(top_builddir)/test/test_logitadaptedcov
 TESTS += $(top_builddir)/test/test_scalarCovariance
+TESTS += $(top_builddir)/test/test_diagonalCovariance
 
 XFAIL_TESTS = $(top_builddir)/test/test_SequenceOfVectorsErase
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -39,6 +39,7 @@ check_PROGRAMS += test_scalarCovariance
 check_PROGRAMS += test_diagonalCovariance
 check_PROGRAMS += test_fullCovariance
 check_PROGRAMS += test_blockDiagonalCovariance
+check_PROGRAMS += test_GslBlockMatrixInvertMultiply
 
 LDADD       = $(top_builddir)/src/libqueso.la
 
@@ -103,6 +104,7 @@ test_scalarCovariance_SOURCES = test_gaussian_likelihoods/test_scalarCovariance.
 test_diagonalCovariance_SOURCES = test_gaussian_likelihoods/test_diagonalCovariance.C
 test_fullCovariance_SOURCES = test_gaussian_likelihoods/test_fullCovariance.C
 test_blockDiagonalCovariance_SOURCES = test_gaussian_likelihoods/test_blockDiagonalCovariance.C
+test_GslBlockMatrixInvertMultiply_SOURCES = test_GslBlockMatrix/test_GslBlockMatrixInvertMultiply.C
 
 # Files to freedom stamp
 srcstamp =
@@ -139,6 +141,7 @@ srcstamp += $(test_scalarCovariance_SOURCES)
 srcstamp += $(test_diagonalCovariance_SOURCES)
 srcstamp += $(test_fullCovariance_SOURCES)
 srcstamp += $(test_blockDiagonalCovariance_SOURCES)
+srcstamp += $(test_GslBlockMatrixInvertMultiply_SOURCES)
 
 TESTS =
 TESTS += $(top_builddir)/test/test_uqEnvironmentCopy
@@ -175,6 +178,7 @@ TESTS += $(top_builddir)/test/test_scalarCovariance
 TESTS += $(top_builddir)/test/test_diagonalCovariance
 TESTS += $(top_builddir)/test/test_fullCovariance
 TESTS += $(top_builddir)/test/test_blockDiagonalCovariance
+TESTS += $(top_builddir)/test/test_GslBlockMatrixInvertMultiply
 
 XFAIL_TESTS = $(top_builddir)/test/test_SequenceOfVectorsErase
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -35,6 +35,7 @@ check_PROGRAMS += test_gsloptimizer
 check_PROGRAMS += test_seedwithmap
 check_PROGRAMS += test_seedwithmap_fd
 check_PROGRAMS += test_logitadaptedcov
+check_PROGRAMS += test_scalarCovariance
 
 LDADD       = $(top_builddir)/src/libqueso.la
 
@@ -95,6 +96,7 @@ test_gsloptimizer_SOURCES = test_optimizer/test_gsloptimizer.C
 test_seedwithmap_SOURCES = test_optimizer/test_seedwithmap.C
 test_seedwithmap_fd_SOURCES = test_optimizer/test_seedwithmap_fd.C
 test_logitadaptedcov_SOURCES = test_Regression/test_logitadaptedcov.C
+test_scalarCovariance_SOURCES = test_gaussian_likelihoods/test_scalarCovariance.C
 
 # Files to freedom stamp
 srcstamp =
@@ -127,6 +129,7 @@ srcstamp += $(test_gsloptimizer_SOURCES)
 srcstamp += $(test_seedwithmap_SOURCES)
 srcstamp += $(test_seedwithmap_fd_SOURCES)
 srcstamp += $(test_logitadaptedcov_SOURCES)
+srcstamp += $(test_scalarCovariance_SOURCES)
 
 TESTS =
 TESTS += $(top_builddir)/test/test_uqEnvironmentCopy
@@ -159,6 +162,7 @@ TESTS += $(top_builddir)/test/test_gsloptimizer
 TESTS += $(top_builddir)/test/test_seedwithmap
 TESTS += $(top_builddir)/test/test_seedwithmap_fd
 TESTS += $(top_builddir)/test/test_logitadaptedcov
+TESTS += $(top_builddir)/test/test_scalarCovariance
 
 XFAIL_TESTS = $(top_builddir)/test/test_SequenceOfVectorsErase
 
@@ -183,6 +187,7 @@ EXTRA_DIST += test_Regression/jeffreys_input.txt.in
 EXTRA_DIST += test_Regression/test_jeffreys_samples_diff.sh.in
 EXTRA_DIST += test_Regression/test_jeffreys_samples.m.in
 EXTRA_DIST += test_Regression/adaptedcov_input.txt.in
+EXTRA_DIST += test_gaussian_likelihoods/queso_input.txt.in
 
 DISTCLEANFILES =
 DISTCLEANFILES += test_gpmsa_cobra_output/display_sub0.txt
@@ -193,6 +198,7 @@ DISTCLEANFILES += test_gpmsa_cobra_output/ip_raw_chain_logtarget.m
 DISTCLEANFILES += test_gpmsa_cobra_output/ip_raw_chain_logtarget_sub0.m
 DISTCLEANFILES += test_gpmsa_cobra_output/ip_raw_chain_sub0.m
 DISTCLEANFILES += test_gpmsa_cobra_output/sipOutput_sub0.m
+DISTCLEANFILES += test_output_gaussian_likelihoods/display_sub0.txt
 
 CLEANFILES =
 CLEANFILES += $(top_srcdir)/test/test_Environment/debug_output_sub0.txt

--- a/test/test_GslBlockMatrix/test_GslBlockMatrixInvertMultiply.C
+++ b/test/test_GslBlockMatrix/test_GslBlockMatrixInvertMultiply.C
@@ -1,0 +1,68 @@
+#include <mpi.h>
+
+#include <queso/Environment.h>
+#include <queso/VectorSpace.h>
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/GslBlockMatrix.h>
+
+#define TOL 1e-10
+
+int main(int argc, char **argv) {
+  MPI_Init(&argc, &argv);
+
+  QUESO::EnvOptionsValues options;
+  options.m_numSubEnvironments = 1;
+
+  QUESO::FullEnvironment env(MPI_COMM_WORLD, "", "", &options);
+
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
+      "param_", 3, NULL);
+
+  // Set up block sizes for observation covariance matrix
+  std::vector<unsigned int> blockSizes(2);
+  blockSizes[0] = 1;  // First block is 1x1 (scalar)
+  blockSizes[1] = 2;  // Second block is 2x2
+
+  // Set up block matrix with specified block sizes
+  QUESO::GslBlockMatrix covariance(env, blockSizes, 1.0);  // Identity matrix
+
+  // The matrix [[1, 0, 0], [0, 1, 2], [0, 2, 8]]
+  // has inverse 0.25 * [[1, 0, 0], [0, 2, -0.5], [0, -0.5, 0.25]]
+  covariance.getBlock(0)(0, 0) = 1.0;
+  covariance.getBlock(1)(0, 0) = 1.0;
+  covariance.getBlock(1)(0, 1) = 2.0;
+  covariance.getBlock(1)(1, 0) = 2.0;
+  covariance.getBlock(1)(1, 1) = 8.0;
+
+  // Example RHS
+  QUESO::GslVector b(paramSpace.zeroVector());
+  b[0] = 1.0;
+  b[1] = 2.0;
+  b[2] = 3.0;
+
+  // Compute solution
+  QUESO::GslVector x(paramSpace.zeroVector());
+  covariance.invertMultiply(b, x);
+
+  // This is the analytical solution
+  QUESO::GslVector sol(paramSpace.zeroVector());
+  sol[0] = 1.0;
+  sol[1] = 2.5;
+  sol[2] = -0.25;
+
+  // So if the solve worked, this sucker should be the zero vector
+  sol -= x;
+
+  // So its norm should be zero
+  if (sol.norm2() > TOL) {
+    std::cerr << "Computed solution:" << std::endl;
+    std::cerr << b << std::endl;
+    std::cerr << "Actual solution:" << std::endl;
+    std::cerr << sol << std::endl;
+    queso_error_msg("TEST: GslBlockMatrix::invertMultiply failed.");
+  }
+
+  MPI_Finalize();
+  return 0;
+}

--- a/test/test_GslBlockMatrix/test_GslBlockMatrixInvertMultiply.C
+++ b/test/test_GslBlockMatrix/test_GslBlockMatrixInvertMultiply.C
@@ -19,13 +19,19 @@ int main(int argc, char **argv) {
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
       "param_", 3, NULL);
 
+  // Example RHS
+  QUESO::GslVector b(paramSpace.zeroVector());
+  b[0] = 1.0;
+  b[1] = 2.0;
+  b[2] = 3.0;
+
   // Set up block sizes for observation covariance matrix
   std::vector<unsigned int> blockSizes(2);
   blockSizes[0] = 1;  // First block is 1x1 (scalar)
   blockSizes[1] = 2;  // Second block is 2x2
 
-  // Set up block matrix with specified block sizes
-  QUESO::GslBlockMatrix covariance(env, blockSizes, 1.0);  // Identity matrix
+  // Set up block (identity) matrix with specified block sizes
+  QUESO::GslBlockMatrix covariance(blockSizes, b, 1.0);
 
   // The matrix [[1, 0, 0], [0, 1, 2], [0, 2, 8]]
   // has inverse 0.25 * [[1, 0, 0], [0, 2, -0.5], [0, -0.5, 0.25]]
@@ -34,12 +40,6 @@ int main(int argc, char **argv) {
   covariance.getBlock(1)(0, 1) = 2.0;
   covariance.getBlock(1)(1, 0) = 2.0;
   covariance.getBlock(1)(1, 1) = 8.0;
-
-  // Example RHS
-  QUESO::GslVector b(paramSpace.zeroVector());
-  b[0] = 1.0;
-  b[1] = 2.0;
-  b[2] = 3.0;
 
   // Compute solution
   QUESO::GslVector x(paramSpace.zeroVector());

--- a/test/test_gaussian_likelihoods/queso_input.txt.in
+++ b/test/test_gaussian_likelihoods/queso_input.txt.in
@@ -1,0 +1,48 @@
+###############################################
+# UQ Environment
+###############################################
+env_help                 = 1
+env_numSubEnvironments   = 1
+env_subDisplayFileName   = test_output_gaussian_likelihoods/display
+env_subDisplayAllowAll   = 0
+env_subDisplayAllowedSet = 0
+env_displayVerbosity     = 1000
+env_syncVerbosity        = 0
+env_seed                 = 0
+
+###############################################
+# Statistical inverse problem (ip)
+###############################################
+ip_help                 = anything
+ip_computeSolution      = 1
+ip_dataOutputFileName   = test_output_gaussian_likelihoods/sipOutput
+ip_dataOutputAllowedSet = 0
+
+###############################################
+# 'ip_': information for Metropolis-Hastings algorithm
+###############################################
+ip_mh_help                 = anything
+ip_mh_dataOutputFileName   = test_output_gaussian_likelihoods/sipOutput
+ip_mh_dataOutputAllowedSet = 0 1
+
+ip_mh_rawChain_dataInputFileName    = .
+ip_mh_rawChain_size                 = 1
+ip_mh_rawChain_generateExtra        = 0
+ip_mh_rawChain_displayPeriod        = 2000
+ip_mh_rawChain_measureRunTimes      = 1
+ip_mh_rawChain_dataOutputFileName   = test_output_gaussian_likelihoods/ip_raw_chain
+ip_mh_rawChain_dataOutputAllowedSet = 0 1
+ip_mh_rawChain_computeStats         = 1
+
+ip_mh_displayCandidates             = 0
+ip_mh_putOutOfBoundsInChain         = 0
+ip_mh_tk_useLocalHessian            = 0
+ip_mh_tk_useNewtonComponent         = 0
+ip_mh_dr_maxNumExtraStages          = 0
+ip_mh_dr_listOfScalesForExtraStages = 5. 10. 20.
+ip_mh_am_initialNonAdaptInterval    = 10
+ip_mh_am_adaptInterval              = 1
+ip_mh_am_eta                        = 0.384
+ip_mh_am_epsilon                    = 1.e-5
+
+ip_mh_filteredChain_generate        = 0

--- a/test/test_gaussian_likelihoods/test_blockDiagonalCovariance.C
+++ b/test/test_gaussian_likelihoods/test_blockDiagonalCovariance.C
@@ -77,20 +77,6 @@ int main(int argc, char ** argv) {
   QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix> paramDomain("param_",
       paramSpace, paramMins, paramMaxs);
 
-  // Set up block sizes for observation covariance matrix
-  std::vector<unsigned int> blockSizes(2);
-  blockSizes[0] = 1;  // First block is 1x1 (scalar)
-  blockSizes[1] = 2;  // Second block is 2x2
-
-  // Set up block matrix with specified block sizes
-  QUESO::GslBlockMatrix covariance(env, blockSizes, 1.0);  // Identity matrix
-
-  covariance.getBlock(0)(0, 0) = 1.0;
-  covariance.getBlock(1)(0, 0) = 1.0;
-  covariance.getBlock(1)(0, 1) = 2.0;
-  covariance.getBlock(1)(1, 0) = 2.0;
-  covariance.getBlock(1)(1, 1) = 8.0;
-
   // Set up observation space
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> obsSpace(env,
       "obs_", 3, NULL);
@@ -100,6 +86,20 @@ int main(int argc, char ** argv) {
   observations[0] = 1.0;
   observations[1] = 1.0;
   observations[2] = 1.0;
+
+  // Set up block sizes for observation covariance matrix
+  std::vector<unsigned int> blockSizes(2);
+  blockSizes[0] = 1;  // First block is 1x1 (scalar)
+  blockSizes[1] = 2;  // Second block is 2x2
+
+  // Set up block (identity) matrix with specified block sizes
+  QUESO::GslBlockMatrix covariance(blockSizes, observations, 1.0);
+
+  covariance.getBlock(0)(0, 0) = 1.0;
+  covariance.getBlock(1)(0, 0) = 1.0;
+  covariance.getBlock(1)(0, 1) = 2.0;
+  covariance.getBlock(1)(1, 0) = 2.0;
+  covariance.getBlock(1)(1, 1) = 8.0;
 
   // Pass in observations to Gaussian likelihood object
   Likelihood<QUESO::GslVector, QUESO::GslMatrix> lhood("llhd_", paramDomain,

--- a/test/test_gaussian_likelihoods/test_diagonalCovariance.C
+++ b/test/test_gaussian_likelihoods/test_diagonalCovariance.C
@@ -1,0 +1,128 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/VectorSet.h>
+#include <queso/BoxSubset.h>
+#include <queso/GaussianLikelihoodDiagonalCovariance.h>
+
+#define TOL 1e-8
+
+template<class V, class M>
+class Likelihood : public QUESO::GaussianLikelihoodDiagonalCovariance<V, M>
+{
+public:
+
+  Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domain,
+      const V & observations, const V & covariance)
+    : QUESO::GaussianLikelihoodDiagonalCovariance<V, M>(prefix, domain,
+        observations, covariance)
+  {
+  }
+
+  virtual ~Likelihood()
+  {
+  }
+
+  virtual void evaluateModel(const V & domainVector, const V * domainDirection,
+      V & modelOutput, V * gradVector, M * hessianMatrix,
+      V * hessianEffect) const
+  {
+    // Model is a map from R to R^2
+
+    // Evaluate model and fill up the m_modelOutput member variable
+    for (unsigned int i = 0; i < modelOutput.sizeLocal(); i++) {
+      modelOutput[i] = domainVector[0] + 3.0;
+    }
+  }
+};
+
+int main(int argc, char ** argv) {
+  MPI_Init(&argc, &argv);
+
+  QUESO::FullEnvironment env(MPI_COMM_WORLD, "test_gaussian_likelihoods/queso_input.txt", "", NULL);
+
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
+      "param_", 1, NULL);
+
+  double min_val = 0.0;
+  double max_val = 1.0;
+
+  QUESO::GslVector paramMins(paramSpace.zeroVector());
+  paramMins.cwSet(min_val);
+  QUESO::GslVector paramMaxs(paramSpace.zeroVector());
+  paramMaxs.cwSet(max_val);
+
+  QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix> paramDomain("param_",
+      paramSpace, paramMins, paramMaxs);
+
+  // Set up observation space
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> obsSpace(env,
+      "obs_", 2, NULL);
+
+  // Fill up observation vector
+  QUESO::GslVector observations(obsSpace.zeroVector());
+  observations[0] = 1.0;
+  observations[1] = 1.0;
+
+  // Fill up covariance 'matrix'
+  QUESO::GslVector covariance(obsSpace.zeroVector());
+  covariance[0] = 1.0;
+  covariance[1] = 2.0;
+
+  // Pass in observations to Gaussian likelihood object
+  Likelihood<QUESO::GslVector, QUESO::GslMatrix> lhood("llhd_", paramDomain,
+      observations, covariance);
+
+  double lhood_value;
+  double truth_value;
+  QUESO::GslVector point(paramSpace.zeroVector());
+  point[0] = 0.0;
+  lhood_value = lhood.actualValue(point, NULL, NULL, NULL, NULL);
+  truth_value = std::exp(-3.0);
+
+  if (std::abs(lhood_value - truth_value) > TOL) {
+    std::cerr << "Scalar Gaussian test case failure." << std::endl;
+    std::cerr << "Computed likelihood value is: " << lhood_value << std::endl;
+    std::cerr << "Likelihood value should be: " << truth_value << std::endl;
+    queso_error();
+  }
+
+  point[0] = -2.0;
+  lhood_value = lhood.actualValue(point, NULL, NULL, NULL, NULL);
+  truth_value = 1.0;
+
+  if (std::abs(lhood_value - truth_value) > TOL) {
+    std::cerr << "Scalar Gaussian test case failure." << std::endl;
+    std::cerr << "Computed likelihood value is: " << lhood_value << std::endl;
+    std::cerr << "Likelihood value should be: " << truth_value << std::endl;
+    queso_error();
+  }
+
+  MPI_Finalize();
+
+  return 0;
+}
+


### PR DESCRIPTION
This PR implements classes that represent Gaussian-form likelihoods.  Note that, if the user's model is not linear, the likelihood is not actually Gaussian, but the expression for the probability distribution function implies a Gaussian distribution for the observational error on the observations.

An example is provided, and a test will be added later today.  I wanted to get this up to elicit any initial feedback people might have on the design.  Looking at the example is a good first start.