### PR TITLE
Deprecate `UQ_*` macros

### DIFF
--- a/src/basic/src/DiscreteSubset.C
+++ b/src/basic/src/DiscreteSubset.C
@@ -35,6 +35,8 @@ DiscreteSubset<V,M>::DiscreteSubset(const char* prefix,
   : VectorSubset<V,M>(prefix, vectorSpace, 0.),
     m_elements(elements.size(),NULL)
 {
+  queso_deprecated();
+
   m_volume = 0.;
   UQ_FATAL_TEST_MACRO(true,
                       m_env.worldRank(),
@@ -46,12 +48,15 @@ DiscreteSubset<V,M>::DiscreteSubset(const char* prefix,
 template<class V, class M>
 DiscreteSubset<V,M>::~DiscreteSubset()
 {
+  queso_deprecated();
 }
 
 // Mathematical methods
 template<class V, class M>
 bool DiscreteSubset<V,M>::contains(const V& vec) const
 {
+  queso_deprecated();
+
   UQ_FATAL_TEST_MACRO(true,
                       m_env.worldRank(),
                       "DiscreteSubset<V,M>::contains()",
@@ -64,6 +69,8 @@ bool DiscreteSubset<V,M>::contains(const V& vec) const
 template <class V, class M>
 void DiscreteSubset<V,M>::print(std::ostream& os) const
 {
+  queso_deprecated();
+
   os << "In DiscreteSubset<V,M>::print()"
      << ": nothing to print"
      << std::endl;

--- a/src/core/inc/Defines.h
+++ b/src/core/inc/Defines.h
@@ -174,7 +174,32 @@ private:
   void copy(const EnvOptionsValues& src);
 };
 
-//! Macros
+// Macros
+
+// The following code is a copy-pasta from libmesh.  The same licence applies,
+// so we're good here.
+//
+// The queso_do_once macro helps us avoid redundant repeated
+// repetitions of the same warning messages
+#undef queso_do_once
+#define queso_do_once(do_this)             \
+  do {                                     \
+    static bool did_this_already = false;  \
+    if (!did_this_already) {               \
+      did_this_already = true;             \
+      do_this;                             \
+    } } while (0)
+
+// The queso_warning macro outputs a file/line/time stamped warning
+// message, if warnings are enabled.
+#define queso_warning(message)         \
+  queso_do_once(std::cerr << message  \
+                << __FILE__ << ", line " << __LINE__ << ", compiled " << __DATE__ << " at " << __TIME__ << " ***" << std::endl;)
+
+// The queso_deprecated macro warns that you are using obsoleted code
+#define queso_deprecated()  \
+  queso_warning("*** Warning:  This code is deprecated and likely to be removed in future library versions.");
+
 #define UQ_RC_MACRO(macroIRc,givenRank,where,what,retValue) \
   if (macroIRc) {                                           \
     int macroRank = givenRank;                              \

--- a/src/core/inc/Defines.h
+++ b/src/core/inc/Defines.h
@@ -198,9 +198,10 @@ private:
 
 // The queso_deprecated macro warns that you are using obsoleted code
 #define queso_deprecated()  \
-  queso_warning("*** Warning:  This code is deprecated and likely to be removed in future library versions.");
+  queso_warning("*** Warning, this code is deprecated and likely to be removed in future library versions:  ");
 
 #define UQ_RC_MACRO(macroIRc,givenRank,where,what,retValue) \
+  queso_deprecated();                                       \
   if (macroIRc) {                                           \
     int macroRank = givenRank;                              \
     if (macroRank < 0) {                                    \
@@ -216,6 +217,7 @@ private:
   }
 
 #define UQ_TEST_MACRO(test,givenRank,where,what,retValue) \
+  queso_deprecated();                                     \
   if (test) {                                             \
     int macroRank = givenRank;                            \
     if (macroRank < 0) {                                  \
@@ -230,6 +232,7 @@ private:
   }
 
 #define UQ_FATAL_RC_MACRO(macroIRc,givenRank,where,what) \
+  queso_deprecated();                                    \
   if (macroIRc) {                                        \
     int macroRank = givenRank;                           \
     if (macroRank < 0) {                                 \
@@ -246,6 +249,7 @@ private:
   }
 
 #define UQ_FATAL_TEST_MACRO(test,givenRank,where,what)  \
+  queso_deprecated();                                   \
   if (test) {                                           \
     int macroRank = givenRank;                          \
     if (macroRank < 0) {                                \

--- a/src/stats/src/FiniteDistribution.C
+++ b/src/stats/src/FiniteDistribution.C
@@ -36,6 +36,8 @@ FiniteDistribution::FiniteDistribution(
   m_prefix ((std::string)(prefix)+"fd_"),
   m_weights(inpWeights.size(),0.)
 {
+  queso_deprecated();
+
   if ((m_env.subDisplayFile()) && (m_env.displayVerbosity() >= 5)) {
     *m_env.subDisplayFile() << "Entering FiniteDistribution::constructor()"
                             << ": prefix = " << m_prefix
@@ -124,6 +126,8 @@ FiniteDistribution::FiniteDistribution(
 // Destructor ---------------------------------------
 FiniteDistribution::~FiniteDistribution()
 {
+  queso_deprecated();
+
   m_map.empty();
   m_weights.clear();
 }
@@ -131,18 +135,24 @@ FiniteDistribution::~FiniteDistribution()
 const BaseEnvironment&
 FiniteDistribution::env() const
 {
+  queso_deprecated();
+
   return m_env;
 }
 // Stats methods-------------------------------------
 const std::vector<double>&
 FiniteDistribution::weights() const
 {
+  queso_deprecated();
+
   return m_weights;
 }
 //---------------------------------------------------
 unsigned int
 FiniteDistribution::sample() const
 {
+  queso_deprecated();
+
   unsigned int result = 0;
 
   double aux = m_env.rngObject()->uniformSample();


### PR DESCRIPTION
Fixes #74.

Note:  #343 should be merged before this (that's where I added the `queso_deprecated()` macro).