### PR TITLE
Add multiplicative coefficients to canned Gaussian likelihood with block diagonal covariance matrix

### DIFF
--- a/src/stats/inc/GaussianLikelihoodBlockDiagonalCovariance.h
+++ b/src/stats/inc/GaussianLikelihoodBlockDiagonalCovariance.h
@@ -25,6 +25,7 @@
 #ifndef UQ_GAUSSIAN_LIKELIHOOD_BLOCK_DIAG_COV_H
 #define UQ_GAUSSIAN_LIKELIHOOD_BLOCK_DIAG_COV_H
 
+#include <vector>
 #include <queso/GslBlockMatrix.h>
 #include <queso/GaussianLikelihood.h>
 
@@ -48,6 +49,9 @@ public:
    * vector of observations and a block diagonal covariance matrix.
    * The diagonal covariance matrix is of type \c GslBlockMatrix.  Each block
    * in the block diagonal matrix is an object of type \c GslMatrix.
+   *
+   * Furthermore, each block comes with a multiplicative coefficient which
+   * defaults to 1.0.
    */
   GaussianLikelihoodBlockDiagonalCovariance(const char * prefix,
       const VectorSet<V, M> & domainSet, const V & observations,
@@ -56,6 +60,12 @@ public:
   //! Destructor
   virtual ~GaussianLikelihoodBlockDiagonalCovariance();
   //@}
+
+  //! Get (non-const) multiplicative coefficient for block \c i
+  double & blockCoefficient(unsigned int i);
+
+  //! Get (const) multiplicative coefficient for block \c i
+  const double & getBlockCoefficient(unsigned int i) const;
 
   //! Actual value of the scalar function.
   virtual double actualValue(const V & domainVector, const V * domainDirection,
@@ -66,6 +76,7 @@ public:
       V * gradVector, M * hessianMatrix, V * hessianEffect) const;
 
 private:
+  std::vector<double> m_covarianceCoefficients;
   const GslBlockMatrix & m_covariance;
 };
 

--- a/src/stats/src/GaussianLikelihoodBlockDiagonalCovariance.C
+++ b/src/stats/src/GaussianLikelihoodBlockDiagonalCovariance.C
@@ -34,6 +34,7 @@ GaussianLikelihoodBlockDiagonalCovariance<V, M>::GaussianLikelihoodBlockDiagonal
     const char * prefix, const VectorSet<V, M> & domainSet,
     const V & observations, const GslBlockMatrix & covariance)
   : BaseGaussianLikelihood<V, M>(prefix, domainSet, observations),
+    m_covarianceCoefficients(covariance.numBlocks(), 1.0),
     m_covariance(covariance)
 {
   unsigned int totalDim = 0;
@@ -50,6 +51,22 @@ GaussianLikelihoodBlockDiagonalCovariance<V, M>::GaussianLikelihoodBlockDiagonal
 template<class V, class M>
 GaussianLikelihoodBlockDiagonalCovariance<V, M>::~GaussianLikelihoodBlockDiagonalCovariance()
 {
+}
+
+template<class V, class M>
+double &
+GaussianLikelihoodBlockDiagonalCovariance<V, M>::blockCoefficient(
+    unsigned int i)
+{
+  return this->m_covarianceCoefficients[i];
+}
+
+template<class V, class M>
+const double &
+GaussianLikelihoodBlockDiagonalCovariance<V, M>::getBlockCoefficient(
+    unsigned int i) const
+{
+  return this->m_covarianceCoefficients[i];
 }
 
 template<class V, class M>
@@ -79,6 +96,20 @@ GaussianLikelihoodBlockDiagonalCovariance<V, M>::lnValue(
 
   // Solve \Sigma u = G(x) - y for u
   this->m_covariance.invertMultiply(modelOutput, weightedMisfit);
+
+  // Deal with the multiplicative coefficients for each of the blocks
+  unsigned int offset = 0;
+
+  // For each block...
+  for (unsigned int i = 0; i < this->m_covariance.numBlocks(); i++) {
+    // ...divide the appropriate parts of the solution by the coefficient
+    unsigned int blockDim = this->m_covariance.getBlock(i).numRowsLocal();
+    for (unsigned int j = 0; j < blockDim; j++) {
+      // coefficient is a variance, so we divide by it
+      modelOutput[offset+j] /= this->m_covarianceCoefficients[i];
+    }
+    offset += blockDim;
+  }
 
   // Compute (G(x) - y)^T \Sigma^{-1} (G(x) - y)
   modelOutput *= weightedMisfit;

--- a/test/test_gaussian_likelihoods/test_blockDiagonalCovariance.C
+++ b/test/test_gaussian_likelihoods/test_blockDiagonalCovariance.C
@@ -105,26 +105,32 @@ int main(int argc, char ** argv) {
   Likelihood<QUESO::GslVector, QUESO::GslMatrix> lhood("llhd_", paramDomain,
       observations, covariance);
 
+  lhood.blockCoefficient(0) = 4.0;
+  lhood.blockCoefficient(1) = 2.0;
+
   double lhood_value;
   double truth_value;
   QUESO::GslVector point(paramSpace.zeroVector());
   point[0] = 0.0;
   lhood_value = lhood.actualValue(point, NULL, NULL, NULL, NULL);
-  truth_value = std::exp(-4.5);
+  truth_value = std::exp(-1.75);
 
   if (std::abs(lhood_value - truth_value) > TOL) {
-    std::cerr << "Scalar Gaussian test case failure." << std::endl;
+    std::cerr << "Block diagonal Gaussian test case failure." << std::endl;
     std::cerr << "Computed likelihood value is: " << lhood_value << std::endl;
     std::cerr << "Likelihood value should be: " << truth_value << std::endl;
     queso_error();
   }
+
+  lhood.blockCoefficient(0) = 1.0;
+  lhood.blockCoefficient(1) = 1.0;
 
   point[0] = -2.0;
   lhood_value = lhood.actualValue(point, NULL, NULL, NULL, NULL);
   truth_value = 1.0;
 
   if (std::abs(lhood_value - truth_value) > TOL) {
-    std::cerr << "Scalar Gaussian test case failure." << std::endl;
+    std::cerr << "Block diagonal Gaussian test case failure." << std::endl;
     std::cerr << "Computed likelihood value is: " << lhood_value << std::endl;
     std::cerr << "Likelihood value should be: " << truth_value << std::endl;
     queso_error();


### PR DESCRIPTION
This PR adds multiplicative coefficients for each block in the block diagonal covariance matrix for the canned Gaussian likelihood.  The default value for the coefficients is 1.0.

The test has been updated to use the coefficients, and `make check` passes.