### PR TITLE
Refactor inputs to StatisticalInverseProblem

### DIFF
--- a/inc/queso/Makefile.am
+++ b/inc/queso/Makefile.am
@@ -27,6 +27,7 @@ BUILT_SOURCES += VectorSequence.h
 BUILT_SOURCES += VectorSet.h
 BUILT_SOURCES += VectorSpace.h
 BUILT_SOURCES += VectorSubset.h
+BUILT_SOURCES += BaseInputOptions.h
 BUILT_SOURCES += BasicPdfsBase.h
 BUILT_SOURCES += BasicPdfsBoost.h
 BUILT_SOURCES += BasicPdfsGsl.h
@@ -225,6 +226,8 @@ VectorSet.h: $(top_srcdir)/src/basic/inc/VectorSet.h
 VectorSpace.h: $(top_srcdir)/src/basic/inc/VectorSpace.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 VectorSubset.h: $(top_srcdir)/src/basic/inc/VectorSubset.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+BaseInputOptions.h: $(top_srcdir)/src/core/inc/BaseInputOptions.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 BasicPdfsBase.h: $(top_srcdir)/src/core/inc/BasicPdfsBase.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -78,6 +78,7 @@ libqueso_la_SOURCES += core/src/DistArray.C
 libqueso_la_SOURCES += core/src/Optimizer.C
 libqueso_la_SOURCES += core/src/GslOptimizer.C
 libqueso_la_SOURCES += core/src/OptimizerMonitor.C
+libqueso_la_SOURCES += core/src/BaseInputOptions.C
 
 
 # Sources that need libmesh
@@ -293,6 +294,7 @@ libqueso_include_HEADERS += core/inc/Vector.h
 libqueso_include_HEADERS += core/inc/Optimizer.h
 libqueso_include_HEADERS += core/inc/GslOptimizer.h
 libqueso_include_HEADERS += core/inc/OptimizerMonitor.h
+libqueso_include_HEADERS += core/inc/BaseInputOptions.h
 
 # Headers that need libmesh
 libqueso_include_HEADERS += core/inc/FunctionBase.h

--- a/src/core/inc/BaseInputOptions.h
+++ b/src/core/inc/BaseInputOptions.h
@@ -49,10 +49,11 @@ public:
 private:
   const BaseEnvironment * m_env;
 
-  const boost::program_options::options_description * m_optionsDescription;
-
   virtual void defineOptions() = 0;
   virtual void getOptionValues() = 0;
+
+protected:
+  boost::program_options::options_description * m_optionsDescription;
 };
 
 }  // End namespace QUESO

--- a/src/core/inc/BaseInputOptions.h
+++ b/src/core/inc/BaseInputOptions.h
@@ -40,14 +40,36 @@ class BaseEnvironment;
 class BaseInputOptions
 {
 public:
+  //! Constructor that sets the internal environment
   BaseInputOptions(const BaseEnvironment * env);
+
+  //! Default constructor that sets m_env to NULL
+  /*!
+   * The use-case for m_env being NULL is that options are *not* read in from
+   * a file but are instead wholly provided by the user.
+   */
   BaseInputOptions();
+
+  //! Destructor
+  /*!
+   * Deletes m_optionsDescription, but not m_env
+   */
   virtual ~BaseInputOptions();
 
+  //! Calls the relevant QUESO BaseEnvironment methods to scan the input file
   void scanOptionsValues();
 
 private:
+  //! Subclasses implement this to *define* input options
+  /*!
+   * This will act on the boost-specific m_optionsDescription
+   */
   virtual void defineOptions() = 0;
+
+  //! Subclasses implement this to *set* input options from an input string
+  /*!
+   * This will act on the boost-specific m_optionsDescription
+   */
   virtual void getOptionValues() = 0;
 
 protected:

--- a/src/core/inc/BaseInputOptions.h
+++ b/src/core/inc/BaseInputOptions.h
@@ -47,12 +47,11 @@ public:
   void scanOptionsValues();
 
 private:
-  const BaseEnvironment * m_env;
-
   virtual void defineOptions() = 0;
   virtual void getOptionValues() = 0;
 
 protected:
+  const BaseEnvironment * m_env;
   boost::program_options::options_description * m_optionsDescription;
 };
 

--- a/src/core/inc/BaseInputOptions.h
+++ b/src/core/inc/BaseInputOptions.h
@@ -1,0 +1,51 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef UQ_BASE_INPUT_OPTIONS_H
+#define UQ_BASE_INPUT_OPTIONS_H
+
+namespace QUESO {
+
+class BaseEnvironment;
+
+class BaseInputOptions
+{
+public:
+  BaseInputOptions(const BaseEnvironment & env);
+  ~BaseInputOptions();
+
+  void scanOptionsValues();
+
+private:
+  const BaseEnvironment & m_env;
+
+  const boost::program_options::options_description * m_optionsDescription;
+
+  virtual void defineOptions() = 0;
+  virtual void getOptionValues() = 0;
+};
+
+}  // End namespace QUESO
+
+#endif // UQ_BASE_INPUT_OPTIONS_H

--- a/src/core/inc/BaseInputOptions.h
+++ b/src/core/inc/BaseInputOptions.h
@@ -42,7 +42,7 @@ class BaseInputOptions
 public:
   BaseInputOptions(const BaseEnvironment * env);
   BaseInputOptions();
-  ~BaseInputOptions();
+  virtual ~BaseInputOptions();
 
   void scanOptionsValues();
 

--- a/src/core/inc/BaseInputOptions.h
+++ b/src/core/inc/BaseInputOptions.h
@@ -40,13 +40,14 @@ class BaseEnvironment;
 class BaseInputOptions
 {
 public:
-  BaseInputOptions(const BaseEnvironment & env);
+  BaseInputOptions(const BaseEnvironment * env);
+  BaseInputOptions();
   ~BaseInputOptions();
 
   void scanOptionsValues();
 
 private:
-  const BaseEnvironment & m_env;
+  const BaseEnvironment * m_env;
 
   const boost::program_options::options_description * m_optionsDescription;
 

--- a/src/core/inc/BaseInputOptions.h
+++ b/src/core/inc/BaseInputOptions.h
@@ -25,6 +25,14 @@
 #ifndef UQ_BASE_INPUT_OPTIONS_H
 #define UQ_BASE_INPUT_OPTIONS_H
 
+namespace boost
+{
+  namespace program_options
+  {
+    class options_description;
+  }
+}
+
 namespace QUESO {
 
 class BaseEnvironment;

--- a/src/core/src/BaseInputOptions.C
+++ b/src/core/src/BaseInputOptions.C
@@ -1,0 +1,65 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/Environment.h>
+#include <queso/BaseInputOptions.h>
+
+namespace QUESO {
+
+BaseInputOptions::BaseInputOptions(const BaseEnvironment & env)
+  :
+    m_env(env),
+    m_optionsDescription(new po::options_description("Input options"))
+{
+}
+
+BaseInputOptions::~BaseInputOptions()
+{
+  if (m_optionsDescription) {
+    delete m_optionsDescription;
+  }
+}
+
+void
+BaseInputOptions::scanOptionsValues()
+{
+  UQ_FATAL_TEST_MACRO(m_optionsDescription == NULL,
+                      m_env.worldRank(),
+                      "BaseInputOptions::scanOptionsValues()",
+                      "m_optionsDescription variable is NULL");
+
+  defineOptions();
+  m_env.scanInputFileForMyOptions(*m_optionsDescription);
+  getOptionValues();
+
+  // if (m_env.subDisplayFile() != NULL) {
+  //   *m_env.subDisplayFile() << "In BaseInputOptions::scanOptionsValues()"
+  //                           << ": after reading values of options with prefix '" << m_prefix
+  //                           << "', state of  object is:"
+  //                           << "\n" << *this
+  //                           << std::endl;
+  // }
+}
+
+}  // End namespace QUESO

--- a/src/core/src/BaseInputOptions.C
+++ b/src/core/src/BaseInputOptions.C
@@ -27,9 +27,16 @@
 
 namespace QUESO {
 
-BaseInputOptions::BaseInputOptions(const BaseEnvironment & env)
+BaseInputOptions::BaseInputOptions(const BaseEnvironment * env)
   :
     m_env(env),
+    m_optionsDescription(new po::options_description("Input options"))
+{
+}
+
+BaseInputOptions::BaseInputOptions()
+  :
+    m_env(NULL),
     m_optionsDescription(new po::options_description("Input options"))
 {
 }
@@ -45,13 +52,16 @@ void
 BaseInputOptions::scanOptionsValues()
 {
   UQ_FATAL_TEST_MACRO(m_optionsDescription == NULL,
-                      m_env.worldRank(),
+                      (*m_env).worldRank(),
                       "BaseInputOptions::scanOptionsValues()",
                       "m_optionsDescription variable is NULL");
 
-  defineOptions();
-  m_env.scanInputFileForMyOptions(*m_optionsDescription);
-  getOptionValues();
+  // If it's NULL then the defaults are used
+  if (m_env != NULL) {
+    defineOptions();
+    (*m_env).scanInputFileForMyOptions(*m_optionsDescription);
+    getOptionValues();
+  }
 
   // if (m_env.subDisplayFile() != NULL) {
   //   *m_env.subDisplayFile() << "In BaseInputOptions::scanOptionsValues()"

--- a/src/stats/inc/StatisticalInverseProblem.h
+++ b/src/stats/inc/StatisticalInverseProblem.h
@@ -228,8 +228,7 @@ private:
         ScalarSequence      <double>*    m_logLikelihoodValues;
         ScalarSequence      <double>*    m_logTargetValues;
 
-        SipOptionsValues                  m_alternativeOptionsValues;
-        StatisticalInverseProblemOptions* m_optionsObj;
+        const SipOptionsValues * m_optionsObj;
 
         bool                              m_seedWithMAPEstimator;
 

--- a/src/stats/inc/StatisticalInverseProblemOptions.h
+++ b/src/stats/inc/StatisticalInverseProblemOptions.h
@@ -87,8 +87,18 @@ public:
 #endif
 
   //MhOptionsValues m_mhOptionsValues;
+  std::string m_prefix;
 
 private:
+  // The input options as strings so we can parse the input file later
+  std::string                   m_option_help;
+  std::string                   m_option_computeSolution;
+  std::string                   m_option_dataOutputFileName;
+  std::string                   m_option_dataOutputAllowedSet;
+#ifdef UQ_SIP_READS_SOLVER_OPTION
+  std::string                   m_option_solver;
+#endif
+
   // We have these two because of we don't want to break backwards
   // compatibility
   virtual void defineOptions();

--- a/src/stats/inc/StatisticalInverseProblemOptions.h
+++ b/src/stats/inc/StatisticalInverseProblemOptions.h
@@ -64,6 +64,7 @@ public:
   //! Default constructor.
   /*! Assigns the default suite of options to the Statistical Inverse Problem.*/
   SipOptionsValues            ();
+  SipOptionsValues(const BaseEnvironment * env, const char * prefix);
 
   //! Copy constructor.
   /*! It assigns the same options values from  \c src to \c this.*/
@@ -79,6 +80,8 @@ public:
   SipOptionsValues& operator= (const SipOptionsValues& rhs);
   //@}
 
+  std::string m_prefix;
+
   bool                   m_computeSolution;
   std::string            m_dataOutputFileName;
   std::set<unsigned int> m_dataOutputAllowedSet;
@@ -87,7 +90,6 @@ public:
 #endif
 
   //MhOptionsValues m_mhOptionsValues;
-  std::string m_prefix;
 
 private:
   // The input options as strings so we can parse the input file later

--- a/src/stats/inc/StatisticalInverseProblemOptions.h
+++ b/src/stats/inc/StatisticalInverseProblemOptions.h
@@ -22,11 +22,11 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/BaseInputOptions.h>
+#include <queso/Environment.h>
+
 #ifndef UQ_SIP_OPTIONS_H
 #define UQ_SIP_OPTIONS_H
-
-#include <queso/Environment.h>
-//#include <queso/MetropolisHastingsSGOptions.h>
 
 #undef UQ_SIP_READS_SOLVER_OPTION
 
@@ -56,7 +56,7 @@ namespace QUESO {
  * values for such options if no input file is available.
  */
 
-class SipOptionsValues
+class SipOptionsValues : public BaseInputOptions
 {
 public:
   //! @name Constructor/Destructor methods
@@ -70,7 +70,7 @@ public:
   SipOptionsValues            (const SipOptionsValues& src);
 
   //! Destructor
-  ~SipOptionsValues            ();
+  virtual ~SipOptionsValues            ();
   //@}
 
   //! @name Set methods
@@ -89,6 +89,11 @@ public:
   //MhOptionsValues m_mhOptionsValues;
 
 private:
+  // We have these two because of we don't want to break backwards
+  // compatibility
+  virtual void defineOptions();
+  virtual void getOptionValues();
+
   //! Copies the option values from \c src to \c this.
   void copy(const SipOptionsValues& src);
 };

--- a/src/stats/src/StatisticalInverseProblemOptions.C
+++ b/src/stats/src/StatisticalInverseProblemOptions.C
@@ -34,6 +34,7 @@ namespace QUESO {
 // Default constructor -----------------------------
 SipOptionsValues::SipOptionsValues()
   :
+    BaseInputOptions(),
   m_computeSolution     (UQ_SIP_COMPUTE_SOLUTION_ODV     ),
   m_dataOutputFileName  (UQ_SIP_DATA_OUTPUT_FILE_NAME_ODV)
 //m_dataOutputAllowedSet(),
@@ -60,6 +61,18 @@ SipOptionsValues::operator=(const SipOptionsValues& rhs)
   return *this;
 }
 // Private methods-----------------------------------
+void
+SipOptionsValues::defineOptions()
+{
+  queso_not_implemented();
+}
+
+void
+SipOptionsValues::getOptionValues()
+{
+  queso_not_implemented();
+}
+
 void
 SipOptionsValues::copy(const SipOptionsValues& src)
 {

--- a/src/stats/src/StatisticalInverseProblemOptions.C
+++ b/src/stats/src/StatisticalInverseProblemOptions.C
@@ -36,6 +36,26 @@ namespace QUESO {
 SipOptionsValues::SipOptionsValues()
   :
     BaseInputOptions(),
+  m_prefix("ip_"),
+  m_computeSolution     (UQ_SIP_COMPUTE_SOLUTION_ODV     ),
+  m_dataOutputFileName  (UQ_SIP_DATA_OUTPUT_FILE_NAME_ODV),
+//m_dataOutputAllowedSet(),
+  m_option_help                (m_prefix + "help"                ),
+  m_option_computeSolution     (m_prefix + "computeSolution"     ),
+  m_option_dataOutputFileName  (m_prefix + "dataOutputFileName"  ),
+  m_option_dataOutputAllowedSet(m_prefix + "dataOutputAllowedSet")
+#ifdef UQ_SIP_READS_SOLVER_OPTION
+  m_option_solver              (m_prefix + "solver"              ),
+  m_solverString        (UQ_SIP_SOLVER_ODV)
+#endif
+{
+}
+
+SipOptionsValues::SipOptionsValues(const BaseEnvironment * env, const char *
+    prefix)
+  :
+    BaseInputOptions(env),
+  m_prefix((std::string)(prefix) + "ip_"),
   m_computeSolution     (UQ_SIP_COMPUTE_SOLUTION_ODV     ),
   m_dataOutputFileName  (UQ_SIP_DATA_OUTPUT_FILE_NAME_ODV),
 //m_dataOutputAllowedSet(),

--- a/src/stats/src/StatisticalInverseProblemOptions.C
+++ b/src/stats/src/StatisticalInverseProblemOptions.C
@@ -22,6 +22,7 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/Defines.h>
 #include <queso/StatisticalInverseProblemOptions.h>
 #include <queso/Miscellaneous.h>
 
@@ -95,7 +96,7 @@ SipOptionsValues::copy(const SipOptionsValues& src)
 StatisticalInverseProblemOptions::StatisticalInverseProblemOptions(
   const BaseEnvironment& env,
   const char*                   prefix)
-  :
+:
   m_ov                         (),
   m_prefix                     ((std::string)(prefix) + "ip_"),
   m_env                        (env),
@@ -108,6 +109,7 @@ StatisticalInverseProblemOptions::StatisticalInverseProblemOptions(
   m_option_solver              (m_prefix + "solver"              )
 #endif
 {
+  queso_deprecated();
   UQ_FATAL_TEST_MACRO(m_env.optionsInputFileName() == "",
                       m_env.worldRank(),
                       "StatisticalInverseProblemOptions::constructor(1)",
@@ -119,7 +121,7 @@ StatisticalInverseProblemOptions::StatisticalInverseProblemOptions(
   const BaseEnvironment&  env,
   const char*                    prefix,
   const SipOptionsValues& alternativeOptionsValues)
-  :
+:
   m_ov                         (alternativeOptionsValues),
   m_prefix                     ((std::string)(prefix) + "ip_"),
   m_env                        (env),
@@ -132,6 +134,8 @@ StatisticalInverseProblemOptions::StatisticalInverseProblemOptions(
   m_option_solver              (m_prefix + "solver"              )
 #endif
 {
+  queso_deprecated();
+
   UQ_FATAL_TEST_MACRO(m_env.optionsInputFileName() != "",
                       m_env.worldRank(),
                       "StatisticalInverseProblemOptions::constructor(2)",
@@ -148,6 +152,7 @@ StatisticalInverseProblemOptions::StatisticalInverseProblemOptions(
 // Destructor --------------------------------------
 StatisticalInverseProblemOptions::~StatisticalInverseProblemOptions()
 {
+  queso_deprecated();
   if (m_optionsDesc) delete m_optionsDesc;
 }
 
@@ -178,10 +183,13 @@ StatisticalInverseProblemOptions::scanOptionsValues()
 
   return;
 }
+
 // --------------------------------------------------
 void
 StatisticalInverseProblemOptions::print(std::ostream& os) const
 {
+  queso_deprecated();
+
   os << "\n" << m_option_computeSolution      << " = " << m_ov.m_computeSolution
      << "\n" << m_option_dataOutputFileName   << " = " << m_ov.m_dataOutputFileName;
   os << "\n" << m_option_dataOutputAllowedSet << " = ";
@@ -199,6 +207,8 @@ StatisticalInverseProblemOptions::print(std::ostream& os) const
 void
 StatisticalInverseProblemOptions::defineMyOptions(po::options_description& optionsDesc) const
 {
+  queso_deprecated();
+
   optionsDesc.add_options()
     (m_option_help.c_str(),                                                                                              "produce help message for statistical inverse problem")
     (m_option_computeSolution.c_str(),      po::value<bool       >()->default_value(UQ_SIP_COMPUTE_SOLUTION_ODV       ), "compute solution process"                            )
@@ -215,6 +225,8 @@ StatisticalInverseProblemOptions::defineMyOptions(po::options_description& optio
 void
 StatisticalInverseProblemOptions::getMyOptionValues(po::options_description& optionsDesc)
 {
+  queso_deprecated();
+
   if (m_env.allOptionsMap().count(m_option_help)) {
     if (m_env.subDisplayFile()) {
       *m_env.subDisplayFile() << optionsDesc
@@ -258,6 +270,7 @@ StatisticalInverseProblemOptions::getMyOptionValues(po::options_description& opt
 
 std::ostream& operator<<(std::ostream& os, const StatisticalInverseProblemOptions& obj)
 {
+  queso_deprecated();
   obj.print(os);
 
   return os;


### PR DESCRIPTION
This PR implements what I think (with advice from @pbauman) is a good start for #346.  I've only done it for the `StatisticalInverseProblem` class because there aren't too many options for that so it's easier to see what's going on.

To summarise, I've deprecated all the methods in `StatisticalInverseProblemOptions`, which was created internally by `StatisticalInverseProblem`.  So we're not breaking backwards compatibility here.  I've moved all the parsing functionality into `SipOptionsValues`, which is the type of object that the user passes to the `StatisticalInverseProblem` constructor for custom options set programmatically.  All the options that were in `SipOptionsValues` have not moved, so we're not breaking backwards compatibility here either.  The `StatisticalInverseProblem` class now creates a `SipOptionsValues` object internally instead of a `StatisticalInverseProblemOptions`.  Lastly, I factored out the `scanOptionsValues` method into a `BaseInputOptions` class, because this method is common for all the other input option classes (which I haven't touched in this PR).  Later down the road, we'll get some code re-use out of that method.

Note that the class hierarchy is only one level.  The base class does the `boost`-specific parsing.  One could envisage inserting class in between `BaseInputOptions` and `SipOptionsValues` called `BaseBoostInputOptions` and making the `BaseBoostInputOptions` do all the boost-specific parsing instead.  This is would open up the opportunity to transition to `GetPot` for input file parsing down the road.  I haven't done that in this PR, though.

Tests are passing locally for me.

Feedback appreciated.