### PR TITLE
Add explicit cast with template parameters for GPMSA.

### DIFF
--- a/src/gp/src/GPMSA.C
+++ b/src/gp/src/GPMSA.C
@@ -266,7 +266,7 @@ GPMSAFactory<V, M>::GPMSAFactory(
     m_experimentOutputs(numExperiments, (V *)NULL),
     m_numSimulationAdds(0),
     m_numExperimentAdds(0),
-    priors(7, NULL)
+    priors(7, (const BaseVectorRV<V, M> *)NULL)
 {
   // DM: Not sure if the logic in these 3 if-blocks is correct
   if ((opts == NULL) && (this->m_env.optionsInputFileName() == "")) {


### PR DESCRIPTION
This resolves ambiguity that gave gcc-4.3.2 trouble.

Comes from Dakota upstream: https://software.sandia.gov/trac/tpl/changeset/2747
