### PR TITLE
Test canned likelihoods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,3 +183,5 @@ test/test_VectorRV_gsl
 test/test_VectorRealizer_gsl
 test/test_fullCovarianceRandomCoefficient
 test/test_blockDiagonalCovarianceRandomCoefficients
+test/test_gaussian_likelihoods/gaussian_consistency_input.txt
+test/test_fullCovarianceChain

--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,4 @@ test/test_blockDiagonalCovarianceRandomCoefficients
 test/test_gaussian_likelihoods/gaussian_consistency_input.txt
 test/test_fullCovarianceChain
 test/test_diagonalCovarianceChain
+test/test_scalarCovarianceChain

--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,4 @@ test/test_gaussian_likelihoods/gaussian_consistency_input.txt
 test/test_fullCovarianceChain
 test/test_diagonalCovarianceChain
 test/test_scalarCovarianceChain
+test/test_blockDiagonalCovarianceChain

--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,4 @@ test/test_fullCovarianceRandomCoefficient
 test/test_blockDiagonalCovarianceRandomCoefficients
 test/test_gaussian_likelihoods/gaussian_consistency_input.txt
 test/test_fullCovarianceChain
+test/test_diagonalCovarianceChain

--- a/configure.ac
+++ b/configure.ac
@@ -212,6 +212,7 @@ AC_CONFIG_FILES([
   doxygen/Makefile
   doxygen/queso.dox
   doxygen/txt_common/about_vpath.page
+  test/test_gaussian_likelihoods/gaussian_consistency_input.txt
 ])
 
 AC_CONFIG_FILES([test/test_Regression/test_cobra_samples_diff.sh

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -47,6 +47,7 @@ check_PROGRAMS += test_unifiedPositionsOfMaximum
 check_PROGRAMS += test_fullCovarianceRandomCoefficient
 check_PROGRAMS += test_blockDiagonalCovarianceRandomCoefficients
 check_PROGRAMS += test_fullCovarianceChain
+check_PROGRAMS += test_diagonalCovarianceChain
 
 LDADD       = $(top_builddir)/src/libqueso.la
 
@@ -119,6 +120,7 @@ test_unifiedPositionsOfMaximum_SOURCES = test_SequenceOfVectors/test_unifiedPosi
 test_fullCovarianceRandomCoefficient_SOURCES = test_gaussian_likelihoods/test_fullCovarianceRandomCoefficient.C
 test_blockDiagonalCovarianceRandomCoefficients_SOURCES = test_gaussian_likelihoods/test_blockDiagonalCovarianceRandomCoefficients.C
 test_fullCovarianceChain_SOURCES = test_gaussian_likelihoods/test_fullCovarianceChain.C
+test_diagonalCovarianceChain_SOURCES = test_gaussian_likelihoods/test_diagonalCovarianceChain.C
 
 # Files to freedom stamp
 srcstamp =
@@ -206,6 +208,7 @@ TESTS += $(top_builddir)/test/test_SequenceOfVectors/test_unifiedPositionsOfMaxi
 TESTS += $(top_builddir)/test/test_fullCovarianceRandomCoefficient
 TESTS += $(top_builddir)/test/test_blockDiagonalCovarianceRandomCoefficients
 TESTS += $(top_builddir)/test/test_fullCovarianceChain
+TESTS += $(top_builddir)/test/test_diagonalCovarianceChain
 
 XFAIL_TESTS = $(top_builddir)/test/test_SequenceOfVectorsErase
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -48,6 +48,7 @@ check_PROGRAMS += test_fullCovarianceRandomCoefficient
 check_PROGRAMS += test_blockDiagonalCovarianceRandomCoefficients
 check_PROGRAMS += test_fullCovarianceChain
 check_PROGRAMS += test_diagonalCovarianceChain
+check_PROGRAMS += test_scalarCovarianceChain
 
 LDADD       = $(top_builddir)/src/libqueso.la
 
@@ -121,6 +122,7 @@ test_fullCovarianceRandomCoefficient_SOURCES = test_gaussian_likelihoods/test_fu
 test_blockDiagonalCovarianceRandomCoefficients_SOURCES = test_gaussian_likelihoods/test_blockDiagonalCovarianceRandomCoefficients.C
 test_fullCovarianceChain_SOURCES = test_gaussian_likelihoods/test_fullCovarianceChain.C
 test_diagonalCovarianceChain_SOURCES = test_gaussian_likelihoods/test_diagonalCovarianceChain.C
+test_scalarCovarianceChain_SOURCES = test_gaussian_likelihoods/test_scalarCovarianceChain.C
 
 # Files to freedom stamp
 srcstamp =
@@ -209,6 +211,7 @@ TESTS += $(top_builddir)/test/test_fullCovarianceRandomCoefficient
 TESTS += $(top_builddir)/test/test_blockDiagonalCovarianceRandomCoefficients
 TESTS += $(top_builddir)/test/test_fullCovarianceChain
 TESTS += $(top_builddir)/test/test_diagonalCovarianceChain
+TESTS += $(top_builddir)/test/test_scalarCovarianceChain
 
 XFAIL_TESTS = $(top_builddir)/test/test_SequenceOfVectorsErase
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -49,6 +49,7 @@ check_PROGRAMS += test_blockDiagonalCovarianceRandomCoefficients
 check_PROGRAMS += test_fullCovarianceChain
 check_PROGRAMS += test_diagonalCovarianceChain
 check_PROGRAMS += test_scalarCovarianceChain
+check_PROGRAMS += test_blockDiagonalCovarianceChain
 
 LDADD       = $(top_builddir)/src/libqueso.la
 
@@ -123,6 +124,7 @@ test_blockDiagonalCovarianceRandomCoefficients_SOURCES = test_gaussian_likelihoo
 test_fullCovarianceChain_SOURCES = test_gaussian_likelihoods/test_fullCovarianceChain.C
 test_diagonalCovarianceChain_SOURCES = test_gaussian_likelihoods/test_diagonalCovarianceChain.C
 test_scalarCovarianceChain_SOURCES = test_gaussian_likelihoods/test_scalarCovarianceChain.C
+test_blockDiagonalCovarianceChain_SOURCES = test_gaussian_likelihoods/test_blockDiagonalCovarianceChain.C
 
 # Files to freedom stamp
 srcstamp =
@@ -212,6 +214,7 @@ TESTS += $(top_builddir)/test/test_blockDiagonalCovarianceRandomCoefficients
 TESTS += $(top_builddir)/test/test_fullCovarianceChain
 TESTS += $(top_builddir)/test/test_diagonalCovarianceChain
 TESTS += $(top_builddir)/test/test_scalarCovarianceChain
+TESTS += $(top_builddir)/test/test_blockDiagonalCovarianceChain
 
 XFAIL_TESTS = $(top_builddir)/test/test_SequenceOfVectorsErase
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -46,6 +46,7 @@ check_PROGRAMS += test_GslBlockMatrixInvertMultiply
 check_PROGRAMS += test_unifiedPositionsOfMaximum
 check_PROGRAMS += test_fullCovarianceRandomCoefficient
 check_PROGRAMS += test_blockDiagonalCovarianceRandomCoefficients
+check_PROGRAMS += test_fullCovarianceChain
 
 LDADD       = $(top_builddir)/src/libqueso.la
 
@@ -117,6 +118,7 @@ test_GslBlockMatrixInvertMultiply_SOURCES = test_GslBlockMatrix/test_GslBlockMat
 test_unifiedPositionsOfMaximum_SOURCES = test_SequenceOfVectors/test_unifiedPositionsOfMaximum.C
 test_fullCovarianceRandomCoefficient_SOURCES = test_gaussian_likelihoods/test_fullCovarianceRandomCoefficient.C
 test_blockDiagonalCovarianceRandomCoefficients_SOURCES = test_gaussian_likelihoods/test_blockDiagonalCovarianceRandomCoefficients.C
+test_fullCovarianceChain_SOURCES = test_gaussian_likelihoods/test_fullCovarianceChain.C
 
 # Files to freedom stamp
 srcstamp =
@@ -203,6 +205,7 @@ TESTS += $(top_builddir)/test/test_GslBlockMatrixInvertMultiply
 TESTS += $(top_builddir)/test/test_SequenceOfVectors/test_unifiedPositionsOfMaximum.sh
 TESTS += $(top_builddir)/test/test_fullCovarianceRandomCoefficient
 TESTS += $(top_builddir)/test/test_blockDiagonalCovarianceRandomCoefficients
+TESTS += $(top_builddir)/test/test_fullCovarianceChain
 
 XFAIL_TESTS = $(top_builddir)/test/test_SequenceOfVectorsErase
 

--- a/test/test_gaussian_likelihoods/gaussian_consistency_input.txt.in
+++ b/test/test_gaussian_likelihoods/gaussian_consistency_input.txt.in
@@ -1,0 +1,50 @@
+###############################################
+# UQ Environment
+###############################################
+# env_help                 = 0
+env_numSubEnvironments   = 1
+env_subDisplayFileName   =
+env_subDisplayAllowAll   = 0
+env_subDisplayAllowedSet =
+env_displayVerbosity     = 0
+env_syncVerbosity        = 0
+env_seed                 = 0
+
+###############################################
+# Statistical inverse problem (ip)
+###############################################
+# ip_help                 = 0
+ip_computeSolution      = 1
+ip_dataOutputFileName   =
+ip_dataOutputAllowedSet =
+
+###############################################
+# 'ip_': information for Metropolis-Hastings algorithm
+###############################################
+# ip_mh_help                 = 0
+ip_mh_dataOutputFileName   =
+ip_mh_dataOutputAllowedSet =
+
+ip_mh_rawChain_dataInputFileName    = .
+ip_mh_rawChain_size                 = 1000
+ip_mh_rawChain_generateExtra        = 0
+ip_mh_rawChain_displayPeriod        = 2000
+ip_mh_rawChain_measureRunTimes      = 1
+ip_mh_rawChain_dataOutputFileName   =
+ip_mh_rawChain_dataOutputAllowedSet =
+ip_mh_rawChain_computeStats         = 1
+
+ip_mh_displayCandidates             = 0
+ip_mh_putOutOfBoundsInChain         = 0
+ip_mh_tk_useLocalHessian            = 0
+ip_mh_tk_useNewtonComponent         = 0
+ip_mh_dr_maxNumExtraStages          = 0
+ip_mh_dr_listOfScalesForExtraStages = 5. 10. 20.
+ip_mh_am_initialNonAdaptInterval    = 10
+ip_mh_am_adaptInterval              = 1
+ip_mh_am_eta                        = 0.384
+ip_mh_am_epsilon                    = 1.e-5
+ip_mh_filteredChain_generate        = 0
+ip_mh_outputLogLikelihood           = 0
+ip_mh_outputLogTarget               = 0
+ip_mh_totallyMute                   = 1

--- a/test/test_gaussian_likelihoods/test_blockDiagonalCovarianceChain.C
+++ b/test/test_gaussian_likelihoods/test_blockDiagonalCovarianceChain.C
@@ -1,0 +1,252 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/GslBlockMatrix.h>
+#include <queso/VectorSet.h>
+#include <queso/BoxSubset.h>
+#include <queso/UniformVectorRV.h>
+#include <queso/GenericVectorRV.h>
+#include <queso/ScalarFunction.h>
+#include <queso/GaussianLikelihoodBlockDiagonalCovariance.h>
+#include <queso/StatisticalInverseProblem.h>
+
+#define TOL 1e-15
+
+// A Gaussian likelihood
+template<class V, class M>
+class Likelihood : public QUESO::GaussianLikelihoodBlockDiagonalCovariance<V, M>
+{
+public:
+  Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domain,
+      const V & observations, const QUESO::GslBlockMatrix & covariance)
+    : QUESO::GaussianLikelihoodBlockDiagonalCovariance<V, M>(prefix, domain,
+        observations, covariance)
+  {
+  }
+
+  virtual ~Likelihood()
+  {
+  }
+
+  virtual void evaluateModel(const V & domainVector, const V * domainDirection,
+      V & modelOutput, V * gradVector, M * hessianMatrix,
+      V * hessianEffect) const
+  {
+    for (unsigned int i = 0; i < modelOutput.sizeLocal(); i++) {
+      modelOutput[i] = domainVector[i];
+    }
+  }
+};
+
+// A custom likelihood (that just so happens to also be Gaussian)
+template<class V, class M>
+class CustomLikelihood : public QUESO::BaseScalarFunction<V, M>
+{
+public:
+  CustomLikelihood(const char * prefix, const QUESO::VectorSet<V, M> & domain)
+    : QUESO::BaseScalarFunction<V, M>(prefix, domain)
+  {
+  }
+
+  virtual ~CustomLikelihood()
+  {
+  }
+
+  virtual double lnValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const
+  {
+    double d1 = domainVector[0] - 1.0;
+    double d2 = domainVector[1] - 1.0;
+    double d3 = domainVector[2] - 1.0;
+
+    // Sigma inverse multiplied by d
+    double r1 = 2.0 * d1 - 0.5 * d2;
+    double r2 = -0.5 * d1 + 0.25 * d2;
+    double r3 = 0.5 * d3;
+
+    r1 *= d1;
+    r2 *= d2;
+    r3 *= d3;
+
+    // The square of the 2-norm of the misfit
+    double misfit = r1 + r2 + r3;
+    misfit /= -2.0;
+    return misfit;
+  }
+
+  virtual double actualValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const
+  {
+    return this->lnValue(domainVector, domainDirection, gradVector, hessianMatrix, hessianEffect);
+  }
+};
+
+template<class V, class M>
+class BayesianInverseProblem
+{
+public:
+  BayesianInverseProblem(unsigned int likelihoodFlag)
+  {
+    this->env = new QUESO::FullEnvironment(MPI_COMM_WORLD,
+        "test_gaussian_likelihoods/gaussian_consistency_input.txt", "", NULL);
+
+    this->paramSpace =
+      new QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>(*env,
+          "param_", 3, NULL);
+
+    double min_val = -INFINITY;
+    double max_val = INFINITY;
+
+    this->paramMins = new QUESO::GslVector(this->paramSpace->zeroVector());
+    this->paramMins->cwSet(min_val);
+    this->paramMaxs = new QUESO::GslVector(this->paramSpace->zeroVector());
+    this->paramMaxs->cwSet(max_val);
+
+    this->paramDomain =
+      new QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix>("param_",
+          *(this->paramSpace), *(this->paramMins), *(this->paramMaxs));
+
+    this->priorRv =
+      new QUESO::UniformVectorRV<QUESO::GslVector, QUESO::GslMatrix>("prior_",
+          *(this->paramDomain));
+
+    // Set up observation space
+    this->obsSpace =
+      new QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>(*env, "obs_",
+          3, NULL);
+
+    // Fill up observation vector
+    this->observations = new QUESO::GslVector(this->obsSpace->zeroVector());
+    (*(this->observations))[0] = 1.0;
+    (*(this->observations))[1] = 1.0;
+    (*(this->observations))[2] = 1.0;
+
+    // Fill up covariance 'matrix'
+    std::vector<unsigned int> blockSizes(2);
+    blockSizes[0] = 2;  // First block is 2x2
+    blockSizes[1] = 1;  // Second block is 1x1 (scalar)
+
+    this->covariance = new QUESO::GslBlockMatrix(blockSizes,
+        this->obsSpace->zeroVector(), 1.0);
+    (this->covariance->getBlock(0))(0, 0) = 1.0;
+    (this->covariance->getBlock(0))(0, 1) = 2.0;
+    (this->covariance->getBlock(0))(1, 0) = 2.0;
+    (this->covariance->getBlock(0))(1, 1) = 8.0;
+    (this->covariance->getBlock(1))(0, 0) = 2.0;
+
+    // Construct whatever likelihood we need
+
+    if (likelihoodFlag == 1) {
+      // Do canned Gaussian likelihood
+      this->lhood = new Likelihood<QUESO::GslVector, QUESO::GslMatrix>("llhd_",
+          *(this->paramDomain), *(this->observations), *(this->covariance));
+    }
+    else if (likelihoodFlag == 2) {
+      // Do the other, custom, likelihood (which just so happens to be
+      // Gaussian)
+      this->lhood = new CustomLikelihood<QUESO::GslVector, QUESO::GslMatrix>(
+          "llhd_", *(this->paramDomain));
+    }
+    else {
+      // Wat
+      queso_error_msg("DIE!");
+    }
+
+    this->postRv =
+      new QUESO::GenericVectorRV<QUESO::GslVector, QUESO::GslMatrix>("post_",
+        *(this->paramSpace));
+
+    this->ip =
+      new QUESO::StatisticalInverseProblem<QUESO::GslVector, QUESO::GslMatrix>(
+          "", NULL, *(this->priorRv), *(this->lhood), *(this->postRv));
+
+    this->paramInitials = new QUESO::GslVector(this->paramSpace->zeroVector());
+    (*(this->paramInitials))[0] = 1.0;
+    (*(this->paramInitials))[1] = 1.0;
+
+    this->proposalCovMatrix = new QUESO::GslMatrix(
+        this->paramSpace->zeroVector());
+    (*(this->proposalCovMatrix))(0, 0) = 1.0;
+    (*(this->proposalCovMatrix))(0, 1) = 2.0;
+    (*(this->proposalCovMatrix))(0, 2) = 0.0;
+    (*(this->proposalCovMatrix))(1, 0) = 2.0;
+    (*(this->proposalCovMatrix))(1, 1) = 8.0;
+    (*(this->proposalCovMatrix))(1, 2) = 0.0;
+    (*(this->proposalCovMatrix))(2, 0) = 0.0;
+    (*(this->proposalCovMatrix))(2, 1) = 0.0;
+    (*(this->proposalCovMatrix))(2, 2) = 2.0;
+
+    this->ip->solveWithBayesMetropolisHastings(NULL, *(this->paramInitials),
+        this->proposalCovMatrix);
+
+    this->draw = new QUESO::GslVector(this->paramSpace->zeroVector());
+  }
+
+  virtual ~BayesianInverseProblem()
+  {
+  }
+
+  QUESO::FullEnvironment * env;
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> * paramSpace;
+  QUESO::GslVector * paramMins;
+  QUESO::GslVector * paramMaxs;
+  QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix> * paramDomain;
+  QUESO::UniformVectorRV<QUESO::GslVector, QUESO::GslMatrix> * priorRv;
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> * obsSpace;
+  QUESO::GslVector * observations;
+  QUESO::GslBlockMatrix * covariance;
+  QUESO::BaseScalarFunction<QUESO::GslVector, QUESO::GslMatrix> * lhood;
+  QUESO::StatisticalInverseProblem<QUESO::GslVector, QUESO::GslMatrix> * ip;
+  QUESO::GslVector * paramInitials;
+  QUESO::GslMatrix * proposalCovMatrix;
+  QUESO::GslVector * draw;
+  QUESO::GenericVectorRV<V, M> * postRv;
+};
+
+int main(int argc, char ** argv) {
+  MPI_Init(&argc, &argv);
+
+  // Instantiate each inverse problem
+  BayesianInverseProblem<QUESO::GslVector, QUESO::GslMatrix> b1(1);
+  BayesianInverseProblem<QUESO::GslVector, QUESO::GslMatrix> b2(2);
+
+  // Compare each draw
+  for (unsigned int i = 0; i < 1000; i++) {
+    b1.postRv->realizer().realization(*(b1.draw));
+    b2.postRv->realizer().realization(*(b2.draw));
+
+    // Test draws
+    QUESO::GslVector diff(*(b1.draw));
+    diff -= *(b2.draw);
+    if (diff.norm2() > TOL) {
+      queso_error_msg("test_fullCovarianceChain: Samples from the canned likelihood do not match samples from the equivalent custom likelihood");
+    }
+  }
+
+  MPI_Finalize();
+
+  return 0;
+}

--- a/test/test_gaussian_likelihoods/test_diagonalCovarianceChain.C
+++ b/test/test_gaussian_likelihoods/test_diagonalCovarianceChain.C
@@ -1,0 +1,234 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/VectorSet.h>
+#include <queso/BoxSubset.h>
+#include <queso/UniformVectorRV.h>
+#include <queso/GenericVectorRV.h>
+#include <queso/ScalarFunction.h>
+#include <queso/GaussianLikelihoodDiagonalCovariance.h>
+#include <queso/StatisticalInverseProblem.h>
+
+#define TOL 1e-15
+
+// A Gaussian likelihood
+template<class V, class M>
+class Likelihood : public QUESO::GaussianLikelihoodDiagonalCovariance<V, M>
+{
+public:
+  Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domain,
+      const V & observations, const V & covariance)
+    : QUESO::GaussianLikelihoodDiagonalCovariance<V, M>(prefix, domain,
+        observations, covariance)
+  {
+  }
+
+  virtual ~Likelihood()
+  {
+  }
+
+  virtual void evaluateModel(const V & domainVector, const V * domainDirection,
+      V & modelOutput, V * gradVector, M * hessianMatrix,
+      V * hessianEffect) const
+  {
+    for (unsigned int i = 0; i < modelOutput.sizeLocal(); i++) {
+      modelOutput[i] = domainVector[i];
+    }
+  }
+};
+
+// A custom likelihood (that just so happens to also be Gaussian)
+template<class V, class M>
+class CustomLikelihood : public QUESO::BaseScalarFunction<V, M>
+{
+public:
+  CustomLikelihood(const char * prefix, const QUESO::VectorSet<V, M> & domain)
+    : QUESO::BaseScalarFunction<V, M>(prefix, domain)
+  {
+  }
+
+  virtual ~CustomLikelihood()
+  {
+  }
+
+  virtual double lnValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const
+  {
+    double d1 = domainVector[0] - 1.0;
+    double d2 = domainVector[1] - 1.0;
+
+    // Sigma inverse multiplied by d
+    double r1 = 0.5 * d1;
+    double r2 = 0.125 * d2;
+
+    r1 *= d1;
+    r2 *= d2;
+
+    // The square of the 2-norm of the misfit
+    double misfit = r1 + r2;
+    misfit /= -2.0;
+    return misfit;
+  }
+
+  virtual double actualValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const
+  {
+    return this->lnValue(domainVector, domainDirection, gradVector, hessianMatrix, hessianEffect);
+  }
+};
+
+template<class V, class M>
+class BayesianInverseProblem
+{
+public:
+  BayesianInverseProblem(unsigned int likelihoodFlag)
+  {
+    this->env = new QUESO::FullEnvironment(MPI_COMM_WORLD,
+        "test_gaussian_likelihoods/gaussian_consistency_input.txt", "", NULL);
+
+    this->paramSpace =
+      new QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>(*env,
+          "param_", 2, NULL);
+
+    double min_val = -INFINITY;
+    double max_val = INFINITY;
+
+    this->paramMins = new QUESO::GslVector(this->paramSpace->zeroVector());
+    this->paramMins->cwSet(min_val);
+    this->paramMaxs = new QUESO::GslVector(this->paramSpace->zeroVector());
+    this->paramMaxs->cwSet(max_val);
+
+    this->paramDomain =
+      new QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix>("param_",
+          *(this->paramSpace), *(this->paramMins), *(this->paramMaxs));
+
+    this->priorRv =
+      new QUESO::UniformVectorRV<QUESO::GslVector, QUESO::GslMatrix>("prior_",
+          *(this->paramDomain));
+
+    // Set up observation space
+    this->obsSpace =
+      new QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>(*env, "obs_",
+          2, NULL);
+
+    // Fill up observation vector
+    this->observations = new QUESO::GslVector(this->obsSpace->zeroVector());
+    (*(this->observations))[0] = 1.0;
+    (*(this->observations))[1] = 1.0;
+
+    // Fill up covariance 'matrix'
+    this->covariance = new QUESO::GslVector(this->obsSpace->zeroVector());
+    (*(this->covariance))[0] = 2.0;
+    (*(this->covariance))[1] = 8.0;
+
+    // Construct whatever likelihood we need
+
+    if (likelihoodFlag == 1) {
+      // Do canned Gaussian likelihood
+      this->lhood = new Likelihood<QUESO::GslVector, QUESO::GslMatrix>("llhd_",
+          *(this->paramDomain), *(this->observations), *(this->covariance));
+    }
+    else if (likelihoodFlag == 2) {
+      // Do the other, custom, likelihood (which just so happens to be
+      // Gaussian)
+      this->lhood = new CustomLikelihood<QUESO::GslVector, QUESO::GslMatrix>(
+          "llhd_", *(this->paramDomain));
+    }
+    else {
+      // Wat
+      queso_error_msg("DIE!");
+    }
+
+    this->postRv =
+      new QUESO::GenericVectorRV<QUESO::GslVector, QUESO::GslMatrix>("post_",
+        *(this->paramSpace));
+
+    this->ip =
+      new QUESO::StatisticalInverseProblem<QUESO::GslVector, QUESO::GslMatrix>(
+          "", NULL, *(this->priorRv), *(this->lhood), *(this->postRv));
+
+    this->paramInitials = new QUESO::GslVector(this->paramSpace->zeroVector());
+    (*(this->paramInitials))[0] = 1.0;
+    (*(this->paramInitials))[1] = 1.0;
+
+    this->proposalCovMatrix = new QUESO::GslMatrix(
+        this->paramSpace->zeroVector());
+    (*(this->proposalCovMatrix))(0, 0) = 2.0;
+    (*(this->proposalCovMatrix))(0, 1) = 0.0;
+    (*(this->proposalCovMatrix))(1, 0) = 0.0;
+    (*(this->proposalCovMatrix))(1, 1) = 8.0;
+
+    this->ip->solveWithBayesMetropolisHastings(NULL, *(this->paramInitials),
+        this->proposalCovMatrix);
+
+    this->draw = new QUESO::GslVector(this->paramSpace->zeroVector());
+  }
+
+  virtual ~BayesianInverseProblem()
+  {
+  }
+
+  QUESO::FullEnvironment * env;
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> * paramSpace;
+  QUESO::GslVector * paramMins;
+  QUESO::GslVector * paramMaxs;
+  QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix> * paramDomain;
+  QUESO::UniformVectorRV<QUESO::GslVector, QUESO::GslMatrix> * priorRv;
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> * obsSpace;
+  QUESO::GslVector * observations;
+  QUESO::GslVector * covariance;
+  QUESO::BaseScalarFunction<QUESO::GslVector, QUESO::GslMatrix> * lhood;
+  QUESO::StatisticalInverseProblem<QUESO::GslVector, QUESO::GslMatrix> * ip;
+  QUESO::GslVector * paramInitials;
+  QUESO::GslMatrix * proposalCovMatrix;
+  QUESO::GslVector * draw;
+  QUESO::GenericVectorRV<V, M> * postRv;
+};
+
+int main(int argc, char ** argv) {
+  MPI_Init(&argc, &argv);
+
+  // Instantiate each inverse problem
+  BayesianInverseProblem<QUESO::GslVector, QUESO::GslMatrix> b1(1);
+  BayesianInverseProblem<QUESO::GslVector, QUESO::GslMatrix> b2(2);
+
+  // Compare each draw
+  for (unsigned int i = 0; i < 1000; i++) {
+    b1.postRv->realizer().realization(*(b1.draw));
+    b2.postRv->realizer().realization(*(b2.draw));
+
+    // Test draws
+    QUESO::GslVector diff(*(b1.draw));
+    diff -= *(b2.draw);
+    if (diff.norm2() > TOL) {
+      queso_error_msg("test_fullCovarianceChain: Samples from the canned likelihood do not match samples from the equivalent custom likelihood");
+    }
+  }
+
+  MPI_Finalize();
+
+  return 0;
+}

--- a/test/test_gaussian_likelihoods/test_scalarCovarianceChain.C
+++ b/test/test_gaussian_likelihoods/test_scalarCovarianceChain.C
@@ -1,0 +1,223 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/VectorSet.h>
+#include <queso/BoxSubset.h>
+#include <queso/UniformVectorRV.h>
+#include <queso/GenericVectorRV.h>
+#include <queso/ScalarFunction.h>
+#include <queso/GaussianLikelihoodScalarCovariance.h>
+#include <queso/StatisticalInverseProblem.h>
+
+#define TOL 1e-15
+
+// A Gaussian likelihood
+template<class V, class M>
+class Likelihood : public QUESO::GaussianLikelihoodScalarCovariance<V, M>
+{
+public:
+  Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domain,
+      const V & observations, double covariance)
+    : QUESO::GaussianLikelihoodScalarCovariance<V, M>(prefix, domain,
+        observations, covariance)
+  {
+  }
+
+  virtual ~Likelihood()
+  {
+  }
+
+  virtual void evaluateModel(const V & domainVector, const V * domainDirection,
+      V & modelOutput, V * gradVector, M * hessianMatrix,
+      V * hessianEffect) const
+  {
+    for (unsigned int i = 0; i < modelOutput.sizeLocal(); i++) {
+      modelOutput[i] = domainVector[i];
+    }
+  }
+};
+
+// A custom likelihood (that just so happens to also be Gaussian)
+template<class V, class M>
+class CustomLikelihood : public QUESO::BaseScalarFunction<V, M>
+{
+public:
+  CustomLikelihood(const char * prefix, const QUESO::VectorSet<V, M> & domain)
+    : QUESO::BaseScalarFunction<V, M>(prefix, domain)
+  {
+  }
+
+  virtual ~CustomLikelihood()
+  {
+  }
+
+  virtual double lnValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const
+  {
+    double d1 = domainVector[0] - 1.0;
+
+    // Sigma inverse multiplied by d
+    double r1 = 0.5 * d1;
+
+    r1 *= d1;
+
+    // The square of the 2-norm of the misfit
+    double misfit = -r1 / 2.0;
+    return misfit;
+  }
+
+  virtual double actualValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const
+  {
+    return this->lnValue(domainVector, domainDirection, gradVector, hessianMatrix, hessianEffect);
+  }
+};
+
+template<class V, class M>
+class BayesianInverseProblem
+{
+public:
+  BayesianInverseProblem(unsigned int likelihoodFlag)
+  {
+    this->env = new QUESO::FullEnvironment(MPI_COMM_WORLD,
+        "test_gaussian_likelihoods/gaussian_consistency_input.txt", "", NULL);
+
+    this->paramSpace =
+      new QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>(*env,
+          "param_", 1, NULL);
+
+    double min_val = -INFINITY;
+    double max_val = INFINITY;
+
+    this->paramMins = new QUESO::GslVector(this->paramSpace->zeroVector());
+    this->paramMins->cwSet(min_val);
+    this->paramMaxs = new QUESO::GslVector(this->paramSpace->zeroVector());
+    this->paramMaxs->cwSet(max_val);
+
+    this->paramDomain =
+      new QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix>("param_",
+          *(this->paramSpace), *(this->paramMins), *(this->paramMaxs));
+
+    this->priorRv =
+      new QUESO::UniformVectorRV<QUESO::GslVector, QUESO::GslMatrix>("prior_",
+          *(this->paramDomain));
+
+    // Set up observation space
+    this->obsSpace =
+      new QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>(*env, "obs_",
+          1, NULL);
+
+    // Fill up observation vector
+    this->observations = new QUESO::GslVector(this->obsSpace->zeroVector());
+    (*(this->observations))[0] = 1.0;
+
+    // Fill up covariance 'matrix'
+    this->covariance = 2.0;
+
+    // Construct whatever likelihood we need
+
+    if (likelihoodFlag == 1) {
+      // Do canned Gaussian likelihood
+      this->lhood = new Likelihood<QUESO::GslVector, QUESO::GslMatrix>("llhd_",
+          *(this->paramDomain), *(this->observations), this->covariance);
+    }
+    else if (likelihoodFlag == 2) {
+      // Do the other, custom, likelihood (which just so happens to be
+      // Gaussian)
+      this->lhood = new CustomLikelihood<QUESO::GslVector, QUESO::GslMatrix>(
+          "llhd_", *(this->paramDomain));
+    }
+    else {
+      // Wat
+      queso_error_msg("DIE!");
+    }
+
+    this->postRv =
+      new QUESO::GenericVectorRV<QUESO::GslVector, QUESO::GslMatrix>("post_",
+        *(this->paramSpace));
+
+    this->ip =
+      new QUESO::StatisticalInverseProblem<QUESO::GslVector, QUESO::GslMatrix>(
+          "", NULL, *(this->priorRv), *(this->lhood), *(this->postRv));
+
+    this->paramInitials = new QUESO::GslVector(this->paramSpace->zeroVector());
+    (*(this->paramInitials))[0] = 1.0;
+
+    this->proposalCovMatrix = new QUESO::GslMatrix(
+        this->paramSpace->zeroVector());
+    (*(this->proposalCovMatrix))(0, 0) = 2.0;
+
+    this->ip->solveWithBayesMetropolisHastings(NULL, *(this->paramInitials),
+        this->proposalCovMatrix);
+
+    this->draw = new QUESO::GslVector(this->paramSpace->zeroVector());
+  }
+
+  virtual ~BayesianInverseProblem()
+  {
+  }
+
+  QUESO::FullEnvironment * env;
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> * paramSpace;
+  QUESO::GslVector * paramMins;
+  QUESO::GslVector * paramMaxs;
+  QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix> * paramDomain;
+  QUESO::UniformVectorRV<QUESO::GslVector, QUESO::GslMatrix> * priorRv;
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> * obsSpace;
+  QUESO::GslVector * observations;
+  double covariance;
+  QUESO::BaseScalarFunction<QUESO::GslVector, QUESO::GslMatrix> * lhood;
+  QUESO::StatisticalInverseProblem<QUESO::GslVector, QUESO::GslMatrix> * ip;
+  QUESO::GslVector * paramInitials;
+  QUESO::GslMatrix * proposalCovMatrix;
+  QUESO::GslVector * draw;
+  QUESO::GenericVectorRV<V, M> * postRv;
+};
+
+int main(int argc, char ** argv) {
+  MPI_Init(&argc, &argv);
+
+  // Instantiate each inverse problem
+  BayesianInverseProblem<QUESO::GslVector, QUESO::GslMatrix> b1(1);
+  BayesianInverseProblem<QUESO::GslVector, QUESO::GslMatrix> b2(2);
+
+  // Compare each draw
+  for (unsigned int i = 0; i < 1000; i++) {
+    b1.postRv->realizer().realization(*(b1.draw));
+    b2.postRv->realizer().realization(*(b2.draw));
+
+    // Test draws
+    QUESO::GslVector diff(*(b1.draw));
+    diff -= *(b2.draw);
+    if (diff.norm2() > TOL) {
+      queso_error_msg("test_fullCovarianceChain: Samples from the canned likelihood do not match samples from the equivalent custom likelihood");
+    }
+  }
+
+  MPI_Finalize();
+
+  return 0;
+}


### PR DESCRIPTION
In addition to the tests I've already implemented for the canned likelihood classes, I wanted to implement some extra tests that did a sanity check on the chain output against the same posterior without using the canned likelihood class.

This should be good to merge once Travis is happy.