### PR TITLE
Add a coefficient for cov matrix in Gaussian llhd

### DIFF
--- a/examples/gaussian_likelihoods/fullCovariance.C
+++ b/examples/gaussian_likelihoods/fullCovariance.C
@@ -35,12 +35,12 @@ template<class V, class M>
 class Likelihood : public QUESO::GaussianLikelihoodFullCovariance<V, M>
 {
 public:
-
   Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domain,
       const V & observations, const M & covariance)
     : QUESO::GaussianLikelihoodFullCovariance<V, M>(prefix, domain,
         observations, covariance)
   {
+    // Default covariance coefficient is 1.0
   }
 
   virtual ~Likelihood()

--- a/src/stats/inc/GaussianLikelihoodFullCovariance.h
+++ b/src/stats/inc/GaussianLikelihoodFullCovariance.h
@@ -46,10 +46,14 @@ public:
    * Instantiates a Gaussian likelihood function, given a prefix, its domain,
    * a set of observations and a full covariance matrix.  The full
    * covariance matrix is stored as a matrix in the \c covariance parameter.
+   *
+   * The parameter \c covarianceCoefficient is a multiplying factor of
+   * \c covaraince and is fixed (i.e. not solved for in a statistical
+   * inversion).
    */
   GaussianLikelihoodFullCovariance(const char * prefix,
       const VectorSet<V, M> & domainSet, const V & observations,
-      const M & covariance);
+      const M & covariance, double covarianceCoefficient=1.0);
 
   //! Destructor
   virtual ~GaussianLikelihoodFullCovariance();
@@ -64,6 +68,7 @@ public:
       V * gradVector, M * hessianMatrix, V * hessianEffect) const;
 
 private:
+  double m_covarianceCoefficient;
   const M & m_covariance;
 };
 

--- a/src/stats/src/GaussianLikelihoodFullCovariance.C
+++ b/src/stats/src/GaussianLikelihoodFullCovariance.C
@@ -32,8 +32,9 @@ namespace QUESO {
 template<class V, class M>
 GaussianLikelihoodFullCovariance<V, M>::GaussianLikelihoodFullCovariance(
     const char * prefix, const VectorSet<V, M> & domainSet,
-    const V & observations, const M & covariance)
+    const V & observations, const M & covariance, double covarianceCoefficient)
   : BaseGaussianLikelihood<V, M>(prefix, domainSet, observations),
+    m_covarianceCoefficient(covarianceCoefficient),
     m_covariance(covariance)
 {
   if (covariance.numRowsLocal() != observations.sizeLocal()) {
@@ -80,7 +81,7 @@ GaussianLikelihoodFullCovariance<V, M>::lnValue(const V & domainVector,
   // This is square of 2-norm
   double norm2_squared = modelOutput.sumOfComponents();
 
-  return -0.5 * norm2_squared;
+  return -0.5 * norm2_squared / (this->m_covarianceCoefficient);
 }
 
 }  // End namespace QUESO

--- a/test/test_gaussian_likelihoods/test_fullCovariance.C
+++ b/test/test_gaussian_likelihoods/test_fullCovariance.C
@@ -40,6 +40,7 @@ public:
     : QUESO::GaussianLikelihoodFullCovariance<V, M>(prefix, domain,
         observations, covariance)
   {
+    // Default covariance coefficient is 1.0
   }
 
   virtual ~Likelihood()


### PR DESCRIPTION
The user can specify a multiplicative coefficient for the covariance matrix in a Gaussian likelihood.