### PR TITLE
Adding canned Gaussian likelihood with random multiplicative hyperparameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,4 @@ test/test_blockDiagonalCovariance
 test/test_output_gaussian_likelihoods
 test/test_gaussian_likelihoods/queso_input.txt
 test/test_GslBlockMatrixInvertMultiply
+test/test_fullCovarianceRandomCoefficient

--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ examples/scalarCovariance
 examples/diagonalCovariance
 examples/fullCovariance
 examples/blockDiagonalCovariance
+examples/fullCovarianceRandomCoefficient
 
 src/core/inc/queso.h
 src/libqueso.la

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -394,6 +394,12 @@ blockDiagonalCovariance_SOURCES = gaussian_likelihoods/blockDiagonalCovariance.C
 blockDiagonalCovariance_LDADD = $(top_builddir)/src/libqueso.la
 blockDiagonalCovariance_CPPFLAGS = -I$(top_srcdir)/examples/gaussian_likelihoods/blockDiagonalCovariance $(QUESO_CPPFLAGS)
 
+fullCovarianceRandomCoefficientdir = $(prefix)/examples/gaussian_likelihoods
+fullCovarianceRandomCoefficient_PROGRAMS = fullCovarianceRandomCoefficient
+fullCovarianceRandomCoefficient_SOURCES = gaussian_likelihoods/fullCovarianceRandomCoefficient.C
+fullCovarianceRandomCoefficient_LDADD = $(top_builddir)/src/libqueso.la
+fullCovarianceRandomCoefficient_CPPFLAGS = -I$(top_srcdir)/examples/gaussian_likelihoods/fullCovarianceRandomCoefficient $(QUESO_CPPFLAGS)
+
 dist_gpmsa_scalar_DATA =
 dist_gpmsa_scalar_DATA += ${gpmsa_scalar_SOURCES}
 

--- a/examples/gaussian_likelihoods/fullCovarianceRandomCoefficient.C
+++ b/examples/gaussian_likelihoods/fullCovarianceRandomCoefficient.C
@@ -1,0 +1,137 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/VectorSet.h>
+#include <queso/BoxSubset.h>
+#include <queso/UniformVectorRV.h>
+#include <queso/GenericVectorRV.h>
+#include <queso/GaussianLikelihoodFullCovarianceRandomCoefficient.h>
+#include <queso/StatisticalInverseProblem.h>
+
+template<class V, class M>
+class Likelihood : public QUESO::GaussianLikelihoodFullCovarianceRandomCoefficient<V, M>
+{
+public:
+  Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domain,
+      const V & observations, const M & covariance)
+    : QUESO::GaussianLikelihoodFullCovarianceRandomCoefficient<V, M>(prefix,
+        domain, observations, covariance)
+  {
+    // Default covariance coefficient is 1.0
+  }
+
+  virtual ~Likelihood()
+  {
+  }
+
+  virtual void evaluateModel(const V & domainVector, const V * domainDirection,
+      V & modelOutput, V * gradVector, M * hessianMatrix,
+      V * hessianEffect) const
+  {
+    // domainVector is of size 2 because the first element is the model
+    // parameter and the second (last) element is the multiplicative
+    // coefficient of the observational error covariance matrix.  Therefore,
+    // for calling the model code, we need only concern ourselves with the
+    // first element of domainVector.
+
+    // Evaluate model and fill up the m_modelOutput member variable
+    for (unsigned int i = 0; i < modelOutput.sizeLocal(); i++) {
+      modelOutput[i] = 1.0;
+    }
+  }
+};
+
+int main(int argc, char ** argv) {
+  MPI_Init(&argc, &argv);
+
+  QUESO::FullEnvironment env(MPI_COMM_WORLD, argv[1], "", NULL);
+
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
+      "param_", 2, NULL);
+
+  double min_val = 0.0;
+  double max_val = 1.0;
+
+  QUESO::GslVector paramMins(paramSpace.zeroVector());
+  QUESO::GslVector paramMaxs(paramSpace.zeroVector());
+
+  // Model parameter between 0 and 1
+  paramMins[0] = 0.0;
+  paramMaxs[0] = 1.0;
+
+  // Hyperparameter (multiplicative coefficient of observational error
+  // covariance matrix) between 0.0 and \infty
+  paramMins[1] = 0.0;
+  paramMaxs[1] = INFINITY;
+
+  QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix> paramDomain("param_",
+      paramSpace, paramMins, paramMaxs);
+
+  QUESO::UniformVectorRV<QUESO::GslVector, QUESO::GslMatrix> priorRv("prior_",
+      paramDomain);
+
+  // Set up observation space
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> obsSpace(env,
+      "obs_", 2, NULL);
+
+  // Fill up observation vector
+  QUESO::GslVector observations(obsSpace.zeroVector());
+  observations[0] = 1.0;
+  observations[1] = 1.0;
+
+  // Fill up covariance 'matrix'
+  QUESO::GslMatrix covariance(obsSpace.zeroVector());
+  covariance(0, 0) = 1.0;
+  covariance(0, 1) = 0.0;
+  covariance(1, 0) = 0.0;
+  covariance(1, 1) = 1.0;
+
+  // Pass in observations to Gaussian likelihood object
+  Likelihood<QUESO::GslVector, QUESO::GslMatrix> lhood("llhd_", paramDomain,
+      observations, covariance);
+
+  QUESO::GenericVectorRV<QUESO::GslVector, QUESO::GslMatrix>
+    postRv("post_", paramSpace);
+
+  QUESO::StatisticalInverseProblem<QUESO::GslVector, QUESO::GslMatrix>
+    ip("", NULL, priorRv, lhood, postRv);
+
+  QUESO::GslVector paramInitials(paramSpace.zeroVector());
+
+  paramInitials[0] = 0.0;
+
+  QUESO::GslMatrix proposalCovMatrix(paramSpace.zeroVector());
+
+  for (unsigned int i = 0; i < 1; i++) {
+    proposalCovMatrix(i, i) = 0.1;
+  }
+
+  ip.solveWithBayesMetropolisHastings(NULL, paramInitials, &proposalCovMatrix);
+
+  MPI_Finalize();
+
+  return 0;
+}

--- a/inc/queso/Makefile.am
+++ b/inc/queso/Makefile.am
@@ -110,6 +110,7 @@ BUILT_SOURCES += GaussianLikelihood.h
 BUILT_SOURCES += GaussianLikelihoodBlockDiagonalCovariance.h
 BUILT_SOURCES += GaussianLikelihoodDiagonalCovariance.h
 BUILT_SOURCES += GaussianLikelihoodFullCovariance.h
+BUILT_SOURCES += GaussianLikelihoodFullCovarianceRandomCoefficient.h
 BUILT_SOURCES += GaussianLikelihoodScalarCovariance.h
 BUILT_SOURCES += GaussianVectorCdf.h
 BUILT_SOURCES += GaussianVectorMdf.h
@@ -389,6 +390,8 @@ GaussianLikelihoodBlockDiagonalCovariance.h: $(top_srcdir)/src/stats/inc/Gaussia
 GaussianLikelihoodDiagonalCovariance.h: $(top_srcdir)/src/stats/inc/GaussianLikelihoodDiagonalCovariance.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 GaussianLikelihoodFullCovariance.h: $(top_srcdir)/src/stats/inc/GaussianLikelihoodFullCovariance.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+GaussianLikelihoodFullCovarianceRandomCoefficient.h: $(top_srcdir)/src/stats/inc/GaussianLikelihoodFullCovarianceRandomCoefficient.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 GaussianLikelihoodScalarCovariance.h: $(top_srcdir)/src/stats/inc/GaussianLikelihoodScalarCovariance.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -241,6 +241,7 @@ libqueso_la_SOURCES += stats/src/GaussianLikelihood.C
 libqueso_la_SOURCES += stats/src/GaussianLikelihoodScalarCovariance.C
 libqueso_la_SOURCES += stats/src/GaussianLikelihoodDiagonalCovariance.C
 libqueso_la_SOURCES += stats/src/GaussianLikelihoodFullCovariance.C
+libqueso_la_SOURCES += stats/src/GaussianLikelihoodFullCovarianceRandomCoefficient.C
 libqueso_la_SOURCES += stats/src/GaussianLikelihoodBlockDiagonalCovariance.C
 
 # Sources from gp/src
@@ -429,6 +430,7 @@ libqueso_include_HEADERS += stats/inc/GaussianLikelihood.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodScalarCovariance.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodDiagonalCovariance.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodFullCovariance.h
+libqueso_include_HEADERS += stats/inc/GaussianLikelihoodFullCovarianceRandomCoefficient.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodBlockDiagonalCovariance.h
 
 # Headers to install from gp/inc

--- a/src/stats/inc/GaussianLikelihood.h
+++ b/src/stats/inc/GaussianLikelihood.h
@@ -62,10 +62,18 @@ public:
   //! Evaluates the user's model at the point \c domainVector
   /*!
    * This is pure virtual, so the user must implement this when subclassing a
-   * Gaussian likelihood class.  Note that, what is returned is void.  The user
-   * will fill up the \c modelOutput vector with output from the model.
-   * This represents a vector of synthetic observations that will be to compare
-   * to actual observations when computing the likelihood functional.
+   * Gaussian likelihood class.  Note that void is returned.  The user will
+   * fill up the \c modelOutput vector with output from the model.  This
+   * represents a vector of synthetic observations that will be to compare to
+   * actual observations when computing the likelihood functional.
+   *
+   * The first \c n components of \c domainVector are the model parameters.
+   * The rest of \c domainVector contains the hyperparameters, if any.  For
+   * example, in \c GaussianLikelihoodFullCovarainceRandomCoefficient, the last
+   * component of \c domainVector contains the multiplicative coefficient of
+   * the observational covariance matrix.  In this case, the user need not
+   * concern themselves with this parameter as it is handled not in the model
+   * evaluation but by the likelihood evaluation.
    */
   virtual void evaluateModel(const V & domainVector, const V * domainDirection,
       V & modelOutput, V * gradVector, M * hessianMatrix,

--- a/src/stats/inc/GaussianLikelihoodFullCovarianceRandomCoefficient.h
+++ b/src/stats/inc/GaussianLikelihoodFullCovarianceRandomCoefficient.h
@@ -1,0 +1,77 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef UQ_GAUSSIAN_LIKELIHOOD_FULL_COV_RAND_COEFF_H
+#define UQ_GAUSSIAN_LIKELIHOOD_FULL_COV_RAND_COEFF_H
+
+#include <queso/GaussianLikelihood.h>
+
+namespace QUESO {
+
+/*!
+ * \file GaussianLikelihoodFullCovarianceRandomCoefficient.h
+ *
+ * \class GaussianLikelihoodFullCovarianceRandomCoefficient
+ * \brief A class that represents a Gaussian likelihood with full covariance and random coefficient
+ */
+
+template<class V, class M>
+class GaussianLikelihoodFullCovarianceRandomCoefficient : public BaseGaussianLikelihood<V, M> {
+public:
+  //! @name Constructor/Destructor methods.
+  //@{
+  //! Default constructor.
+  /*!
+   * Instantiates a Gaussian likelihood function, given a prefix, its domain,
+   * a set of observations and a full covariance matrix.  The full
+   * covariance matrix is stored as a matrix in the \c covariance parameter.
+   *
+   * The parameter \c covarianceCoefficient is a multiplying factor of
+   * \c covaraince and is treated as a random variable (i.e. it is solved for
+   * in a statistical inversion).
+   */
+  GaussianLikelihoodFullCovarianceRandomCoefficient(const char * prefix,
+      const VectorSet<V, M> & domainSet, const V & observations,
+      const M & covariance);
+
+  //! Destructor
+  virtual ~GaussianLikelihoodFullCovarianceRandomCoefficient();
+  //@}
+
+  //! Actual value of the scalar function.
+  virtual double actualValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const;
+
+  //! Logarithm of the value of the scalar function.
+  virtual double lnValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const;
+
+private:
+  double m_covarianceCoefficient;
+  const M & m_covariance;
+};
+
+}  // End namespace QUESO
+
+#endif  // UQ_GAUSSIAN_LIKELIHOOD_FULL_COV_RAND_COEFF_H

--- a/src/stats/src/GaussianLikelihoodFullCovarianceRandomCoefficient.C
+++ b/src/stats/src/GaussianLikelihoodFullCovarianceRandomCoefficient.C
@@ -1,0 +1,95 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/VectorSet.h>
+#include <queso/VectorSpace.h>
+#include <queso/GaussianLikelihoodFullCovarianceRandomCoefficient.h>
+
+namespace QUESO {
+
+template<class V, class M>
+GaussianLikelihoodFullCovarianceRandomCoefficient<V, M>::GaussianLikelihoodFullCovarianceRandomCoefficient(
+    const char * prefix, const VectorSet<V, M> & domainSet,
+    const V & observations, const M & covariance)
+  : BaseGaussianLikelihood<V, M>(prefix, domainSet, observations),
+    m_covariance(covariance)
+{
+  if (covariance.numRowsLocal() != observations.sizeLocal()) {
+    queso_error_msg("Covariance matrix not same size as observation vector");
+  }
+
+  if (domainSet.vectorSpace().dimLocal() != observations.sizeLocal() + 1) {
+    queso_error_msg("Vector space must have dimension one larger than observation vector");
+  }
+}
+
+template<class V, class M>
+GaussianLikelihoodFullCovarianceRandomCoefficient<V, M>::~GaussianLikelihoodFullCovarianceRandomCoefficient()
+{
+}
+
+template<class V, class M>
+double
+GaussianLikelihoodFullCovarianceRandomCoefficient<V, M>::actualValue(const V & domainVector,
+    const V * domainDirection, V * gradVector, M * hessianMatrix,
+    V * hessianEffect) const
+{
+  return std::exp(this->lnValue(domainVector, domainDirection, gradVector,
+        hessianMatrix, hessianEffect));
+}
+
+template<class V, class M>
+double
+GaussianLikelihoodFullCovarianceRandomCoefficient<V, M>::lnValue(const V & domainVector,
+    const V * domainDirection, V * gradVector, M * hessianMatrix,
+    V * hessianEffect) const
+{
+  V modelOutput(this->m_observations, 0, 0);  // At least it's not a copy
+  V weightedMisfit(this->m_observations, 0, 0);  // At least it's not a copy
+
+  this->evaluateModel(domainVector, domainDirection, modelOutput, gradVector,
+      hessianMatrix, hessianEffect);
+
+  // Compute misfit G(x) - y
+  modelOutput -= this->m_observations;
+
+  // Solve \Sigma u = G(x) - y for u
+  this->m_covariance.invertMultiply(modelOutput, weightedMisfit);
+
+  // Compute (G(x) - y)^T \Sigma^{-1} (G(x) - y)
+  modelOutput *= weightedMisfit;
+
+  // This is square of 2-norm
+  double norm2_squared = modelOutput.sumOfComponents();
+
+  // The last element of domainVector is the multiplicative coefficient of the
+  // covariance matrix
+  return -0.5 * norm2_squared / (domainVector[domainVector.sizeLocal()-1]);
+}
+
+}  // End namespace QUESO
+
+template class QUESO::GaussianLikelihoodFullCovarianceRandomCoefficient<QUESO::GslVector, QUESO::GslMatrix>;

--- a/src/stats/src/GaussianLikelihoodFullCovarianceRandomCoefficient.C
+++ b/src/stats/src/GaussianLikelihoodFullCovarianceRandomCoefficient.C
@@ -40,10 +40,6 @@ GaussianLikelihoodFullCovarianceRandomCoefficient<V, M>::GaussianLikelihoodFullC
   if (covariance.numRowsLocal() != observations.sizeLocal()) {
     queso_error_msg("Covariance matrix not same size as observation vector");
   }
-
-  if (domainSet.vectorSpace().dimLocal() != observations.sizeLocal() + 1) {
-    queso_error_msg("Vector space must have dimension one larger than observation vector");
-  }
 }
 
 template<class V, class M>
@@ -53,9 +49,9 @@ GaussianLikelihoodFullCovarianceRandomCoefficient<V, M>::~GaussianLikelihoodFull
 
 template<class V, class M>
 double
-GaussianLikelihoodFullCovarianceRandomCoefficient<V, M>::actualValue(const V & domainVector,
-    const V * domainDirection, V * gradVector, M * hessianMatrix,
-    V * hessianEffect) const
+GaussianLikelihoodFullCovarianceRandomCoefficient<V, M>::actualValue(
+    const V & domainVector, const V * domainDirection, V * gradVector,
+    M * hessianMatrix, V * hessianEffect) const
 {
   return std::exp(this->lnValue(domainVector, domainDirection, gradVector,
         hessianMatrix, hessianEffect));
@@ -63,9 +59,9 @@ GaussianLikelihoodFullCovarianceRandomCoefficient<V, M>::actualValue(const V & d
 
 template<class V, class M>
 double
-GaussianLikelihoodFullCovarianceRandomCoefficient<V, M>::lnValue(const V & domainVector,
-    const V * domainDirection, V * gradVector, M * hessianMatrix,
-    V * hessianEffect) const
+GaussianLikelihoodFullCovarianceRandomCoefficient<V, M>::lnValue(
+    const V & domainVector, const V * domainDirection, V * gradVector,
+    M * hessianMatrix, V * hessianEffect) const
 {
   V modelOutput(this->m_observations, 0, 0);  // At least it's not a copy
   V weightedMisfit(this->m_observations, 0, 0);  // At least it's not a copy

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -40,6 +40,7 @@ check_PROGRAMS += test_diagonalCovariance
 check_PROGRAMS += test_fullCovariance
 check_PROGRAMS += test_blockDiagonalCovariance
 check_PROGRAMS += test_GslBlockMatrixInvertMultiply
+check_PROGRAMS += test_fullCovarianceRandomCoefficient
 
 LDADD       = $(top_builddir)/src/libqueso.la
 
@@ -105,6 +106,7 @@ test_diagonalCovariance_SOURCES = test_gaussian_likelihoods/test_diagonalCovaria
 test_fullCovariance_SOURCES = test_gaussian_likelihoods/test_fullCovariance.C
 test_blockDiagonalCovariance_SOURCES = test_gaussian_likelihoods/test_blockDiagonalCovariance.C
 test_GslBlockMatrixInvertMultiply_SOURCES = test_GslBlockMatrix/test_GslBlockMatrixInvertMultiply.C
+test_fullCovarianceRandomCoefficient_SOURCES = test_gaussian_likelihoods/test_fullCovarianceRandomCoefficient.C
 
 # Files to freedom stamp
 srcstamp =
@@ -142,6 +144,7 @@ srcstamp += $(test_diagonalCovariance_SOURCES)
 srcstamp += $(test_fullCovariance_SOURCES)
 srcstamp += $(test_blockDiagonalCovariance_SOURCES)
 srcstamp += $(test_GslBlockMatrixInvertMultiply_SOURCES)
+srcstamp += $(test_fullCovarianceRandomCoefficient_SOURCES)
 
 TESTS =
 TESTS += $(top_builddir)/test/test_uqEnvironmentCopy
@@ -179,6 +182,7 @@ TESTS += $(top_builddir)/test/test_diagonalCovariance
 TESTS += $(top_builddir)/test/test_fullCovariance
 TESTS += $(top_builddir)/test/test_blockDiagonalCovariance
 TESTS += $(top_builddir)/test/test_GslBlockMatrixInvertMultiply
+TESTS += $(top_builddir)/test/test_fullCovarianceRandomCoefficient
 
 XFAIL_TESTS = $(top_builddir)/test/test_SequenceOfVectorsErase
 


### PR DESCRIPTION
This pull request implements a Gaussian likelihood where the multiplicative factor in front of the observation error covariance matrix is treated as a random variable.

The user must specify the appropriate dimension in the vector space for the `StatisticalInverseProblem` class, but that is all.  The user does not have to deal with the hyperparameter explicitly in the model evaluation, since this is dealt with directly in the likelihood.