### PR TITLE
Add Gaussian canned likelihood with block diagonal covariance matrix and random multiplicative coefficients for each block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ examples/scalarCovariance
 examples/diagonalCovariance
 examples/fullCovariance
 examples/blockDiagonalCovariance
+examples/blockDiagonalCovarianceRandomCoefficients
 
 src/core/inc/queso.h
 src/libqueso.la

--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,4 @@ test/test_blockDiagonalCovariance
 test/test_output_gaussian_likelihoods
 test/test_gaussian_likelihoods/queso_input.txt
 test/test_GslBlockMatrixInvertMultiply
+test/test_blockDiagonalCovarianceRandomCoefficients

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -394,6 +394,12 @@ blockDiagonalCovariance_SOURCES = gaussian_likelihoods/blockDiagonalCovariance.C
 blockDiagonalCovariance_LDADD = $(top_builddir)/src/libqueso.la
 blockDiagonalCovariance_CPPFLAGS = -I$(top_srcdir)/examples/gaussian_likelihoods/blockDiagonalCovariance $(QUESO_CPPFLAGS)
 
+blockDiagonalCovarianceRandomCoefficientsdir = $(prefix)/examples/gaussian_likelihoods
+blockDiagonalCovarianceRandomCoefficients_PROGRAMS = blockDiagonalCovarianceRandomCoefficients
+blockDiagonalCovarianceRandomCoefficients_SOURCES = gaussian_likelihoods/blockDiagonalCovarianceRandomCoefficients.C
+blockDiagonalCovarianceRandomCoefficients_LDADD = $(top_builddir)/src/libqueso.la
+blockDiagonalCovarianceRandomCoefficients_CPPFLAGS = -I$(top_srcdir)/examples/gaussian_likelihoods/blockDiagonalCovarianceRandomCoefficients $(QUESO_CPPFLAGS)
+
 dist_gpmsa_scalar_DATA =
 dist_gpmsa_scalar_DATA += ${gpmsa_scalar_SOURCES}
 

--- a/examples/gaussian_likelihoods/blockDiagonalCovarianceRandomCoefficients.C
+++ b/examples/gaussian_likelihoods/blockDiagonalCovarianceRandomCoefficients.C
@@ -1,0 +1,133 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/GslBlockMatrix.h>
+#include <queso/VectorSet.h>
+#include <queso/BoxSubset.h>
+#include <queso/UniformVectorRV.h>
+#include <queso/GenericVectorRV.h>
+#include <queso/GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.h>
+#include <queso/StatisticalInverseProblem.h>
+
+template<class V, class M>
+class Likelihood : public QUESO::GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients<V, M>
+{
+public:
+
+  Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domain,
+      const V & observations, const QUESO::GslBlockMatrix & covariance)
+    : QUESO::GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients<V, M>(prefix, domain,
+        observations, covariance)
+  {
+  }
+
+  virtual ~Likelihood()
+  {
+  }
+
+  virtual void evaluateModel(const V & domainVector, const V * domainDirection,
+      V & modelOutput, V * gradVector, M * hessianMatrix,
+      V * hessianEffect) const
+  {
+    // Evaluate model and fill up the m_modelOutput member variable
+    for (unsigned int i = 0; i < modelOutput.sizeLocal(); i++) {
+      modelOutput[i] = 1.0;
+    }
+  }
+};
+
+int main(int argc, char ** argv) {
+  MPI_Init(&argc, &argv);
+
+  QUESO::FullEnvironment env(MPI_COMM_WORLD, argv[1], "", NULL);
+
+  // Need 3 dims because two are for the hyperparameters
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
+      "param_", 3, NULL);
+
+  double min_val = 0.0;
+  double max_val = INFINITY;
+
+  QUESO::GslVector paramMins(paramSpace.zeroVector());
+  QUESO::GslVector paramMaxs(paramSpace.zeroVector());
+
+  // Hyperparameter bounds
+  paramMins.cwSet(min_val);
+  paramMaxs.cwSet(max_val);
+
+  // Model parameter bounds
+  paramMaxs[0] = 1.0;
+
+  QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix> paramDomain("param_",
+      paramSpace, paramMins, paramMaxs);
+
+  QUESO::UniformVectorRV<QUESO::GslVector, QUESO::GslMatrix> priorRv("prior_",
+      paramDomain);
+
+  // Set up observation space
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> obsSpace(env,
+      "obs_", 3, NULL);
+
+  // Fill up observation vector
+  QUESO::GslVector observations(obsSpace.zeroVector());
+  observations[0] = 1.0;
+  observations[1] = 1.0;
+  observations[2] = 1.0;
+
+  // Set up block sizes for observation covariance matrix
+  std::vector<unsigned int> blockSizes(2);
+  blockSizes[0] = 1;  // First block is 1x1 (scalar)
+  blockSizes[1] = 2;  // Second block is 2x2
+
+  // Set up block matrix (identity matrix) with specified block sizes
+  QUESO::GslBlockMatrix covariance(blockSizes, observations, 1.0);
+
+  // Pass in observations to Gaussian likelihood object
+  Likelihood<QUESO::GslVector, QUESO::GslMatrix> lhood("llhd_", paramDomain,
+      observations, covariance);
+
+  QUESO::GenericVectorRV<QUESO::GslVector, QUESO::GslMatrix>
+    postRv("post_", paramSpace);
+
+  QUESO::StatisticalInverseProblem<QUESO::GslVector, QUESO::GslMatrix>
+    ip("", NULL, priorRv, lhood, postRv);
+
+  QUESO::GslVector paramInitials(paramSpace.zeroVector());
+
+  paramInitials[0] = 0.0;
+
+  QUESO::GslMatrix proposalCovMatrix(paramSpace.zeroVector());
+
+  for (unsigned int i = 0; i < 1; i++) {
+    proposalCovMatrix(i, i) = 0.1;
+  }
+
+  ip.solveWithBayesMetropolisHastings(NULL, paramInitials, &proposalCovMatrix);
+
+  MPI_Finalize();
+
+  return 0;
+}

--- a/inc/queso/Makefile.am
+++ b/inc/queso/Makefile.am
@@ -108,6 +108,7 @@ BUILT_SOURCES += GammaVectorRealizer.h
 BUILT_SOURCES += GaussianJointPdf.h
 BUILT_SOURCES += GaussianLikelihood.h
 BUILT_SOURCES += GaussianLikelihoodBlockDiagonalCovariance.h
+BUILT_SOURCES += GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.h
 BUILT_SOURCES += GaussianLikelihoodDiagonalCovariance.h
 BUILT_SOURCES += GaussianLikelihoodFullCovariance.h
 BUILT_SOURCES += GaussianLikelihoodScalarCovariance.h
@@ -385,6 +386,8 @@ GaussianJointPdf.h: $(top_srcdir)/src/stats/inc/GaussianJointPdf.h
 GaussianLikelihood.h: $(top_srcdir)/src/stats/inc/GaussianLikelihood.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 GaussianLikelihoodBlockDiagonalCovariance.h: $(top_srcdir)/src/stats/inc/GaussianLikelihoodBlockDiagonalCovariance.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.h: $(top_srcdir)/src/stats/inc/GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 GaussianLikelihoodDiagonalCovariance.h: $(top_srcdir)/src/stats/inc/GaussianLikelihoodDiagonalCovariance.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -242,6 +242,7 @@ libqueso_la_SOURCES += stats/src/GaussianLikelihoodScalarCovariance.C
 libqueso_la_SOURCES += stats/src/GaussianLikelihoodDiagonalCovariance.C
 libqueso_la_SOURCES += stats/src/GaussianLikelihoodFullCovariance.C
 libqueso_la_SOURCES += stats/src/GaussianLikelihoodBlockDiagonalCovariance.C
+libqueso_la_SOURCES += stats/src/GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.C
 
 # Sources from gp/src
 
@@ -430,6 +431,7 @@ libqueso_include_HEADERS += stats/inc/GaussianLikelihoodScalarCovariance.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodDiagonalCovariance.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodFullCovariance.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodBlockDiagonalCovariance.h
+libqueso_include_HEADERS += stats/inc/GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.h
 
 # Headers to install from gp/inc
 

--- a/src/stats/inc/GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.h
+++ b/src/stats/inc/GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.h
@@ -35,6 +35,9 @@ namespace QUESO {
  *
  * \class GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients
  * \brief A class representing a Gaussian likelihood with block-diagonal covariance matrix
+ *
+ * Each block diagonal matrix has a multiplicative coefficient that is treated
+ * as a hyperparameter to be inferred during the sampling procedure.
  */
 
 template<class V, class M>
@@ -48,6 +51,9 @@ public:
    * vector of observations and a block diagonal covariance matrix.
    * The diagonal covariance matrix is of type \c GslBlockMatrix.  Each block
    * in the block diagonal matrix is an object of type \c GslMatrix.
+   *
+   * Each block diagonal matrix has a multiplicative coefficient that is
+   * treated as a hyperparameter to be inferred during the sampling procedure.
    */
   GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients(const char * prefix,
       const VectorSet<V, M> & domainSet, const V & observations,

--- a/src/stats/inc/GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.h
+++ b/src/stats/inc/GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.h
@@ -1,0 +1,83 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef UQ_GAUSSIAN_LIKELIHOOD_BLOCK_DIAG_COV_RAND_COEFFS_H
+#define UQ_GAUSSIAN_LIKELIHOOD_BLOCK_DIAG_COV_RAND_COEFFS_H
+
+#include <queso/GslBlockMatrix.h>
+#include <queso/GaussianLikelihood.h>
+
+namespace QUESO {
+
+/*!
+ * \file GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.h
+ *
+ * \class GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients
+ * \brief A class representing a Gaussian likelihood with block-diagonal covariance matrix
+ */
+
+template<class V, class M>
+class GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients : public BaseGaussianLikelihood<V, M> {
+public:
+  //! @name Constructor/Destructor methods.
+  //@{
+  //! Default constructor.
+  /*!
+   * Instantiates a Gaussian likelihood function, given a prefix, its domain, a
+   * vector of observations and a block diagonal covariance matrix.
+   * The diagonal covariance matrix is of type \c GslBlockMatrix.  Each block
+   * in the block diagonal matrix is an object of type \c GslMatrix.
+   */
+  GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients(const char * prefix,
+      const VectorSet<V, M> & domainSet, const V & observations,
+      const GslBlockMatrix & covariance);
+
+  //! Destructor
+  virtual ~GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients();
+  //@}
+
+  //! Actual value of the scalar function.
+  virtual double actualValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const;
+
+  //! Logarithm of the value of the scalar function.
+  /*!
+   * The last \c n elements of \c domainVector, where \c n is the number of
+   * blocks in the block diagonal covariance matrix, are treated as
+   * hyperparameters and will be sample in a statistical inversion.
+   *
+   * The user need not concern themselves with handling these in the model
+   * evaluation routine, since they are handled by the likelihood evaluation
+   * routine.
+   */
+  virtual double lnValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const;
+
+private:
+  const GslBlockMatrix & m_covariance;
+};
+
+}  // End namespace QUESO
+
+#endif  // UQ_GAUSSIAN_LIKELIHOOD_BLOCK_DIAG_COV_RAND_COEFFS_H

--- a/src/stats/src/GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.C
+++ b/src/stats/src/GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.C
@@ -1,0 +1,113 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/VectorSet.h>
+#include <queso/GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.h>
+
+namespace QUESO {
+
+template<class V, class M>
+GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients<V, M>::GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients(
+    const char * prefix, const VectorSet<V, M> & domainSet,
+    const V & observations, const GslBlockMatrix & covariance)
+  : BaseGaussianLikelihood<V, M>(prefix, domainSet, observations),
+    m_covariance(covariance)
+{
+  unsigned int totalDim = 0;
+
+  for (unsigned int i = 0; i < this->m_covariance.numBlocks(); i++) {
+    totalDim += this->m_covariance.getBlock(i).numRowsLocal();
+  }
+
+  if (totalDim != observations.sizeLocal()) {
+    queso_error_msg("Covariance matrix not same dimension as observation vector");
+  }
+}
+
+template<class V, class M>
+GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients<V, M>::~GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients()
+{
+}
+
+template<class V, class M>
+double
+GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients<V, M>::actualValue(
+    const V & domainVector, const V * domainDirection, V * gradVector,
+    M * hessianMatrix, V * hessianEffect) const
+{
+  return std::exp(this->lnValue(domainVector, domainDirection, gradVector,
+        hessianMatrix, hessianEffect));
+}
+
+template<class V, class M>
+double
+GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients<V, M>::lnValue(
+    const V & domainVector, const V * domainDirection, V * gradVector,
+    M * hessianMatrix, V * hessianEffect) const
+{
+  V modelOutput(this->m_observations, 0, 0);  // At least it's not a copy
+  V weightedMisfit(this->m_observations, 0, 0);  // At least it's not a copy
+
+  this->evaluateModel(domainVector, domainDirection, modelOutput, gradVector,
+      hessianMatrix, hessianEffect);
+
+  // Compute misfit G(x) - y
+  modelOutput -= this->m_observations;
+
+  // Solve \Sigma u = G(x) - y for u
+  this->m_covariance.invertMultiply(modelOutput, weightedMisfit);
+
+  // Deal with the multiplicative coefficients for each of the blocks
+  unsigned int numBlocks = this->m_covariance.numBlocks();
+  unsigned int offset = 0;
+
+  // For each block...
+  for (unsigned int i = 0; i < this->m_covariance.numBlocks(); i++) {
+
+    // ...find the right hyperparameter
+    unsigned int index = domainVector.sizeLocal() + (i - numBlocks);
+    double coefficient = domainVector[index];
+
+    // ...divide the appropriate parts of the solution by the coefficient
+    unsigned int blockDim = this->m_covariance.getBlock(i).numRowsLocal();
+    for (unsigned int j = 0; j < blockDim; j++) {
+      // 'coefficient' is a variance, so we divide by it
+      modelOutput[offset+j] /= coefficient;
+    }
+    offset += blockDim;
+  }
+
+  // Compute (G(x) - y)^T \Sigma^{-1} (G(x) - y)
+  modelOutput *= weightedMisfit;
+
+  double norm2_squared = modelOutput.sumOfComponents();  // This is square of 2-norm
+
+  return -0.5 * norm2_squared;
+}
+
+}  // End namespace QUESO
+
+template class QUESO::GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients<QUESO::GslVector, QUESO::GslMatrix>;

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -40,6 +40,7 @@ check_PROGRAMS += test_diagonalCovariance
 check_PROGRAMS += test_fullCovariance
 check_PROGRAMS += test_blockDiagonalCovariance
 check_PROGRAMS += test_GslBlockMatrixInvertMultiply
+check_PROGRAMS += test_blockDiagonalCovarianceRandomCoefficients
 
 LDADD       = $(top_builddir)/src/libqueso.la
 
@@ -105,6 +106,7 @@ test_diagonalCovariance_SOURCES = test_gaussian_likelihoods/test_diagonalCovaria
 test_fullCovariance_SOURCES = test_gaussian_likelihoods/test_fullCovariance.C
 test_blockDiagonalCovariance_SOURCES = test_gaussian_likelihoods/test_blockDiagonalCovariance.C
 test_GslBlockMatrixInvertMultiply_SOURCES = test_GslBlockMatrix/test_GslBlockMatrixInvertMultiply.C
+test_blockDiagonalCovarianceRandomCoefficients_SOURCES = test_gaussian_likelihoods/test_blockDiagonalCovarianceRandomCoefficients.C
 
 # Files to freedom stamp
 srcstamp =
@@ -142,6 +144,7 @@ srcstamp += $(test_diagonalCovariance_SOURCES)
 srcstamp += $(test_fullCovariance_SOURCES)
 srcstamp += $(test_blockDiagonalCovariance_SOURCES)
 srcstamp += $(test_GslBlockMatrixInvertMultiply_SOURCES)
+srcstamp += $(test_blockDiagonalCovarianceRandomCoefficients_SOURCES)
 
 TESTS =
 TESTS += $(top_builddir)/test/test_uqEnvironmentCopy
@@ -179,6 +182,7 @@ TESTS += $(top_builddir)/test/test_diagonalCovariance
 TESTS += $(top_builddir)/test/test_fullCovariance
 TESTS += $(top_builddir)/test/test_blockDiagonalCovariance
 TESTS += $(top_builddir)/test/test_GslBlockMatrixInvertMultiply
+TESTS += $(top_builddir)/test/test_blockDiagonalCovarianceRandomCoefficients
 
 XFAIL_TESTS = $(top_builddir)/test/test_SequenceOfVectorsErase
 

--- a/test/test_gaussian_likelihoods/test_blockDiagonalCovarianceRandomCoefficients.C
+++ b/test/test_gaussian_likelihoods/test_blockDiagonalCovarianceRandomCoefficients.C
@@ -1,0 +1,145 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/GslBlockMatrix.h>
+#include <queso/VectorSet.h>
+#include <queso/BoxSubset.h>
+#include <queso/GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.h>
+
+#define TOL 1e-8
+
+template<class V, class M>
+class Likelihood : public QUESO::GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients<V, M>
+{
+public:
+
+  Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domain,
+      const V & observations, const QUESO::GslBlockMatrix & covariance)
+    : QUESO::GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients<V, M>(prefix, domain,
+        observations, covariance)
+  {
+  }
+
+  virtual ~Likelihood()
+  {
+  }
+
+  virtual void evaluateModel(const V & domainVector, const V * domainDirection,
+      V & modelOutput, V * gradVector, M * hessianMatrix,
+      V * hessianEffect) const
+  {
+    // Evaluate model and fill up the m_modelOutput member variable
+    for (unsigned int i = 0; i < modelOutput.sizeLocal(); i++) {
+      modelOutput[i] = domainVector[0] + 3.0;
+    }
+  }
+};
+
+int main(int argc, char ** argv) {
+  MPI_Init(&argc, &argv);
+
+  QUESO::FullEnvironment env(MPI_COMM_WORLD, "test_gaussian_likelihoods/queso_input.txt", "", NULL);
+
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
+      "param_", 3, NULL);
+
+  double min_val = 0.0;
+  double max_val = INFINITY;
+
+  QUESO::GslVector paramMins(paramSpace.zeroVector());
+  QUESO::GslVector paramMaxs(paramSpace.zeroVector());
+
+  // Hyperparameter bounds
+  paramMins.cwSet(min_val);
+  paramMaxs.cwSet(max_val);
+
+  // Model parameter bounds
+  paramMaxs[0] = 1.0;
+
+  QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix> paramDomain("param_",
+      paramSpace, paramMins, paramMaxs);
+
+  // Set up observation space
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> obsSpace(env,
+      "obs_", 3, NULL);
+
+  // Fill up observation vector
+  QUESO::GslVector observations(obsSpace.zeroVector());
+  observations[0] = 1.0;
+  observations[1] = 1.0;
+  observations[2] = 1.0;
+
+  // Set up block sizes for observation covariance matrix
+  std::vector<unsigned int> blockSizes(2);
+  blockSizes[0] = 1;  // First block is 1x1 (scalar)
+  blockSizes[1] = 2;  // Second block is 2x2
+
+  // Set up block (identity) matrix with specified block sizes
+  QUESO::GslBlockMatrix covariance(blockSizes, observations, 1.0);
+
+  covariance.getBlock(0)(0, 0) = 1.0;
+  covariance.getBlock(1)(0, 0) = 1.0;
+  covariance.getBlock(1)(0, 1) = 2.0;
+  covariance.getBlock(1)(1, 0) = 2.0;
+  covariance.getBlock(1)(1, 1) = 8.0;
+
+  // Pass in observations to Gaussian likelihood object
+  Likelihood<QUESO::GslVector, QUESO::GslMatrix> lhood("llhd_", paramDomain,
+      observations, covariance);
+
+  double lhood_value;
+  double truth_value;
+  QUESO::GslVector point(paramSpace.zeroVector());
+  point[0] = 0.0;
+  point[1] = 4.0;
+  point[2] = 2.0;
+  lhood_value = lhood.actualValue(point, NULL, NULL, NULL, NULL);
+  truth_value = std::exp(-1.75);
+
+  if (std::abs(lhood_value - truth_value) > TOL) {
+    std::cerr << "Random coefficient Gaussian test case failure." << std::endl;
+    std::cerr << "Computed likelihood value is: " << lhood_value << std::endl;
+    std::cerr << "Likelihood value should be: " << truth_value << std::endl;
+    queso_error();
+  }
+
+  point[0] = -2.0;
+  point[1] = 1.0;
+  point[2] = 1.0;
+  lhood_value = lhood.actualValue(point, NULL, NULL, NULL, NULL);
+  truth_value = 1.0;
+
+  if (std::abs(lhood_value - truth_value) > TOL) {
+    std::cerr << "Random coefficient Gaussian test case failure." << std::endl;
+    std::cerr << "Computed likelihood value is: " << lhood_value << std::endl;
+    std::cerr << "Likelihood value should be: " << truth_value << std::endl;
+    queso_error();
+  }
+
+  MPI_Finalize();
+
+  return 0;
+}


### PR DESCRIPTION
This PR implements the natural extension of #321.

The user must specify the appropriate dimension for the vector space to include the hyperparameters, but the user needn't concern themselves with these hyperparameters in the model evaluation method since they are handled directly in the likelihood evaluation.

This PR also includes a test for the multiplicative coefficients and includes example code.