### PR TITLE
Default to silent rules for build system

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,7 @@ AX_PREFIX_CONFIG_H(config_queso.h,QUESO,config_queso.h.tmp)
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CANONICAL_TARGET()
 AM_INIT_AUTOMAKE([color-tests subdir-objects])
+AM_SILENT_RULES(yes)  # use silent rules where available - automake 1.11
 
 # Release versioning
 


### PR DESCRIPTION
Instead of having the full compile line emitted by default when
building, we will instead get something like
CXX target_name
Then, if we want a verbose build, you do make V=1 instead. This looks
better, IMHO, when building, but it also makes warnings stick out
like a sore thumb, which is also useful.