### PR TITLE
Implement default template parameters

### DIFF
--- a/examples/gravity/src/gravity_compute.C
+++ b/examples/gravity/src/gravity_compute.C
@@ -88,8 +88,7 @@ void computeGravityAndTraveledDistance(const QUESO::FullEnvironment& env) {
   //------------------------------------------------------
   // SIP Step 1 of 6: Instantiate the parameter space
   //------------------------------------------------------
-  QUESO::VectorSpace<QUESO::GslVector,QUESO::GslMatrix> paramSpace(env,
-      "param_", 1, NULL);
+  QUESO::VectorSpace<> paramSpace(env, "param_", 1, NULL);
 
   //------------------------------------------------------
   // SIP Step 2 of 6: Instantiate the parameter domain
@@ -100,34 +99,28 @@ void computeGravityAndTraveledDistance(const QUESO::FullEnvironment& env) {
   paramMinValues[0] = 8.;
   paramMaxValues[0] = 11.;
 
-  QUESO::BoxSubset<QUESO::GslVector,QUESO::GslMatrix> paramDomain("param_",
-      paramSpace, paramMinValues, paramMaxValues);
+  QUESO::BoxSubset<> paramDomain("param_", paramSpace, paramMinValues,
+      paramMaxValues);
 
   //------------------------------------------------------
   // SIP Step 3 of 6: Instantiate the likelihood function
   // object to be used by QUESO.
   //------------------------------------------------------
-  Likelihood<QUESO::GslVector, QUESO::GslMatrix> lhood("like_", paramDomain);
+  Likelihood<> lhood("like_", paramDomain);
 
   //------------------------------------------------------
   // SIP Step 4 of 6: Define the prior RV
   //------------------------------------------------------
-  QUESO::UniformVectorRV<QUESO::GslVector,QUESO::GslMatrix> priorRv("prior_",
-      paramDomain);
+  QUESO::UniformVectorRV<> priorRv("prior_", paramDomain);
 
   //------------------------------------------------------
   // SIP Step 5 of 6: Instantiate the inverse problem
   //------------------------------------------------------
-  QUESO::GenericVectorRV<QUESO::GslVector,QUESO::GslMatrix>
-    postRv("post_",  // Extra prefix before the default "rv_" prefix
-           paramSpace);
+  // Extra prefix before the default "rv_" prefix
+  QUESO::GenericVectorRV<> postRv("post_", paramSpace);
 
-  QUESO::StatisticalInverseProblem<QUESO::GslVector,QUESO::GslMatrix>
-    ip("",          // No extra prefix before the default "ip_" prefix
-       NULL,
-       priorRv,
-       lhood,
-       postRv);
+  // No extra prefix before the default "ip_" prefix
+  QUESO::StatisticalInverseProblem<> ip("", NULL, priorRv, lhood, postRv);
 
   //------------------------------------------------------
   // SIP Step 6 of 6: Solve the inverse problem, that is,
@@ -157,8 +150,7 @@ void computeGravityAndTraveledDistance(const QUESO::FullEnvironment& env) {
   // SFP input RV = FIP posterior RV, so SFP parameter space
   // has been already defined.
   //------------------------------------------------------
-  QUESO::VectorSpace<QUESO::GslVector,QUESO::GslMatrix> qoiSpace(env, "qoi_",
-      1, NULL);
+  QUESO::VectorSpace<> qoiSpace(env, "qoi_", 1, NULL);
 
   //------------------------------------------------------
   // SFP Step 2 of 6: Instantiate the parameter domain
@@ -171,8 +163,7 @@ void computeGravityAndTraveledDistance(const QUESO::FullEnvironment& env) {
   // SFP Step 3 of 6: Instantiate the qoi object
   // to be used by QUESO.
   //------------------------------------------------------
-  Qoi<QUESO::GslVector, QUESO::GslMatrix, QUESO::GslVector, QUESO::GslMatrix>
-    qoi("qoi_", paramDomain, qoiSpace);
+  Qoi<> qoi("qoi_", paramDomain, qoiSpace);
 
   //------------------------------------------------------
   // SFP Step 4 of 6: Define the input RV
@@ -184,11 +175,9 @@ void computeGravityAndTraveledDistance(const QUESO::FullEnvironment& env) {
   //------------------------------------------------------
   // SFP Step 5 of 6: Instantiate the forward problem
   //------------------------------------------------------
-  QUESO::GenericVectorRV<QUESO::GslVector, QUESO::GslMatrix> qoiRv("qoi_",
-      qoiSpace);
+  QUESO::GenericVectorRV<> qoiRv("qoi_", qoiSpace);
 
-  QUESO::StatisticalForwardProblem<QUESO::GslVector, QUESO::GslMatrix,
-    QUESO::GslVector, QUESO::GslMatrix> fp("", NULL, postRv, qoi, qoiRv);
+  QUESO::StatisticalForwardProblem<> fp("", NULL, postRv, qoi, qoiRv);
 
   //------------------------------------------------------
   // SFP Step 6 of 6: Solve the forward problem

--- a/examples/gravity/src/gravity_likelihood.h
+++ b/examples/gravity/src/gravity_likelihood.h
@@ -28,7 +28,7 @@
 #include <queso/ScalarFunction.h>
 #include <queso/GslMatrix.h>
 
-template<class V, class M>
+template<class V = QUESO::GslVector, class M = QUESO::GslMatrix>
 class Likelihood : public QUESO::BaseScalarFunction<V, M>
 {
 public:

--- a/examples/gravity/src/gravity_main.C
+++ b/examples/gravity/src/gravity_main.C
@@ -1,27 +1,27 @@
-/*-------------------------------------------------------------------
- *
- * Copyright (C) 2012 The PECOS Development Team
- *
- * Please see http://pecos.ices.utexas.edu for more information.
- *
- * This file is part of the QUESO Library (Quantification of Uncertainty
- * for Estimation, Simulation and Optimization).
- *
- * QUESO is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * QUESO is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with QUESO. If not, see <http://www.gnu.org/licenses/>.
- *
- *-------------------------------------------------------------------
- */
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
  /*------------------------------------------------------------------
  * Brief description of this file:
  *

--- a/examples/gravity/src/gravity_qoi.h
+++ b/examples/gravity/src/gravity_qoi.h
@@ -34,7 +34,8 @@
 #include <queso/VectorFunction.h>
 #include <queso/DistArray.h>
 
-template<class P_V, class P_M, class Q_V, class Q_M>
+template<class P_V = QUESO::GslVector, class P_M = QUESO::GslMatrix,
+         class Q_V = QUESO::GslVector, class Q_M = QUESO::GslMatrix>
 class Qoi : public QUESO::BaseVectorFunction<P_V, P_M, Q_V, Q_M>
 {
 public:

--- a/src/basic/inc/ArrayOfSequences.h
+++ b/src/basic/inc/ArrayOfSequences.h
@@ -29,6 +29,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*! \file uqArrayOfSequences.h
  * \brief A templated class for handling samples of scalar sequences
  *
@@ -40,7 +43,7 @@ namespace QUESO {
  * means, correlation and covariance matrices. It is derived from and implements
  * BaseVectorSequence<V,M>.*/
 
-template <class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class ArrayOfSequences : public BaseVectorSequence<V,M>
 {
 public:

--- a/src/basic/inc/BoxSubset.h
+++ b/src/basic/inc/BoxSubset.h
@@ -30,6 +30,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!
  * \class BoxSubset
  * \brief Class representing a subset of a vector space shaped like a hypercube
@@ -37,7 +40,7 @@ namespace QUESO {
  * This class is determined by a collection of upper and lower limits of the hypercube.
  * (line segment in \f$ R \f$, rectangle in \f$ R^2 \f$, and so on). */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class BoxSubset : public VectorSubset<V,M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/basic/inc/ConcatenationSubset.h
+++ b/src/basic/inc/ConcatenationSubset.h
@@ -30,13 +30,16 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*! \class ConcatenationSubset
  * \brief A templated class representing the concatenation of two vector subsets.
  *
  * This class is used to represent the concatenation of two subsets. It allows concatenation
  * of both two subsets as well as a collection of subsets into one.
  */
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class ConcatenationSubset : public VectorSubset<V,M> {
 public:
    //! @name Constructor/Destructor methods.

--- a/src/basic/inc/ConstantScalarFunction.h
+++ b/src/basic/inc/ConstantScalarFunction.h
@@ -33,13 +33,16 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!\class ConstantScalarFunction
  * \brief A class for handling scalar functions which image is a constant (real number).
  *
  * This class allows the mathematical definition of a scalar function which image set
  * is a constant (real number). */
 
-template<class V,class M>
+template <class V = GslVector, class M = GslMatrix>
 class ConstantScalarFunction : public BaseScalarFunction<V,M> {
 public:
     //! @name Constructor/Destructor methods

--- a/src/basic/inc/ConstantVectorFunction.h
+++ b/src/basic/inc/ConstantVectorFunction.h
@@ -32,6 +32,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Constant class
 //*****************************************************
@@ -42,7 +45,7 @@ namespace QUESO {
  * This class allows the mathematical definition of a vector-valued function which image
  * set is constant vector. */
 
-template<class P_V,class P_M,class Q_V,class Q_M>
+template <class P_V = GslVector, class P_M = GslMatrix, class Q_V = GslVector ,class Q_M = GslMatrix>
 class ConstantVectorFunction : public BaseVectorFunction<P_V,P_M,Q_V,Q_M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/basic/inc/DiscreteSubset.h
+++ b/src/basic/inc/DiscreteSubset.h
@@ -30,6 +30,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*! \class DiscreteSubset
  * \brief A templated class representing the discrete vector subsets.
  *
@@ -38,7 +41,7 @@ namespace QUESO {
  * elements (vectors) that belongs to the subset.
  */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class DiscreteSubset : public VectorSubset<V,M> {
 public:
   //! @name Constructor/Destructor methods.

--- a/src/basic/inc/GenericScalarFunction.h
+++ b/src/basic/inc/GenericScalarFunction.h
@@ -33,13 +33,16 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!\class GenericScalarFunction
  * \brief A class for handling generic scalar functions.
  *
  * This class allows the mathematical definition of a scalar function such as:
  * \f$ f: B \subset R \rightarrow R \f$. It is derived from BaseScalarFunction. */
 
-template<class V,class M>
+template <class V = GslVector, class M = GslMatrix>
 class GenericScalarFunction : public BaseScalarFunction<V,M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/basic/inc/GenericVectorFunction.h
+++ b/src/basic/inc/GenericVectorFunction.h
@@ -32,9 +32,8 @@
 
 namespace QUESO {
 
-//*****************************************************
-// Generic class
-//*****************************************************
+class GslVector;
+class GslMatrix;
 
 /*!\class GenericVectorFunction
  * \brief A class for handling generic vector functions.
@@ -44,7 +43,7 @@ namespace QUESO {
  * BaseVectorFunction.
  */
 
-template<class P_V,class P_M,class Q_V,class Q_M>
+template <class P_V = GslVector, class P_M = GslMatrix, class Q_V = GslVector, class Q_M = GslMatrix>
 class GenericVectorFunction : public BaseVectorFunction<P_V,P_M,Q_V,Q_M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/basic/inc/InstantiateIntersection.h
+++ b/src/basic/inc/InstantiateIntersection.h
@@ -29,6 +29,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!\file InstantiateIntersection.h
  * \brief A templated method to calculate intersection of two domains (vector spaces).
  */
@@ -36,7 +39,7 @@ namespace QUESO {
 //! This method calculates the intersection of \c domain1 and \c domain2.
 /*! It is used, for instance, to calculate the domain of the Posterior PDF, which is
  * the intersection of the domain of the Prior PDF and of the likelihood function.*/
-template<class V, class M>
+template <class V, class M>
 VectorSet<V,M>* InstantiateIntersection(const VectorSet<V,M>& domain1,
     const VectorSet<V,M>& domain2);
 

--- a/src/basic/inc/IntersectionSubset.h
+++ b/src/basic/inc/IntersectionSubset.h
@@ -30,6 +30,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*! \class IntersectionSubset
  * \brief A templated class representing the intersection of two vector sets.
  *
@@ -38,7 +41,7 @@ namespace QUESO {
  * is the intersection of the domain of the prior PDF with the domain of the
  * likelihood function.*/
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class IntersectionSubset : public VectorSubset<V,M> {
 public:
   //! @name Constructor/Destructor methods.

--- a/src/basic/inc/ScalarFunction.h
+++ b/src/basic/inc/ScalarFunction.h
@@ -32,6 +32,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*! \file ScalarFunction.h
  * \brief Set of classes for handling vector functions.
  *
@@ -44,7 +47,7 @@ namespace QUESO {
  * of scalar functions.
  */
 
-template<class V,class M>
+template <class V = GslVector, class M = GslMatrix>
 class BaseScalarFunction {
 public:
   //! @name Constructor/Destructor methods.

--- a/src/basic/inc/ScalarFunctionSynchronizer.h
+++ b/src/basic/inc/ScalarFunctionSynchronizer.h
@@ -30,6 +30,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*! \file ScalarFunctionSynchronizer.h
  * \brief Class for synchronizing the calls of scalar functions
  *
@@ -40,7 +43,7 @@ namespace QUESO {
  * This means that all processes must reach a point in their code before they can all begin
  * executing again. */
 
-template <class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class ScalarFunctionSynchronizer
 {
 public:

--- a/src/basic/inc/ScalarSequence.h
+++ b/src/basic/inc/ScalarSequence.h
@@ -50,7 +50,7 @@ namespace QUESO {
  * as operations that can be carried over them, e.g., calculation of means,
  * correlation  and covariance matrices. */
 
-template <class T>
+template <class T = double>
 class ScalarSequence
 {
 public:

--- a/src/basic/inc/SequenceOfVectors.h
+++ b/src/basic/inc/SequenceOfVectors.h
@@ -31,6 +31,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*! \file SequenceofVectors.h
  * \brief A templated class for handling vector samples
  *
@@ -42,7 +45,7 @@ namespace QUESO {
  * correlation and covariance matrices. It is derived from and implements
  * BaseVectorSequence<V,M>.*/
 
-template <class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class SequenceOfVectors : public BaseVectorSequence<V,M>
 {
 public:

--- a/src/basic/inc/VectorFunction.h
+++ b/src/basic/inc/VectorFunction.h
@@ -31,11 +31,10 @@
 
 namespace QUESO {
 
-//*****************************************************
-// Base class
-//*****************************************************
+class GslVector;
+class GslMatrix;
 
-/*! \file uqVectorFunction.h
+/*! \file VectorFunction.h
  * \brief Set of classes for handling vector functions.
  *
  * \class BaseVectorFunction
@@ -47,7 +46,7 @@ namespace QUESO {
  * (and have already been introduced by the class VectorSet) and  of the
  * image set \f$ R^m \f$.*/
 
-template<class P_V,class P_M,class Q_V,class Q_M>
+template <class P_V = GslVector, class P_M = GslMatrix, class Q_V = GslVector, class Q_M = GslMatrix>
 class BaseVectorFunction {
 public:
   //! @name Constructor/Destructor methods.

--- a/src/basic/inc/VectorFunctionSynchronizer.h
+++ b/src/basic/inc/VectorFunctionSynchronizer.h
@@ -29,6 +29,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*! \file VectorFunctionSynchronizer.h
  * \brief Class for synchronizing the calls of vector-valued functions
  *
@@ -39,7 +42,7 @@ namespace QUESO {
  * functions. This means that all processes must reach a point in their code before they
  * can all begin executing again. */
 
-template <class P_V, class P_M, class Q_V, class Q_M>
+template <class P_V = GslVector, class P_M = GslMatrix, class Q_V = GslVector, class Q_M = GslMatrix>
 class VectorFunctionSynchronizer
 {
 public:

--- a/src/basic/inc/VectorSequence.h
+++ b/src/basic/inc/VectorSequence.h
@@ -39,6 +39,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*! \file VectorSequence.h
  * \brief A templated class for handling vector and arrays samples
  *
@@ -49,8 +52,7 @@ namespace QUESO {
  * as operations that can be carried over them, e.g., calculation of means, correlation
  * and covariance matrices. */
 
-
-template <class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class BaseVectorSequence
 {
 public:

--- a/src/basic/inc/VectorSet.h
+++ b/src/basic/inc/VectorSet.h
@@ -30,6 +30,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*! \file uqVectorSet.h
  * \brief A templated class for handling sets.
  *
@@ -45,7 +48,7 @@ namespace QUESO {
 template <class V, class M>
 class VectorSpace;
 
-template <class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class VectorSet
 {
 public:

--- a/src/basic/inc/VectorSpace.h
+++ b/src/basic/inc/VectorSpace.h
@@ -32,6 +32,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!
  * \class VectorSpace
  * \brief A class representing a vector space.
@@ -40,7 +43,7 @@ namespace QUESO {
  * respectively. Currently (as of version 0.46.0) QUESO has matrix and vector classes
  * implemented using either GSL or Trilinos-Teuchos libraries. */
 
-template <class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class VectorSpace : public VectorSet<V,M>
 {
 public:

--- a/src/basic/inc/VectorSubset.h
+++ b/src/basic/inc/VectorSubset.h
@@ -29,6 +29,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*! \file uqVectorSubset.h
  * \brief A templated class for handling subsets.
  *
@@ -39,8 +42,7 @@ namespace QUESO {
  * present, for instance, in the definition of a scalar function: \f$ \pi: B \subset R^n \rightarrow R \f$.
  * \f$ B \f$ is a subset of the set \f$ R^n \f$, which is also a vector space. */
 
-
-template <class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class VectorSubset : public VectorSet<V,M>
 {
 public:

--- a/src/core/inc/DistArray.h
+++ b/src/core/inc/DistArray.h
@@ -52,7 +52,7 @@ namespace QUESO {
     each node. RowSize is constant for all elements.
 */
 
-template<typename T>
+template <typename T>
 class DistArray
 {
 public:

--- a/src/gp/inc/ExperimentModel.h
+++ b/src/gp/inc/ExperimentModel.h
@@ -32,7 +32,10 @@
 
 namespace QUESO {
 
-template <class S_V,class S_M,class D_V,class D_M>
+class GslVector;
+class GslMatrix;
+
+template <class S_V = GslVector, class S_M = GslMatrix, class D_V = GslVector, class D_M = GslMatrix>
 class ExperimentModel
 {
 public:

--- a/src/gp/inc/ExperimentStorage.h
+++ b/src/gp/inc/ExperimentStorage.h
@@ -29,7 +29,10 @@
 
 namespace QUESO {
 
-template <class S_V,class S_M,class D_V,class D_M>
+class GslVector;
+class GslMatrix;
+
+template <class S_V = GslVector, class S_M = GslMatrix, class D_V = GslVector, class D_M = GslMatrix>
 class ExperimentStorage
 {
 public:

--- a/src/gp/inc/GPMSA.h
+++ b/src/gp/inc/GPMSA.h
@@ -39,7 +39,10 @@
 
 namespace QUESO {
 
-template <class V, class M>
+class GslVector;
+class GslMatrix;
+
+template <class V = GslVector, class M = GslMatrix>
 class GPMSAEmulator : public BaseScalarFunction<V, M>
 {
 public:
@@ -92,7 +95,7 @@ public:
   const ConcatenatedVectorRV<V, M> & m_totalPrior;
 };
 
-template <class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class GPMSAFactory
 {
 public:

--- a/src/gp/inc/GcmExperimentInfo.h
+++ b/src/gp/inc/GcmExperimentInfo.h
@@ -34,7 +34,10 @@
 
 namespace QUESO {
 
-template <class S_V,class S_M,class D_V,class D_M,class P_V,class P_M>
+class GslVector;
+class GslMatrix;
+
+template <class S_V = GslVector, class S_M = GslMatrix, class D_V = GslVector, class D_M = GslMatrix, class P_V = GslVector, class P_M = GslMatrix>
 class GcmExperimentInfo
 {
 public:

--- a/src/gp/inc/GcmJointInfo.h
+++ b/src/gp/inc/GcmJointInfo.h
@@ -30,7 +30,12 @@
 
 namespace QUESO {
 
-template <class S_V,class S_M,class D_V,class D_M,class P_V,class P_M,class Q_V,class Q_M>
+class GslVector;
+class GslMatrix;
+
+template <class S_V = GslVector, class S_M = GslMatrix, class D_V = GslVector,
+  class D_M = GslMatrix, class P_V = GslVector, class P_M = GslMatrix,
+  class Q_V = GslVector, class Q_M = GslMatrix>
 class GcmJointInfo
 {
 public:

--- a/src/gp/inc/GcmJointTildeInfo.h
+++ b/src/gp/inc/GcmJointTildeInfo.h
@@ -31,7 +31,12 @@
 
 namespace QUESO {
 
-template <class S_V,class S_M,class D_V,class D_M,class P_V,class P_M,class Q_V,class Q_M>
+class GslVector;
+class GslMatrix;
+
+template <class S_V = GslVector, class S_M = GslMatrix, class D_V = GslVector,
+  class D_M = GslMatrix, class P_V = GslVector, class P_M = GslMatrix,
+  class Q_V = GslVector, class Q_M = GslMatrix>
 class GcmJointTildeInfo
 {
 public:

--- a/src/gp/inc/GcmSimulationInfo.h
+++ b/src/gp/inc/GcmSimulationInfo.h
@@ -34,7 +34,10 @@
 
 namespace QUESO {
 
-template <class S_V,class S_M,class P_V,class P_M,class Q_V,class Q_M>
+class GslVector;
+class GslMatrix;
+
+template <class S_V = GslVector, class S_M = GslMatrix, class P_V = GslVector, class P_M = GslMatrix, class Q_V = GslVector, class Q_M = GslMatrix>
 class GcmSimulationInfo
 {
 public:

--- a/src/gp/inc/GcmSimulationTildeInfo.h
+++ b/src/gp/inc/GcmSimulationTildeInfo.h
@@ -33,7 +33,10 @@
 
 namespace QUESO {
 
-template <class S_V,class S_M,class P_V,class P_M,class Q_V,class Q_M>
+class GslVector;
+class GslMatrix;
+
+template <class S_V = GslVector, class S_M = GslMatrix, class P_V = GslVector, class P_M = GslMatrix, class Q_V = GslVector, class Q_M = GslMatrix>
 class GcmSimulationTildeInfo
 {
 public:

--- a/src/gp/inc/GcmTotalInfo.h
+++ b/src/gp/inc/GcmTotalInfo.h
@@ -35,7 +35,12 @@
 
 namespace QUESO {
 
-template <class S_V,class S_M,class D_V,class D_M,class P_V,class P_M,class Q_V,class Q_M>
+class GslVector;
+class GslMatrix;
+
+template <class S_V = GslVector, class S_M = GslMatrix, class D_V = GslVector,
+         class D_M = GslMatrix, class P_V = GslVector, class P_M = GslMatrix,
+         class Q_V = GslVector, class Q_M = GslMatrix>
 class GcmTotalInfo
 {
 public:

--- a/src/gp/inc/GcmZInfo.h
+++ b/src/gp/inc/GcmZInfo.h
@@ -31,7 +31,12 @@
 
 namespace QUESO {
 
-template <class S_V,class S_M,class D_V,class D_M,class P_V,class P_M,class Q_V,class Q_M>
+class GslVector;
+class GslMatrix;
+
+template <class S_V = GslVector, class S_M = GslMatrix, class D_V = GslVector,
+         class D_M = GslMatrix, class P_V = GslVector, class P_M = GslMatrix,
+         class Q_V = GslVector, class Q_M = GslMatrix>
 class GcmZInfo
 {
 public:

--- a/src/gp/inc/GcmZTildeInfo.h
+++ b/src/gp/inc/GcmZTildeInfo.h
@@ -34,7 +34,12 @@
 
 namespace QUESO {
 
-template <class S_V,class S_M,class D_V,class D_M,class P_V,class P_M,class Q_V,class Q_M>
+class GslVector;
+class GslMatrix;
+
+template <class S_V = GslVector, class S_M = GslMatrix, class D_V = GslVector,
+         class D_M = GslMatrix, class P_V = GslVector, class P_M = GslMatrix,
+         class Q_V = GslVector, class Q_M = GslMatrix>
 class GcmZTildeInfo
 {
 public:

--- a/src/gp/inc/GpmsaComputerModel.h
+++ b/src/gp/inc/GpmsaComputerModel.h
@@ -45,7 +45,12 @@
 
 namespace QUESO {
 
-template <class S_V,class S_M,class D_V,class D_M,class P_V,class P_M,class Q_V,class Q_M>
+class GslVector;
+class GslMatrix;
+
+template <class S_V = GslVector, class S_M = GslMatrix, class D_V = GslVector,
+         class D_M = GslMatrix, class P_V = GslVector, class P_M = GslMatrix,
+         class Q_V = GslVector, class Q_M = GslMatrix>
 class GpmsaComputerModel
 {
 public:

--- a/src/gp/inc/SimulationModel.h
+++ b/src/gp/inc/SimulationModel.h
@@ -32,7 +32,10 @@
 
 namespace QUESO {
 
-template <class S_V,class S_M,class P_V,class P_M,class Q_V,class Q_M>
+class GslVector;
+class GslMatrix;
+
+template <class S_V = GslVector, class S_M = GslMatrix, class P_V = GslVector, class P_M = GslMatrix, class Q_V = GslVector, class Q_M = GslMatrix>
 class SimulationModel
 {
 public:

--- a/src/gp/inc/SimulationStorage.h
+++ b/src/gp/inc/SimulationStorage.h
@@ -30,7 +30,10 @@
 
 namespace QUESO {
 
-template <class S_V,class S_M,class P_V,class P_M,class Q_V,class Q_M>
+class GslVector;
+class GslMatrix;
+
+template <class S_V = GslVector, class S_M = GslMatrix, class P_V = GslVector, class P_M = GslMatrix, class Q_V = GslVector, class Q_M = GslMatrix>
 class SimulationStorage
 {
 public:

--- a/src/misc/inc/ArrayOfOneDGrids.h
+++ b/src/misc/inc/ArrayOfOneDGrids.h
@@ -30,6 +30,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!\file ArrayOfOneDGrids.h
  * \brief Class to accommodate arrays of one-dimensional grid.
  *
@@ -40,7 +43,7 @@ namespace QUESO {
  * and MDF of vector functions (refer to BaseVectorCdf, BaseVectorMdf, and
  * derived classes).
  */
-template <class V, class M>
+template<class V = GslVector, class M = GslMatrix>
 class ArrayOfOneDGrids
 {
 public:

--- a/src/misc/inc/ArrayOfOneDTables.h
+++ b/src/misc/inc/ArrayOfOneDTables.h
@@ -30,6 +30,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!\file ArrayOfOneDTables
  * \brief Class to accommodate arrays of one-dimensional tables.
  *
@@ -42,7 +45,7 @@ namespace QUESO {
  * (ArrayOfOneDGrids).
  */
 
-template <class V, class M>
+template<class V = GslVector, class M = GslMatrix>
 class ArrayOfOneDTables
 {
 public:

--- a/src/misc/inc/AsciiTable.h
+++ b/src/misc/inc/AsciiTable.h
@@ -32,13 +32,16 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!\file AsciiTable.h
  * \brief Class to read ASCII values from a table.
  *
  * \class AsciiTable
  * \brief Class for reading ASCII values from a table in a file.*/
 
-template <class V, class M>
+template<class V = GslVector, class M = GslMatrix>
 class AsciiTable
 {
 public:

--- a/src/stats/inc/BayesianJointPdf.h
+++ b/src/stats/inc/BayesianJointPdf.h
@@ -36,16 +36,16 @@
 
 namespace QUESO {
 
-//*****************************************************
-// Bayesian probability density class [PDF-02]
-//*****************************************************
+class GslVector;
+class GslMatrix;
+
 /*!
  * \class BayesianJointPdf
  * \brief A class for handling Bayesian joint PDFs.
  *
  * This class allows the mathematical definition of a Bayesian Joint PDF.*/
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class BayesianJointPdf : public BaseJointPdf<V,M> {
 public:
     //! @name Constructor/Destructor methods

--- a/src/stats/inc/BetaJointPdf.h
+++ b/src/stats/inc/BetaJointPdf.h
@@ -36,16 +36,16 @@
 
 namespace QUESO {
 
-//*****************************************************
-// Beta probability density class [PDF-05]
-//*****************************************************
+class GslVector;
+class GslMatrix;
+
 /*!
  * \class BetaJointPdf
  * \brief A class for handling Beta joint PDFs.
  *
  * This class allows the mathematical definition of a Beta Joint PDF.*/
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class BetaJointPdf : public BaseJointPdf<V,M> {
 public:
     //! @name Constructor/Destructor methods

--- a/src/stats/inc/BetaVectorRV.h
+++ b/src/stats/inc/BetaVectorRV.h
@@ -37,6 +37,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Beta class [RV-05]
 //*****************************************************
@@ -57,7 +60,7 @@ namespace QUESO {
  */
 
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class BetaVectorRV : public BaseVectorRV<V,M> {
 public:
     //! @name Constructor/Destructor methods

--- a/src/stats/inc/BetaVectorRealizer.h
+++ b/src/stats/inc/BetaVectorRealizer.h
@@ -32,6 +32,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Beta class [R-05]
 //*****************************************************
@@ -42,7 +45,7 @@ namespace QUESO {
  * This class handles sampling from a Beta probability density distribution, of
  * parameters \c alpha and \c beta.*/
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class BetaVectorRealizer : public BaseVectorRealizer<V,M> {
 public:
 

--- a/src/stats/inc/ConcatenatedJointPdf.h
+++ b/src/stats/inc/ConcatenatedJointPdf.h
@@ -36,6 +36,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Concatenated probability density class [PDF-11]
 //*****************************************************
@@ -48,7 +51,7 @@ namespace QUESO {
  * This class used, for instance, to concatenate priors from two or more RVs, where one
  * of them has a uniform distribution whereas the other one(s) has a Gaussian distribution. */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class ConcatenatedJointPdf : public BaseJointPdf<V,M> {
 public:
     //! @name Constructor/Destructor methods

--- a/src/stats/inc/ConcatenatedVectorRV.h
+++ b/src/stats/inc/ConcatenatedVectorRV.h
@@ -37,6 +37,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Concatenated class [RV-11]
 //*****************************************************
@@ -48,7 +51,7 @@ namespace QUESO {
  * (samples) from this concatenated vector RV. It is used, for instance, to concatenate priors from two or
  * more RVs, where one of them has a uniform distribution whereas the other one(s) has a Gaussian distribution. */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class ConcatenatedVectorRV : public BaseVectorRV<V,M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/ConcatenatedVectorRealizer.h
+++ b/src/stats/inc/ConcatenatedVectorRealizer.h
@@ -32,6 +32,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Concatenated class [R-11]
 //*****************************************************
@@ -44,7 +47,7 @@ namespace QUESO {
  * This class used, for instance, to draw realization of concatenate priors from two or more RVs,
  * where one of them has a uniform distribution whereas the other one(s) has a Gaussian distribution. */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class ConcatenatedVectorRealizer : public BaseVectorRealizer<V,M> {
 public:
 

--- a/src/stats/inc/ExponentialMatrixCovarianceFunction.h
+++ b/src/stats/inc/ExponentialMatrixCovarianceFunction.h
@@ -32,6 +32,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Exponential class
 //*****************************************************
@@ -43,7 +46,7 @@ namespace QUESO {
  * \f[ cov = a \exp{(-d^2/\sigma^2)}\f], where \f$ d=d(x,y) \f$ is the distance between two vectors,
  * \f$ \sigma^2 \f$ is the variance matrix and \f$ a \f$ is the length scale ().*/
 
-template<class P_V, class P_M, class Q_V, class Q_M>
+template <class P_V = GslVector, class P_M = GslMatrix, class Q_V = GslVector, class Q_M = GslMatrix>
 class ExponentialMatrixCovarianceFunction : public BaseMatrixCovarianceFunction<P_V,P_M,Q_V,Q_M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/ExponentialScalarCovarianceFunction.h
+++ b/src/stats/inc/ExponentialScalarCovarianceFunction.h
@@ -32,6 +32,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Exponential class
 //*****************************************************
@@ -45,7 +48,7 @@ namespace QUESO {
  * This is a stationary covariance function with smooth sample paths. Exponential covariance
  * functions are largely employed in Gaussian processes.  */
 
-template<class V,class M>
+template <class V = GslVector, class M = GslMatrix>
 class ExponentialScalarCovarianceFunction : public BaseScalarCovarianceFunction<V,M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/GammaJointPdf.h
+++ b/src/stats/inc/GammaJointPdf.h
@@ -36,6 +36,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Gamma probability density class [PDF-06]
 //*****************************************************
@@ -45,7 +48,7 @@ namespace QUESO {
  *
  * This class allows the mathematical definition of a Gamma Joint PDF.*/
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class GammaJointPdf : public BaseJointPdf<V,M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/GammaVectorRV.h
+++ b/src/stats/inc/GammaVectorRV.h
@@ -37,6 +37,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Gamma class [RV-06]
 //*****************************************************
@@ -55,7 +58,7 @@ namespace QUESO {
  * The parameters \b a and \b b must all be positive, and the values \c x  must lie on the
  * interval \f$ (0, \infty)\f$. */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class GammaVectorRV : public BaseVectorRV<V,M> {
 public:
 

--- a/src/stats/inc/GammaVectorRealizer.h
+++ b/src/stats/inc/GammaVectorRealizer.h
@@ -32,6 +32,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Gamma class [R-06]
 //*****************************************************
@@ -41,7 +44,7 @@ namespace QUESO {
  *
  * This class handles sampling from a Gamma probability density distribution, of
  * parameters \c a and \c b.*/
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class GammaVectorRealizer : public BaseVectorRealizer<V,M> {
 public:
 

--- a/src/stats/inc/GaussianJointPdf.h
+++ b/src/stats/inc/GaussianJointPdf.h
@@ -36,6 +36,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Gaussian probability density class [PDF-03]
 //*****************************************************
@@ -45,7 +48,7 @@ namespace QUESO {
  *
  * This class allows the mathematical definition of a Gaussian Joint PDF.*/
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class GaussianJointPdf : public BaseJointPdf<V,M> {
 public:
     //! @name Constructor/Destructor methods

--- a/src/stats/inc/GaussianLikelihood.h
+++ b/src/stats/inc/GaussianLikelihood.h
@@ -30,6 +30,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!
  * \file BaseGaussianLikelihood.h
  *
@@ -41,7 +44,7 @@ namespace QUESO {
  * the user will implement to interact with the forward code.
  */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class BaseGaussianLikelihood : public BaseScalarFunction<V, M> {
 public:
   //! @name Constructor/Destructor methods.

--- a/src/stats/inc/GaussianLikelihoodBlockDiagonalCovariance.h
+++ b/src/stats/inc/GaussianLikelihoodBlockDiagonalCovariance.h
@@ -31,6 +31,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!
  * \file GaussianLikelihoodBlockDiagonalCovariance.h
  *
@@ -38,7 +41,7 @@ namespace QUESO {
  * \brief A class representing a Gaussian likelihood with block-diagonal covariance matrix
  */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class GaussianLikelihoodBlockDiagonalCovariance : public BaseGaussianLikelihood<V, M> {
 public:
   //! @name Constructor/Destructor methods.

--- a/src/stats/inc/GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.h
+++ b/src/stats/inc/GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.h
@@ -30,6 +30,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!
  * \file GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.h
  *
@@ -40,7 +43,7 @@ namespace QUESO {
  * as a hyperparameter to be inferred during the sampling procedure.
  */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients : public BaseGaussianLikelihood<V, M> {
 public:
   //! @name Constructor/Destructor methods.

--- a/src/stats/inc/GaussianLikelihoodDiagonalCovariance.h
+++ b/src/stats/inc/GaussianLikelihoodDiagonalCovariance.h
@@ -29,6 +29,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!
  * \file GaussianLikelihoodDiagonalCovariance.h
  *
@@ -36,7 +39,7 @@ namespace QUESO {
  * \brief A class that represents a Gaussian likelihood with diagonal covariance matrix
  */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class GaussianLikelihoodDiagonalCovariance : public BaseGaussianLikelihood<V, M> {
 public:
   //! @name Constructor/Destructor methods.

--- a/src/stats/inc/GaussianLikelihoodFullCovariance.h
+++ b/src/stats/inc/GaussianLikelihoodFullCovariance.h
@@ -29,6 +29,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!
  * \file GaussianLikelihoodFullCovariance.h
  *
@@ -36,7 +39,7 @@ namespace QUESO {
  * \brief A class that represents a Gaussian likelihood with full covariance
  */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class GaussianLikelihoodFullCovariance : public BaseGaussianLikelihood<V, M> {
 public:
   //! @name Constructor/Destructor methods.

--- a/src/stats/inc/GaussianLikelihoodFullCovarianceRandomCoefficient.h
+++ b/src/stats/inc/GaussianLikelihoodFullCovarianceRandomCoefficient.h
@@ -29,6 +29,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!
  * \file GaussianLikelihoodFullCovarianceRandomCoefficient.h
  *
@@ -36,7 +39,7 @@ namespace QUESO {
  * \brief A class that represents a Gaussian likelihood with full covariance and random coefficient
  */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class GaussianLikelihoodFullCovarianceRandomCoefficient : public BaseGaussianLikelihood<V, M> {
 public:
   //! @name Constructor/Destructor methods.

--- a/src/stats/inc/GaussianLikelihoodScalarCovariance.h
+++ b/src/stats/inc/GaussianLikelihoodScalarCovariance.h
@@ -29,6 +29,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!
  * \file GaussianLikelihoodScalarCovariance.h
  *
@@ -36,7 +39,7 @@ namespace QUESO {
  * \brief A class that represents a Gaussian likelihood with scalar covariance
  */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class GaussianLikelihoodScalarCovariance : public BaseGaussianLikelihood<V, M> {
 public:
   //! @name Constructor/Destructor methods.

--- a/src/stats/inc/GaussianVectorCdf.h
+++ b/src/stats/inc/GaussianVectorCdf.h
@@ -34,6 +34,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Gaussian cumulative distribution function class
 //*****************************************************
@@ -44,7 +47,7 @@ namespace QUESO {
  * This class \b will implement a Gaussian vector cumulative distribution function (CDF).
  * \todo: Implement me! */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class GaussianVectorCdf : public BaseVectorCdf<V,M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/GaussianVectorMdf.h
+++ b/src/stats/inc/GaussianVectorMdf.h
@@ -33,6 +33,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Gaussian marginal density function class
 //*****************************************************
@@ -43,7 +46,7 @@ namespace QUESO {
  * This class \b will implement a Gaussian vector marginal density function function (MDF).
  * \todo: Implement me! */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class GaussianVectorMdf : public BaseVectorMdf<V,M> {
 public:
     //! @name Constructor/Destructor methods

--- a/src/stats/inc/GaussianVectorRV.h
+++ b/src/stats/inc/GaussianVectorRV.h
@@ -37,6 +37,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Gaussian class [RV-03]
 //*****************************************************
@@ -56,7 +59,7 @@ namespace QUESO {
  * its median and mode). The parameter \f$ \sigma \f$  is its standard deviation; its variance is therefore
  * \f$ \sigma^2 \f$ . */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class GaussianVectorRV : public BaseVectorRV<V,M> {
 public:
   //! @name Constructor/Destructor methods
@@ -113,7 +116,7 @@ private:
 //---------------------------------------------------
 // Method declared outside class definition ---------
 //---------------------------------------------------
-template<class V, class M>
+template <class V, class M>
 void
 ComputeConditionalGaussianVectorRV(
   const V& muVec1,

--- a/src/stats/inc/GaussianVectorRealizer.h
+++ b/src/stats/inc/GaussianVectorRealizer.h
@@ -32,6 +32,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Gaussian class [R-03]
 //*****************************************************
@@ -41,7 +44,7 @@ namespace QUESO {
  *
  * This class handles sampling from a Gaussian probability density distribution.*/
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class GaussianVectorRealizer : public BaseVectorRealizer<V,M> {
 public:
 

--- a/src/stats/inc/GenericJointPdf.h
+++ b/src/stats/inc/GenericJointPdf.h
@@ -36,6 +36,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Generic probability density class [PDF-01]
 //*****************************************************
@@ -45,7 +48,7 @@ namespace QUESO {
  *
  * This class allows the mathematical definition of a generic Joint PDF, such as the posterior PDF.*/
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class GenericJointPdf : public BaseJointPdf<V,M> {
 public:
 

--- a/src/stats/inc/GenericMatrixCovarianceFunction.h
+++ b/src/stats/inc/GenericMatrixCovarianceFunction.h
@@ -32,6 +32,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Generic class
 //*****************************************************
@@ -41,7 +44,7 @@ namespace QUESO {
  *
  * This class implements a generic covariance matrices by calling a routine (via pointer).*/
 
-template<class P_V, class P_M, class Q_V, class Q_M>
+template <class P_V = GslVector, class P_M = GslMatrix, class Q_V = GslVector, class Q_M = GslMatrix>
 class GenericMatrixCovarianceFunction : public BaseMatrixCovarianceFunction<P_V,P_M,Q_V,Q_M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/GenericScalarCovarianceFunction.h
+++ b/src/stats/inc/GenericScalarCovarianceFunction.h
@@ -32,6 +32,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Generic class
 //*****************************************************
@@ -41,7 +44,7 @@ namespace QUESO {
  *
  * This class implements a generic covariance functions, by calling a routine (via pointer).*/
 
-template<class V,class M>
+template <class V = GslVector, class M = GslMatrix>
 class GenericScalarCovarianceFunction : public BaseScalarCovarianceFunction<V,M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/GenericVectorCdf.h
+++ b/src/stats/inc/GenericVectorCdf.h
@@ -34,6 +34,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Generic cumulative distribution function class
 //*****************************************************
@@ -43,7 +46,7 @@ namespace QUESO {
  *
  * This class \b will implement a generic vector cumulative distribution function (CDF).*/
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class GenericVectorCdf : public BaseVectorCdf<V,M> {
 public:
     //! @name Constructor/Destructor methods

--- a/src/stats/inc/GenericVectorMdf.h
+++ b/src/stats/inc/GenericVectorMdf.h
@@ -33,13 +33,16 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Generic marginal density function
 //*****************************************************
 /*!\class GenericVectorMdf
  * \brief A class for handling generic MDFs of vector functions. */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class GenericVectorMdf : public BaseVectorMdf<V,M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/GenericVectorRV.h
+++ b/src/stats/inc/GenericVectorRV.h
@@ -37,6 +37,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Generic class [RV-01]
 //*****************************************************
@@ -47,7 +50,7 @@ namespace QUESO {
  * and to generate realizations (samples) from such PDF.  This is the class used by QUESO to
  * store the solution of an statistical inverse problem. */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class GenericVectorRV : public BaseVectorRV<V,M> {
 public:
     //! @name Constructor/Destructor methods

--- a/src/stats/inc/GenericVectorRealizer.h
+++ b/src/stats/inc/GenericVectorRealizer.h
@@ -32,6 +32,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Generic class [R-01]
 //*****************************************************
@@ -44,7 +47,7 @@ namespace QUESO {
  * density distribution. This is the class that handles generic sampling, used,
  * for example, to sample, posterior PDFs (the solution of a Bayesian problem).*/
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class GenericVectorRealizer : public BaseVectorRealizer<V,M> {
 public:
 

--- a/src/stats/inc/HessianCovMatricesTKGroup.h
+++ b/src/stats/inc/HessianCovMatricesTKGroup.h
@@ -31,13 +31,16 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // TK with Hessians
 //*****************************************************
 /*! \class HessianCovMatricesTKGroup
  *  \brief This class allows the representation of a transition kernel with Hessians. */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class HessianCovMatricesTKGroup : public BaseTKGroup<V,M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/InfoTheory.h
+++ b/src/stats/inc/InfoTheory.h
@@ -61,7 +61,7 @@ double computeMI_ANN( ANNpointArray dataXY,
 // Function: estimateMI_ANN (using a joint)
 // (Mutual Information)
 //*****************************************************
-template<template <class P_V, class P_M> class RV, class P_V, class P_M>
+template <template <class P_V, class P_M> class RV, class P_V, class P_M>
 double estimateMI_ANN( const RV<P_V,P_M>& jointRV,
 		       const unsigned int xDimSel[], unsigned int dimX,
 		       const unsigned int yDimSel[], unsigned int dimY,
@@ -71,7 +71,7 @@ double estimateMI_ANN( const RV<P_V,P_M>& jointRV,
 // Function: estimateMI_ANN (using two seperate RVs)
 // (Mutual Information)
 //*****************************************************
-template<class P_V, class P_M,
+template <class P_V, class P_M,
   template <class P_V, class P_M> class RV_1,
   template <class P_V, class P_M> class RV_2>
 double estimateMI_ANN( const RV_1<P_V,P_M>& xRV,

--- a/src/stats/inc/InvLogitGaussianJointPdf.h
+++ b/src/stats/inc/InvLogitGaussianJointPdf.h
@@ -31,6 +31,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!
  * \class InvLogitGaussianJointPdf
  * \brief A class for handling hybrid (transformed) Gaussians with bounds
@@ -51,7 +54,7 @@ namespace QUESO {
  * \f]
  */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class InvLogitGaussianJointPdf : public BaseJointPdf<V,M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/InvLogitGaussianVectorRV.h
+++ b/src/stats/inc/InvLogitGaussianVectorRV.h
@@ -30,6 +30,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!
  * \class InvLogitGaussianVectorRV
  * \brief A class representing a (transformed) Gaussian vector RV with bounds
@@ -38,7 +41,7 @@ namespace QUESO {
  * PDF and to generate realizations (samples) from it.
  */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class InvLogitGaussianVectorRV : public BaseVectorRV<V, M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/InvLogitGaussianVectorRealizer.h
+++ b/src/stats/inc/InvLogitGaussianVectorRealizer.h
@@ -29,6 +29,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!
  * \class InvLogitGaussianVectorRealizer
  * \brief A class for handling sampling from (transformed) Gaussian probability density distributions with bounds
@@ -44,7 +47,7 @@ namespace QUESO {
  * This will produce a sample in the closed interval [a, b].
  */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class InvLogitGaussianVectorRealizer : public BaseVectorRealizer<V,M> {
 public:
 

--- a/src/stats/inc/InverseGammaJointPdf.h
+++ b/src/stats/inc/InverseGammaJointPdf.h
@@ -36,6 +36,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // InverseGamma probability density class [PDF-07]
 //*****************************************************
@@ -45,7 +48,7 @@ namespace QUESO {
  *
  * This class allows the mathematical definition of an Inverse Gamma Joint PDF.*/
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class InverseGammaJointPdf : public BaseJointPdf<V,M> {
 public:
     //! @name Constructor/Destructor methods

--- a/src/stats/inc/InverseGammaVectorRV.h
+++ b/src/stats/inc/InverseGammaVectorRV.h
@@ -37,6 +37,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // InverseGamma class [RV-07]
 //*****************************************************
@@ -54,7 +57,7 @@ namespace QUESO {
  * \f[  B(a,b)=\frac{\Gamma(a)\Gamma(b)}{\Gamma(a+b)}=\frac{(a-1)!(b-1)!}{(a+b-1)!}.\f]
  * The parameters \b a and \b b must all be positive, and the values \c x  must lie on the
  * interval \f$ (0, \infty)\f$. */
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class InverseGammaVectorRV : public BaseVectorRV<V,M> {
 public:
 

--- a/src/stats/inc/InverseGammaVectorRealizer.h
+++ b/src/stats/inc/InverseGammaVectorRealizer.h
@@ -32,6 +32,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // InverseGamma class [R-07]
 //*****************************************************
@@ -42,7 +45,7 @@ namespace QUESO {
  * This class handles sampling from an Inverse Gamma probability density distribution, of
  * parameters \c alpha and \c beta.*/
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class InverseGammaVectorRealizer : public BaseVectorRealizer<V,M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/JeffreysJointPdf.h
+++ b/src/stats/inc/JeffreysJointPdf.h
@@ -32,6 +32,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!
  * \class JeffreysJointPdf
  * \brief A class for handling jeffreys joint PDFs.
@@ -39,7 +42,7 @@ namespace QUESO {
  * This class allows the mathematical definition of a Jeffreys Joint PDF.
 */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class JeffreysJointPdf : public BaseJointPdf<V,M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/JeffreysVectorRV.h
+++ b/src/stats/inc/JeffreysVectorRV.h
@@ -35,6 +35,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!
  * \class JeffreysVectorRV
  * \brief A class representing a jeffreys vector RV.
@@ -42,7 +45,7 @@ namespace QUESO {
  * This class allows the user to compute the value of a jeffreys PDF and to generate realizations
  * (samples) from it. It is used, for instance, to create a jeffreys prior PDF. */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class JeffreysVectorRV : public BaseVectorRV<V,M> {
 public:
 

--- a/src/stats/inc/JeffreysVectorRealizer.h
+++ b/src/stats/inc/JeffreysVectorRealizer.h
@@ -32,6 +32,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!
  * \class JeffreysVectorRealizer
  * \brief A class for handling sampling from a jeffreys probability density
@@ -39,7 +42,7 @@ namespace QUESO {
  *
  * This class handles sampling from a jeffreys probability density distribution.*/
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class JeffreysVectorRealizer : public BaseVectorRealizer<V,M> {
 public:
 

--- a/src/stats/inc/JointPdf.h
+++ b/src/stats/inc/JointPdf.h
@@ -35,13 +35,9 @@
 
 namespace QUESO {
 
-//*****************************************************
-// Classes to accommodate a probability density.
-//*****************************************************
+class GslVector;
+class GslMatrix;
 
-//*****************************************************
-// Base class [PDF-00]
-//*****************************************************
 /*! \file JointPdf.h
  * \brief Classes to accommodate a probability density.
  *
@@ -56,7 +52,7 @@ namespace QUESO {
  * UniformJointPdf, GaussianJointPdf, and BayesianJointPdf,
  * respectively. The posterior PDF may be represented within QUESO by GenericJointPdf. */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class BaseJointPdf : public BaseScalarFunction<V,M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/LogNormalJointPdf.h
+++ b/src/stats/inc/LogNormalJointPdf.h
@@ -36,6 +36,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // LogNormal probability density class [PDF-10]
 //*****************************************************
@@ -45,7 +48,7 @@ namespace QUESO {
  *
  * This class allows the mathematical definition of a Log-Normal Joint PDF.*/
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class LogNormalJointPdf : public BaseJointPdf<V,M> {
 public:
 

--- a/src/stats/inc/LogNormalVectorRV.h
+++ b/src/stats/inc/LogNormalVectorRV.h
@@ -37,6 +37,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // LogNormal class [RV-10]
 //*****************************************************
@@ -52,7 +55,7 @@ namespace QUESO {
  * where  the parameters denoted \f$ \mu \f$ and \f$ \sigma \f$ are, respectively, the mean and standard
  * deviation of the  variable's natural logarithm; and \c x>0.  */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class LogNormalVectorRV : public BaseVectorRV<V,M> {
 public:
     //! @name Constructor/Destructor methods

--- a/src/stats/inc/LogNormalVectorRealizer.h
+++ b/src/stats/inc/LogNormalVectorRealizer.h
@@ -32,6 +32,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // LogNormal class [R-10]
 //*****************************************************
@@ -42,7 +45,7 @@ namespace QUESO {
  * This class handles sampling from a Log-Normal probability density distribution, of
  * mean and variance given.*/
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class LogNormalVectorRealizer : public BaseVectorRealizer<V,M> {
 public:
     //! @name Constructor/Destructor methods

--- a/src/stats/inc/MLSampling.h
+++ b/src/stats/inc/MLSampling.h
@@ -49,7 +49,9 @@
 
 namespace QUESO {
 
-// aqui 1
+class GslVector;
+class GslMatrix;
+
 #ifdef QUESO_HAS_GLPK
 struct BIP_routine_struct {
   const BaseEnvironment* env;
@@ -71,7 +73,7 @@ struct ExchangeInfoStruct
 
 //---------------------------------------------------------
 
-template <class P_V>
+template <class P_V = GslVector>
 struct BalancedLinkedChainControlStruct
 {
   P_V*         initialPosition;
@@ -80,7 +82,7 @@ struct BalancedLinkedChainControlStruct
   unsigned int numberOfPositions;
 };
 
-template <class P_V>
+template <class P_V = GslVector>
 struct BalancedLinkedChainsPerNodeStruct
 {
   std::vector<BalancedLinkedChainControlStruct<P_V> > balLinkedChains;
@@ -116,7 +118,7 @@ struct UnbalancedLinkedChainsPerNodeStruct
  * 'grep zeros <OUTPUT FILE NAME>' after the solution procedures ends.
  * The names of the variables are chosen to be self explanatory. */
 
-template <class P_V,class P_M>
+template <class P_V = GslVector, class P_M = GslMatrix>
 class MLSampling
 {
 public:

--- a/src/stats/inc/MarkovChainPositionData.h
+++ b/src/stats/inc/MarkovChainPositionData.h
@@ -29,6 +29,8 @@
 
 namespace QUESO {
 
+class GslVector;
+
 /*! \file MarkovChainPositionData.h
  * \brief A templated class that represents a Markov Chain.
  *
@@ -43,7 +45,7 @@ namespace QUESO {
  * the Metropolis-Hastings algorithm and on it is calculated the acceptance ration
  * MetropolisHastingsSG::alpha(). */
 
-template <class V>
+template <class V = GslVector>
 class MarkovChainPositionData
 {
 public:

--- a/src/stats/inc/MatrixCovarianceFunction.h
+++ b/src/stats/inc/MatrixCovarianceFunction.h
@@ -31,6 +31,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*! \file MatrixCovarianceFunction.h
  * \brief Classes to accommodate covariance matrix of random vector functions.
  *
@@ -50,7 +53,7 @@ namespace QUESO {
  * where \f$ \mu_X \f$ and \f$ \mu_Y \f$ are the respective means, which can be written out
  * explicitly as \f[ cov (X,Y) = \sum_{i=1}^{N} \frac{(x_i - \bar{x})(y_i - \bar{y})}{N}\f] */
 
-template<class P_V, class P_M, class Q_V, class Q_M>
+template <class P_V = GslVector, class P_M = GslMatrix, class Q_V = GslVector, class Q_M = GslMatrix>
 class BaseMatrixCovarianceFunction {
 public:
     //! @name Constructor/Destructor methods

--- a/src/stats/inc/MetropolisHastingsSG.h
+++ b/src/stats/inc/MetropolisHastingsSG.h
@@ -39,6 +39,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //--------------------------------------------------
 // MHRawChainInfoStruct --------------------------
 //--------------------------------------------------
@@ -116,7 +119,7 @@ struct MHRawChainInfoStruct
  * are defined and set by running 'grep zeros <OUTPUT FILE NAME>' after the solution procedures ends.
  * The names of the variables are self explanatory. */
 
-template <class P_V,class P_M>
+template <class P_V = GslVector, class P_M = GslMatrix>
 class MetropolisHastingsSG
 {
 public:

--- a/src/stats/inc/ModelValidation.h
+++ b/src/stats/inc/ModelValidation.h
@@ -29,6 +29,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*! \file ModelValidation.h
  * \brief A templated class for model validation of the example validationPyramid.
  *
@@ -38,7 +41,7 @@ namespace QUESO {
  * Its derived class exPhysics1Validation enables comparison between the calibration
  * and validate stages. */
 
-template <class P_V,class P_M,class Q_V,class Q_M>
+template <class P_V = GslVector, class P_M = GslMatrix, class Q_V = GslVector, class Q_M = GslMatrix>
 class ModelValidation
 {
 public:

--- a/src/stats/inc/MonteCarloSG.h
+++ b/src/stats/inc/MonteCarloSG.h
@@ -32,6 +32,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!
  * \file MonteCarloSG.h
  * \brief A templated class that implements a Monte Carlo generator of samples.
@@ -45,7 +48,7 @@ namespace QUESO {
  * variables are defined and set by running 'grep zeros <OUTPUT FILE NAME>' after the solution
  * procedures ends. The names of the variables are self explanatory. */
 
-template <class P_V,class P_M,class Q_V,class Q_M>
+template <class P_V = GslVector, class P_M = GslMatrix, class Q_V = GslVector, class Q_M = GslMatrix>
 class MonteCarloSG
 {
 public:

--- a/src/stats/inc/PoweredJointPdf.h
+++ b/src/stats/inc/PoweredJointPdf.h
@@ -36,6 +36,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Powered probability density class [PDF-08]
 //*****************************************************
@@ -45,7 +48,7 @@ namespace QUESO {
  *
  * This class allows the mathematical definition of a Powered Joint PDF.*/
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class PoweredJointPdf : public BaseJointPdf<V,M> {
 public:
     //! @name Constructor/Destructor methods

--- a/src/stats/inc/SampledScalarCdf.h
+++ b/src/stats/inc/SampledScalarCdf.h
@@ -42,7 +42,7 @@ namespace QUESO {
  * This class implements a sampled cumulative distribution function (CDF), given
  * the grid points where it will be sampled and its resulting values.*/
 
-template<class T>
+template <class T>
 class SampledScalarCdf : public BaseScalarCdf<T> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/SampledVectorCdf.h
+++ b/src/stats/inc/SampledVectorCdf.h
@@ -34,6 +34,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Sampled cumulative distribution function class
 //*****************************************************
@@ -44,7 +47,7 @@ namespace QUESO {
  * This class implements a sampled vector cumulative distribution function (CDF), given
  * the grid points where it will be sampled and it returns its values.*/
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class SampledVectorCdf : public BaseVectorCdf<V,M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/SampledVectorMdf.h
+++ b/src/stats/inc/SampledVectorMdf.h
@@ -33,6 +33,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // Sampled marginal density function class
 //*****************************************************
@@ -43,7 +46,7 @@ namespace QUESO {
  * This class implements a sampled vector marginal density function (MDF), given
  * the grid points where it will be sampled and it returns its values.*/
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class SampledVectorMdf : public BaseVectorMdf<V,M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/ScalarCdf.h
+++ b/src/stats/inc/ScalarCdf.h
@@ -31,13 +31,6 @@
 
 namespace QUESO {
 
-//*****************************************************
-// Classes to accommodate a cumulative distribution function
-//*****************************************************
-
-//*****************************************************
-// Base class
-//*****************************************************
 /*! \file ScalarCdf.h
  * \brief Classes to accommodate a cumulative distribution function.
  *
@@ -52,7 +45,7 @@ namespace QUESO {
  * value less than or equal to x. In the case of a continuous distribution, it gives the area
  * under the probability density function (PDF) from minus infinity to x.*/
 
-template<class T>
+template <class T>
 class BaseScalarCdf {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/ScalarCovarianceFunction.h
+++ b/src/stats/inc/ScalarCovarianceFunction.h
@@ -31,9 +31,9 @@
 
 namespace QUESO {
 
-//*****************************************************
-// Base class
-//*****************************************************
+class GslVector;
+class GslMatrix;
+
 /*! \file ScalarCovarianceFunction.h
  * \brief Classes to accommodate covariance of scalar functions (random variables).
  *
@@ -49,7 +49,7 @@ namespace QUESO {
  * where \f$ \mu_X \f$ and \f$ \mu_Y \f$ are the respective means, which can be written out
  * explicitly as \f[ cov (X,Y) = \sum_{i=1}^{N} \frac{(x_i - \bar{x})(y_i - \bar{y})}{N}\f] */
 
-template<class V,class M>
+template <class V = GslVector, class M = GslMatrix>
 class BaseScalarCovarianceFunction {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/ScalarGaussianRandomField.h
+++ b/src/stats/inc/ScalarGaussianRandomField.h
@@ -31,6 +31,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!
  * \file ScalarGaussianRandomField.h
  * \brief A class for handling Gaussian random fields (GRF).
@@ -42,7 +45,7 @@ namespace QUESO {
  * Gaussian probability density functions (PDFs) of the variables. A one-dimensional GRF is
  * also called a Gaussian process.*/
 
-template <class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class ScalarGaussianRandomField
 {
  public:

--- a/src/stats/inc/ScaledCovMatrixTKGroup.h
+++ b/src/stats/inc/ScaledCovMatrixTKGroup.h
@@ -31,13 +31,16 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 //*****************************************************
 // TK with scaled cov matrix
 //*****************************************************
 /*! \class ScaledCovMatrixTKGroup
  *  \brief This class allows the representation of a transition kernel with a scaled covariance matrix. */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class ScaledCovMatrixTKGroup : public BaseTKGroup<V,M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/SequentialVectorRealizer.h
+++ b/src/stats/inc/SequentialVectorRealizer.h
@@ -32,9 +32,9 @@
 
 namespace QUESO {
 
-//*****************************************************
-// Sequential class [R-nn]
-//*****************************************************
+class GslVector;
+class GslMatrix;
+
 /*!
  * \class SequentialVectorRealizer
  * \brief A class for handling sequential draws (sampling) from probability density distributions.
@@ -42,7 +42,7 @@ namespace QUESO {
  * This class handles sequential sampling (it returns the next value of the chain) from a
  * probability density distribution.*/
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class SequentialVectorRealizer : public BaseVectorRealizer<V,M> {
 public:
 

--- a/src/stats/inc/StatisticalForwardProblem.h
+++ b/src/stats/inc/StatisticalForwardProblem.h
@@ -34,6 +34,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*! \file StatisticalForwardProblem.h
     \brief Class to solve a Statistical Forward Problem
 */
@@ -73,7 +76,7 @@ namespace QUESO {
        instance of the class 'BaseVectorRealizer<Q_V,Q_M>'.
 </list>*/
 
-template <class P_V,class P_M,class Q_V,class Q_M>
+template <class P_V = GslVector, class P_M = GslMatrix, class Q_V = GslVector, class Q_M = GslMatrix>
 class StatisticalForwardProblem
 {
 public:

--- a/src/stats/inc/StatisticalInverseProblem.h
+++ b/src/stats/inc/StatisticalInverseProblem.h
@@ -37,6 +37,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*! \file StatisticalInverseProblem.h
     \brief Class to solve a Statistical Inverse Problem
 */
@@ -77,7 +80,7 @@ namespace QUESO {
  * value the routine is actually computing, so that the 'scalar function' class can properly
  * implements both class operations 'actualValue()' and 'minus2LnValue()'*/
 
-template <class P_V,class P_M>
+template <class P_V = GslVector, class P_M = GslMatrix>
 class StatisticalInverseProblem
 {
 public:

--- a/src/stats/inc/StdScalarCdf.h
+++ b/src/stats/inc/StdScalarCdf.h
@@ -44,7 +44,7 @@ namespace QUESO {
  * m_sampledCdfGrid is an object of the class SampledScalarCdf<T>, so all members of this
  * class are implemented using the members of SampledScalarCdf<T>.*/
 
-template<class T>
+template <class T>
 class StdScalarCdf : public BaseScalarCdf<T> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/TKGroup.h
+++ b/src/stats/inc/TKGroup.h
@@ -31,9 +31,9 @@
 
 namespace QUESO {
 
-//*****************************************************
-// Base class
-//*****************************************************
+class GslVector;
+class GslMatrix;
+
 /*! \file TKGroup.h
  *  \brief Class to set up a Transition Kernel.
  *
@@ -45,7 +45,8 @@ namespace QUESO {
  * a Borel set over \f$ R^n \f$. Since it is a distribution function, \f$ P(x,R^n)=1 \f$, where it
  * is permitted that the chain can make a transition from the point \f$ x \f$ to \f$ x \f$, that is
  * \f$ P(x, {x}) \f$ is not necessarily zero. */
-template<class V, class M>
+
+template <class V = GslVector, class M = GslMatrix>
 class BaseTKGroup {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/TransformedScaledCovMatrixTKGroup.h
+++ b/src/stats/inc/TransformedScaledCovMatrixTKGroup.h
@@ -32,6 +32,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!
  * \class TransformedScaledCovMatrixTKGroup
  * \brief This class represents a transition kernel with a scaled covariance matrix on hybrid bounded/unbounded state spaces.
@@ -41,7 +44,7 @@ namespace QUESO {
  * no realizations are generated outside of the state space.
  */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class TransformedScaledCovMatrixTKGroup : public BaseTKGroup<V, M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/UniformJointPdf.h
+++ b/src/stats/inc/UniformJointPdf.h
@@ -36,16 +36,16 @@
 
 namespace QUESO {
 
-//*****************************************************
-// Uniform probability density class [PDF-04]
-//*****************************************************
+class GslVector;
+class GslMatrix;
+
 /*!
  * \class UniformJointPdf
  * \brief A class for handling uniform joint PDFs.
  *
  * This class allows the mathematical definition of a Uniform Joint PDF.*/
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class UniformJointPdf : public BaseJointPdf<V,M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/UniformVectorRV.h
+++ b/src/stats/inc/UniformVectorRV.h
@@ -37,9 +37,9 @@
 
 namespace QUESO {
 
-//*****************************************************
-// Uniform class [RV-04]
-//*****************************************************
+class GslVector;
+class GslMatrix;
+
 /*!
  * \class UniformVectorRV
  * \brief A class representing a uniform vector RV.
@@ -47,7 +47,7 @@ namespace QUESO {
  * This class allows the user to compute the value of a uniform PDF and to generate realizations
  * (samples) from it. It is used, for instance, to create a uniform prior PDF. */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class UniformVectorRV : public BaseVectorRV<V,M> {
 public:
 

--- a/src/stats/inc/UniformVectorRealizer.h
+++ b/src/stats/inc/UniformVectorRealizer.h
@@ -32,16 +32,16 @@
 
 namespace QUESO {
 
-//*****************************************************
-// Uniform class [R-04]
-//*****************************************************
+class GslVector;
+class GslMatrix;
+
 /*!
  * \class UniformVectorRealizer
  * \brief A class for handling sampling from a Uniform probability density distribution.
  *
  * This class handles sampling from a uniform probability density distribution.*/
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class UniformVectorRealizer : public BaseVectorRealizer<V,M> {
 public:
 

--- a/src/stats/inc/ValidationCycle.h
+++ b/src/stats/inc/ValidationCycle.h
@@ -32,6 +32,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*! \file ValidationCycle.h
  * \brief A templated class for validation cycle of the examples validationCycle and validationCycle2.
  *
@@ -47,7 +50,7 @@ namespace QUESO {
  * The examples validationCycle and validationCycle2 use the present class to solve the same TGA problem,
  * and they only differ in implementation styles. */
 
-template <class P_V,class P_M,class Q_V,class Q_M>
+template <class P_V = GslVector, class P_M = GslMatrix, class Q_V = GslVector, class Q_M = GslMatrix>
 class ValidationCycle
 {
 public:

--- a/src/stats/inc/VectorCdf.h
+++ b/src/stats/inc/VectorCdf.h
@@ -34,9 +34,9 @@
 
 namespace QUESO {
 
-//*****************************************************
-// Classes to accommodate a cumulative distribution function
-//*****************************************************
+class GslVector;
+class GslMatrix;
+
 /*! \file VectorCdf.h
  * \brief Classes to accommodate a cumulative distribution function of a vector RV.
  *
@@ -49,10 +49,7 @@ namespace QUESO {
  * RV, the joint cumulative distribution function must also be defined. This class handles
  * the CDFs of vector RV, which are referred to as  multivariate/vector/joint CDFs.*/
 
-//*****************************************************
-// Base class
-//*****************************************************
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class BaseVectorCdf {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/VectorGaussianRandomField.h
+++ b/src/stats/inc/VectorGaussianRandomField.h
@@ -31,6 +31,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*!
  * \file VectorGaussianRandomField.h
  * \brief A class for handling Gaussian random fields (GRF).
@@ -41,7 +44,7 @@ namespace QUESO {
  * This class implements a vector Gaussian random field (GRF); i.e. a random field involving
  * vector Gaussian probability density functions (PDFs) of the variables. */
 
-template <class P_V, class P_M, class Q_V, class Q_M>
+template <class P_V = GslVector, class P_M = GslMatrix, class Q_V = GslVector, class Q_M = GslMatrix>
 class VectorGaussianRandomField
 {
  public:

--- a/src/stats/inc/VectorMdf.h
+++ b/src/stats/inc/VectorMdf.h
@@ -32,13 +32,9 @@
 
 namespace QUESO {
 
-//*****************************************************
-// Classes to accommodate a marginal density function
-//*****************************************************
+class GslVector;
+class GslMatrix;
 
-//*****************************************************
-// Base class
-//*****************************************************
 /*! \file VectorMdf.h
  * \brief Classes to accommodate a marginal density function of a vector RV.
  *
@@ -52,7 +48,7 @@ namespace QUESO {
  * the marginal distribution of \f$ X_i \f$.
  * This class handles MDFs of a vector RV.*/
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class BaseVectorMdf {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/VectorRV.h
+++ b/src/stats/inc/VectorRV.h
@@ -37,6 +37,9 @@
 
 namespace QUESO {
 
+class GslVector;
+class GslMatrix;
+
 /*! \file VectorRV.h
  * \brief A templated class for handling vector random variables (RV).
  *
@@ -47,7 +50,7 @@ namespace QUESO {
  * PDF of a random variable (RV) at a point and to generate realizations (samples) from such PDF.
  */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class BaseVectorRV {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/VectorRealizer.h
+++ b/src/stats/inc/VectorRealizer.h
@@ -31,13 +31,9 @@
 
 namespace QUESO {
 
-//*****************************************************
-// Classes to accommodate a probability density routine.
-//*****************************************************
+class GslVector;
+class GslMatrix;
 
-//*****************************************************
-// Base class [R-00]
-//*****************************************************
 /*! \file VectorRealizer.h
  * \brief A templated class for sampling from vector RVs (holding probability density distributions).
  *
@@ -49,7 +45,7 @@ namespace QUESO {
  * uniform, Gaussian, Beta, Gamma, Inverse Gamma and LogNormal realizers, as described
  * and implemented in the derived classes. */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class BaseVectorRealizer {
 public:
 

--- a/src/stats/inc/WignerJointPdf.h
+++ b/src/stats/inc/WignerJointPdf.h
@@ -36,16 +36,16 @@
 
 namespace QUESO {
 
-//*****************************************************
-// Wigner probability density class [PDF-09]
-//*****************************************************
+class GslVector;
+class GslMatrix;
+
 /*!
  * \class WignerJointPdf
  * \brief A class for handling Wigner joint PDFs.
  *
  * This class allows the mathematical definition of a Wigner Joint PDF.*/
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class WignerJointPdf : public BaseJointPdf<V,M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/stats/inc/WignerVectorRV.h
+++ b/src/stats/inc/WignerVectorRV.h
@@ -37,9 +37,9 @@
 
 namespace QUESO {
 
-//*****************************************************
-// Wigner class [RV-09]
-//*****************************************************
+class GslVector;
+class GslMatrix;
+
 /*!
  * \class WignerVectorRV
  * \brief A class representing a vector RV constructed via Wigner distribution.
@@ -50,7 +50,7 @@ namespace QUESO {
  * \todo: WignerVectorRealizer.realization() is not yet available, thus this class does
  * nothing. */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class WignerVectorRV : public BaseVectorRV<V,M> {
 public:
 

--- a/src/stats/inc/WignerVectorRealizer.h
+++ b/src/stats/inc/WignerVectorRealizer.h
@@ -32,9 +32,9 @@
 
 namespace QUESO {
 
-//*****************************************************
-// Wigner class [R-09]
-//*****************************************************
+class GslVector;
+class GslMatrix;
+
 /*!
  * \class WignerVectorRealizer
  * \brief A class for handling sampling from a Wigner probability density distribution.
@@ -45,7 +45,7 @@ namespace QUESO {
  * \todo: The method WignerVectorRealizer:realization() is not yet available,
  * thus this class does  nothing. */
 
-template<class V, class M>
+template <class V = GslVector, class M = GslMatrix>
 class WignerVectorRealizer : public BaseVectorRealizer<V,M> {
 public:
   //! @name Constructor/Destructor methods

--- a/src/surrogates/inc/InterpolationSurrogateBase.h
+++ b/src/surrogates/inc/InterpolationSurrogateBase.h
@@ -32,6 +32,8 @@ namespace QUESO
   // Forward declarations
   template<typename V, typename M>
   class InterpolationSurrogateData;
+  class GslVector;
+  class GslMatrix;
 
   //! Base class for interpolation-based surrogates
   /*! This class is used for surrogoate approximations of a model using interpolation.
@@ -46,7 +48,7 @@ namespace QUESO
       For the structured grid, we think of referencing each "node" in the box by its
       index coordinates (i,j,k,...), where i runs from (0, n_points[0]-1),
       j run from (0,n_points[1]-1), etc. We use this indexing to build maps. */
-  template<class V, class M>
+  template<class V = GslVector, class M = GslMatrix>
   class InterpolationSurrogateBase : public SurrogateBase<V>
   {
   public:

--- a/src/surrogates/inc/InterpolationSurrogateBuilder.h
+++ b/src/surrogates/inc/InterpolationSurrogateBuilder.h
@@ -30,13 +30,16 @@
 
 namespace QUESO
 {
+  class GslVector;
+  class GslMatrix;
+
   //! Build interpolation-based surrogate
   /*! Interpolation surrogates assume a structured grid. So, given the domain
       and the number of equally space points desired in each dimension, this
       class will handle calling the user's model to populate the values needed
       by the surrogate objects. User should subclass this object and implement
       the evaluate_model method. */
-  template<class V, class M>
+  template<class V = GslVector, class M = GslMatrix>
   class InterpolationSurrogateBuilder : public SurrogateBuilderBase<V>
   {
   public:

--- a/src/surrogates/inc/InterpolationSurrogateData.h
+++ b/src/surrogates/inc/InterpolationSurrogateData.h
@@ -29,7 +29,10 @@
 
 namespace QUESO
 {
-  template<class V, class M>
+  class GslVector;
+  class GslMatrix;
+
+  template<class V = GslVector, class M = GslMatrix>
   class InterpolationSurrogateData
   {
   public:

--- a/src/surrogates/inc/LinearLagrangeInterpolationSurrogate.h
+++ b/src/surrogates/inc/LinearLagrangeInterpolationSurrogate.h
@@ -34,10 +34,13 @@
 
 namespace QUESO
 {
+  class GslVector;
+  class GslMatrix;
+
   //! Linear Lagrange interpolation surrogate
   /*! Aribritary dimension linear Lagrange interpolant. Uses a structured
       grid to interpolate values given by data passed to the constructor. */
-  template<class V, class M>
+  template<class V = GslVector, class M = GslMatrix>
   class LinearLagrangeInterpolationSurrogate : public InterpolationSurrogateBase<V,M>
   {
   public:

--- a/src/surrogates/inc/SurrogateBase.h
+++ b/src/surrogates/inc/SurrogateBase.h
@@ -27,6 +27,8 @@
 
 namespace QUESO
 {
+  class GslVector;
+
   //! Base class for surrogates of models
   /*! Defines basic interface for using surrogates of models. These surrogates
       map an \f$ n\f$ dimensional parameter space to the reals. That is
@@ -35,7 +37,7 @@ namespace QUESO
       it can be used in the likelihood classes. Subclasses will define the
       particular surrogate model. Other classes will be used to build up the
       surrogate from the user's model. */
-  template<class V>
+  template<class V = GslVector>
   class SurrogateBase
   {
   public:

--- a/src/surrogates/inc/SurrogateBuilderBase.h
+++ b/src/surrogates/inc/SurrogateBuilderBase.h
@@ -27,10 +27,12 @@
 
 namespace QUESO
 {
+  class GslVector;
+
   //! Base class for builders of surrogates
   /*! This class provides the interface to the user's model for which
       we are constructing a surrogate. */
-  template<class V>
+  template<class V = GslVector>
   class SurrogateBuilderBase
   {
   public:

--- a/test/test_InterpolationSurrogate/test_4D_LinearLagrangeInterpolationSurrogate.C
+++ b/test/test_InterpolationSurrogate/test_4D_LinearLagrangeInterpolationSurrogate.C
@@ -37,8 +37,7 @@ int main(int argc, char ** argv)
 
   int return_flag = 0;
 
-  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>
-    paramSpace(env,"param_", 4, NULL);
+  QUESO::VectorSpace<> paramSpace(env,"param_", 4, NULL);
 
   QUESO::GslVector paramMins(paramSpace.zeroVector());
   paramMins[0] = -1;
@@ -52,8 +51,7 @@ int main(int argc, char ** argv)
   paramMaxs[2] = 2.1;
   paramMaxs[3] = 4.1;
 
-  QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix>
-    paramDomain("param_", paramSpace, paramMins, paramMaxs);
+  QUESO::BoxSubset<> paramDomain("param_", paramSpace, paramMins, paramMaxs);
 
   std::vector<unsigned int> n_points(4);
   n_points[0] = 101;
@@ -61,8 +59,7 @@ int main(int argc, char ** argv)
   n_points[2] = 31;
   n_points[3] = 41;
 
-  QUESO::InterpolationSurrogateData<QUESO::GslVector, QUESO::GslMatrix>
-    data(paramDomain,n_points);
+  QUESO::InterpolationSurrogateData<> data(paramDomain,n_points);
 
   std::vector<double> values(n_points[0]*n_points[1]*n_points[2]*n_points[3]);
 
@@ -95,8 +92,7 @@ int main(int argc, char ** argv)
 
   data.set_values( values );
 
-  QUESO::LinearLagrangeInterpolationSurrogate<QUESO::GslVector,QUESO::GslMatrix>
-    four_d_surrogate( data );
+  QUESO::LinearLagrangeInterpolationSurrogate<> four_d_surrogate( data );
 
   QUESO::GslVector domainVector(paramSpace.zeroVector());
   domainVector[0] = -0.4;

--- a/test/test_StatisticalInverseProblem/test_LlhdTargetOutput.C
+++ b/test/test_StatisticalInverseProblem/test_LlhdTargetOutput.C
@@ -6,7 +6,7 @@
 #include <queso/ScalarFunction.h>
 #include <queso/VectorSet.h>
 
-template<class V, class M>
+template<class V = QUESO::GslVector, class M = QUESO::GslMatrix>
 class Likelihood : public QUESO::BaseScalarFunction<V, M>
 {
 public:
@@ -41,8 +41,7 @@ int main(int argc, char ** argv) {
 
   QUESO::FullEnvironment env(MPI_COMM_WORLD, argv[1], "", NULL);
 
-  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
-      "param_", 1, NULL);
+  QUESO::VectorSpace<> paramSpace(env, "param_", 1, NULL);
 
   QUESO::GslVector paramMins(paramSpace.zeroVector());
   QUESO::GslVector paramMaxs(paramSpace.zeroVector());
@@ -52,19 +51,15 @@ int main(int argc, char ** argv) {
   paramMins.cwSet(min_val);
   paramMaxs.cwSet(max_val);
 
-  QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix> paramDomain("param_",
-      paramSpace, paramMins, paramMaxs);
+  QUESO::BoxSubset<> paramDomain("param_", paramSpace, paramMins, paramMaxs);
 
-  QUESO::UniformVectorRV<QUESO::GslVector, QUESO::GslMatrix> priorRv("prior_",
-      paramDomain);
+  QUESO::UniformVectorRV<> priorRv("prior_", paramDomain);
 
-  Likelihood<QUESO::GslVector, QUESO::GslMatrix> lhood("llhd_", paramDomain);
+  Likelihood<> lhood("llhd_", paramDomain);
 
-  QUESO::GenericVectorRV<QUESO::GslVector, QUESO::GslMatrix>
-    postRv("post_", paramSpace);
+  QUESO::GenericVectorRV<> postRv("post_", paramSpace);
 
-  QUESO::StatisticalInverseProblem<QUESO::GslVector, QUESO::GslMatrix>
-    ip("", NULL, priorRv, lhood, postRv);
+  QUESO::StatisticalInverseProblem<> ip("", NULL, priorRv, lhood, postRv);
 
   QUESO::GslVector paramInitials(paramSpace.zeroVector());
   paramInitials[0] = 0.0;


### PR DESCRIPTION
I decided to have a go at setting `GslVector` and `GslMatrix` as default template parameters so the user didn't have to do so much typing to create instantiations of `QUESO`'s classes.  Everything compiles and the tests pass locally and on Travis.

While not necessary, it might be a good idea to refactor the examples to utilise these to encourage new users to take advantage of this new pattern.  I think this is also serves as a good middle ground between now and removing the templates entirely, thus breaking backwards compatibility.