### PR TITLE
Interpolation Surrogate

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -209,6 +209,7 @@ AC_CONFIG_FILES([
   test/test_Regression/test_jeffreys_samples.m
   test/test_Regression/adaptedcov_input.txt
   test/test_gaussian_likelihoods/queso_input.txt
+  test/test_InterpolationSurrogate/queso_input.txt
   doxygen/Makefile
   doxygen/queso.dox
   doxygen/txt_common/about_vpath.page

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -412,6 +412,20 @@ blockDiagonalCovarianceRandomCoefficients_SOURCES = gaussian_likelihoods/blockDi
 blockDiagonalCovarianceRandomCoefficients_LDADD = $(top_builddir)/src/libqueso.la
 blockDiagonalCovarianceRandomCoefficients_CPPFLAGS = -I$(top_srcdir)/examples/gaussian_likelihoods/blockDiagonalCovarianceRandomCoefficients $(QUESO_CPPFLAGS)
 
+####################################
+# Interpolation Surrogate examples #
+####################################
+interpsurrgdir = $(prefix)/examples/interpolation_surrogate
+
+interpsurrg_PROGRAMS = 4d_interp
+4d_interp_SOURCES = interpolation_surrogate/4d_interp.C
+4d_interp_LDADD = $(top_builddir)/src/libqueso.la
+4d_interp_CPPFLAGS = $(QUESO_CPPFLAGS)
+
+dist_interpsurrg_DATA =
+dist_interpsurrg_DATA += ${4d_interp_SOURCES}
+dist_interpsurrg_DATA += interpolation_surrogate/input.in
+
 if CODE_COVERAGE_ENABLED
   CLEANFILES = *.gcda *.gcno
 endif

--- a/examples/interpolation_surrogate/4d_interp.C
+++ b/examples/interpolation_surrogate/4d_interp.C
@@ -1,0 +1,145 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/BoxSubset.h>
+#include <queso/LinearLagrangeInterpolationSurrogate.h>
+#include <queso/InterpolationSurrogateBuilder.h>
+
+double four_d_fn( double x, double y, double z, double a );
+
+/* We subclass InterpolationSurrogateBuilder to implement our model evaluation.
+   In this case, it just calls the simple function, but you may do much more
+   complicated things. */
+template<class V, class M>
+class MyInterpolationBuilder : public QUESO::InterpolationSurrogateBuilder<V,M>
+{
+public:
+  MyInterpolationBuilder( QUESO::InterpolationSurrogateData<V,M>& data )
+    : QUESO::InterpolationSurrogateBuilder<V,M>(data)
+  {};
+
+  virtual ~MyInterpolationBuilder(){};
+
+  virtual double evaluate_model( const V & domainVector ) const
+  { queso_assert_equal_to( domainVector.sizeGlobal(), 4);
+    return four_d_fn(domainVector[0],domainVector[1],domainVector[2],domainVector[3]); };
+};
+
+int main(int argc, char ** argv)
+{
+  if( argc < 2 )
+    {
+      std::cerr << "ERROR: Must run program as '4d_interp <inputfile>'." << std::endl;
+      exit(1);
+    }
+  std::string filename = argv[1];
+
+  MPI_Init(&argc, &argv);
+  QUESO::FullEnvironment env(MPI_COMM_WORLD, filename.c_str(), "", NULL);
+
+  int return_flag = 0;
+
+  // Define the parameter space. It's 4-dimensional in this example.
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>
+    paramSpace(env,"param_", 4, NULL);
+
+  // Define parameter bounds
+  QUESO::GslVector paramMins(paramSpace.zeroVector());
+  paramMins[0] = -1;
+  paramMins[1] = -0.5;
+  paramMins[2] = 1.1;
+  paramMins[3] = -2.1;
+
+  QUESO::GslVector paramMaxs(paramSpace.zeroVector());
+  paramMaxs[0] = 0.9;
+  paramMaxs[1] = 3.14;
+  paramMaxs[2] = 2.1;
+  paramMaxs[3] = 4.1;
+
+  // Define parameter domain.
+  QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix>
+    paramDomain("param_", paramSpace, paramMins, paramMaxs);
+
+  // How many points to use in each coordinate direction of parameter space.
+  // Since we're using an interpolation surrogate, it will evenly space the points
+  // in each coordinate direction. These are the points at which the model
+  // will be evaluated.
+  std::vector<unsigned int> n_points(4);
+  n_points[0] = 101;
+  n_points[1] = 51;
+  n_points[2] = 31;
+  n_points[3] = 41;
+
+  // Construct data object.
+  QUESO::InterpolationSurrogateData<QUESO::GslVector, QUESO::GslMatrix>
+    data(paramDomain,n_points);
+
+  // Construct builder. The builder will add the values from the model evaluations
+  // so the data object must stay alive.
+  MyInterpolationBuilder<QUESO::GslVector,QUESO::GslMatrix>
+    builder( data );
+
+  // The expensive part. The builder will now evaluate the model for all the
+  // desired points in parameter space.
+  builder.build_values();
+
+  // The builder put the model values into the data, so now we can give the data
+  // to the interpolation surrogate. This object can now be used in a likelihood
+  // function for example. Here, we just illustrate calling the surrogate model
+  // evaluation.
+  QUESO::LinearLagrangeInterpolationSurrogate<QUESO::GslVector,QUESO::GslMatrix>
+    four_d_surrogate( data );
+
+  // A point in parameter space at which we want to use the surrogate
+  QUESO::GslVector domainVector(paramSpace.zeroVector());
+  domainVector[0] = -0.4;
+  domainVector[1] = 3.0;
+  domainVector[2] = 1.5;
+  domainVector[3] = 1.65;
+
+  // Evaluate the surrogate model at the given point in parameter space
+  // Because the exact function is quadrilinear, our interpolated value
+  // should be exact.
+  double value = four_d_surrogate.evaluate(domainVector);
+
+  std::cout << "======================================" << std::endl
+            << "Interpolated value: " << value << std::endl
+            << "Exact value: " << four_d_fn( domainVector[0],domainVector[1],domainVector[2],domainVector[3])
+            << std::endl
+            << "======================================" << std::endl;
+
+  MPI_Finalize();
+
+  return return_flag;
+}
+
+double four_d_fn( double x, double y, double z, double a )
+{
+  return 3.0 + 2.5*x - 3.1*y + 2.71*z + 3.14*a
+    + 0.1*x*y + 1.2*x*z + 0.5*y*z + 0.1*x*a + 1.1*y*a + 2.1*z*a
+    + 0.3*x*y*a + 0.5*x*z*a + 1.2*y*z*a + 0.9*x*y*z
+    + 2.5*x*y*z*a;
+}

--- a/examples/interpolation_surrogate/4d_interp.C
+++ b/examples/interpolation_surrogate/4d_interp.C
@@ -60,8 +60,6 @@ int main(int argc, char ** argv)
   MPI_Init(&argc, &argv);
   QUESO::FullEnvironment env(MPI_COMM_WORLD, filename.c_str(), "", NULL);
 
-  int return_flag = 0;
-
   // Define the parameter space. It's 4-dimensional in this example.
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>
     paramSpace(env,"param_", 4, NULL);
@@ -125,15 +123,24 @@ int main(int argc, char ** argv)
   // should be exact.
   double value = four_d_surrogate.evaluate(domainVector);
 
-  std::cout << "======================================" << std::endl
-            << "Interpolated value: " << value << std::endl
-            << "Exact value: " << four_d_fn( domainVector[0],domainVector[1],domainVector[2],domainVector[3])
-            << std::endl
-            << "======================================" << std::endl;
+  for( int r = 0; r < env.fullComm().NumProc(); r++ )
+    {
+      if( env.fullRank() == r )
+        {
+          std::cout << "======================================" << std::endl
+                    << "Processor: " << env.fullRank() << std::endl
+                    << "Interpolated value: " << value << std::endl
+                    << "Exact value: " << four_d_fn( domainVector[0],domainVector[1],domainVector[2],domainVector[3])
+                    << std::endl
+                    << "======================================" << std::endl;
+        }
+
+      MPI_Barrier(MPI_COMM_WORLD);
+    }
 
   MPI_Finalize();
 
-  return return_flag;
+  return 0;
 }
 
 double four_d_fn( double x, double y, double z, double a )

--- a/examples/interpolation_surrogate/input.in
+++ b/examples/interpolation_surrogate/input.in
@@ -1,0 +1,12 @@
+###############################################
+# UQ Environment
+###############################################
+env_help                 = 1
+env_numSubEnvironments   = 1
+env_subDisplayFileName   = output/display
+env_subDisplayAllowAll   = 0
+env_subDisplayAllowedSet = 0
+env_displayVerbosity     = 1000
+env_syncVerbosity        = 0
+env_seed                 = 0
+

--- a/inc/queso/Makefile.am
+++ b/inc/queso/Makefile.am
@@ -180,6 +180,7 @@ BUILT_SOURCES += WignerVectorRV.h
 BUILT_SOURCES += WignerVectorRealizer.h
 BUILT_SOURCES += InterpolationSurrogateBase.h
 BUILT_SOURCES += InterpolationSurrogateBuilder.h
+BUILT_SOURCES += InterpolationSurrogateData.h
 BUILT_SOURCES += LinearLagrangeInterpolationSurrogate.h
 BUILT_SOURCES += SurrogateBase.h
 BUILT_SOURCES += SurrogateBuilderBase.h
@@ -537,6 +538,8 @@ WignerVectorRealizer.h: $(top_srcdir)/src/stats/inc/WignerVectorRealizer.h
 InterpolationSurrogateBase.h: $(top_srcdir)/src/surrogates/inc/InterpolationSurrogateBase.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 InterpolationSurrogateBuilder.h: $(top_srcdir)/src/surrogates/inc/InterpolationSurrogateBuilder.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+InterpolationSurrogateData.h: $(top_srcdir)/src/surrogates/inc/InterpolationSurrogateData.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 LinearLagrangeInterpolationSurrogate.h: $(top_srcdir)/src/surrogates/inc/LinearLagrangeInterpolationSurrogate.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@

--- a/inc/queso/Makefile.am
+++ b/inc/queso/Makefile.am
@@ -181,6 +181,7 @@ BUILT_SOURCES += WignerVectorRealizer.h
 BUILT_SOURCES += InterpolationSurrogateBase.h
 BUILT_SOURCES += InterpolationSurrogateBuilder.h
 BUILT_SOURCES += InterpolationSurrogateData.h
+BUILT_SOURCES += InterpolationSurrogateHelper.h
 BUILT_SOURCES += LinearLagrangeInterpolationSurrogate.h
 BUILT_SOURCES += SurrogateBase.h
 BUILT_SOURCES += SurrogateBuilderBase.h
@@ -540,6 +541,8 @@ InterpolationSurrogateBase.h: $(top_srcdir)/src/surrogates/inc/InterpolationSurr
 InterpolationSurrogateBuilder.h: $(top_srcdir)/src/surrogates/inc/InterpolationSurrogateBuilder.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 InterpolationSurrogateData.h: $(top_srcdir)/src/surrogates/inc/InterpolationSurrogateData.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+InterpolationSurrogateHelper.h: $(top_srcdir)/src/surrogates/inc/InterpolationSurrogateHelper.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 LinearLagrangeInterpolationSurrogate.h: $(top_srcdir)/src/surrogates/inc/LinearLagrangeInterpolationSurrogate.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@

--- a/inc/queso/Makefile.am
+++ b/inc/queso/Makefile.am
@@ -179,6 +179,7 @@ BUILT_SOURCES += WignerJointPdf.h
 BUILT_SOURCES += WignerVectorRV.h
 BUILT_SOURCES += WignerVectorRealizer.h
 BUILT_SOURCES += InterpolationSurrogateBase.h
+BUILT_SOURCES += LinearLagrangeInterpolationSurrogate.h
 BUILT_SOURCES += SurrogateBase.h
 BUILT_SOURCES += config_queso.h
 BUILT_SOURCES += queso.h
@@ -532,6 +533,8 @@ WignerVectorRV.h: $(top_srcdir)/src/stats/inc/WignerVectorRV.h
 WignerVectorRealizer.h: $(top_srcdir)/src/stats/inc/WignerVectorRealizer.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 InterpolationSurrogateBase.h: $(top_srcdir)/src/surrogates/inc/InterpolationSurrogateBase.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+LinearLagrangeInterpolationSurrogate.h: $(top_srcdir)/src/surrogates/inc/LinearLagrangeInterpolationSurrogate.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 SurrogateBase.h: $(top_srcdir)/src/surrogates/inc/SurrogateBase.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@

--- a/inc/queso/Makefile.am
+++ b/inc/queso/Makefile.am
@@ -179,8 +179,10 @@ BUILT_SOURCES += WignerJointPdf.h
 BUILT_SOURCES += WignerVectorRV.h
 BUILT_SOURCES += WignerVectorRealizer.h
 BUILT_SOURCES += InterpolationSurrogateBase.h
+BUILT_SOURCES += InterpolationSurrogateBuilder.h
 BUILT_SOURCES += LinearLagrangeInterpolationSurrogate.h
 BUILT_SOURCES += SurrogateBase.h
+BUILT_SOURCES += SurrogateBuilderBase.h
 BUILT_SOURCES += config_queso.h
 BUILT_SOURCES += queso.h
 
@@ -534,9 +536,13 @@ WignerVectorRealizer.h: $(top_srcdir)/src/stats/inc/WignerVectorRealizer.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 InterpolationSurrogateBase.h: $(top_srcdir)/src/surrogates/inc/InterpolationSurrogateBase.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+InterpolationSurrogateBuilder.h: $(top_srcdir)/src/surrogates/inc/InterpolationSurrogateBuilder.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 LinearLagrangeInterpolationSurrogate.h: $(top_srcdir)/src/surrogates/inc/LinearLagrangeInterpolationSurrogate.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 SurrogateBase.h: $(top_srcdir)/src/surrogates/inc/SurrogateBase.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+SurrogateBuilderBase.h: $(top_srcdir)/src/surrogates/inc/SurrogateBuilderBase.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 config_queso.h: $(top_builddir)/config_queso.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@

--- a/inc/queso/Makefile.am
+++ b/inc/queso/Makefile.am
@@ -178,6 +178,8 @@ BUILT_SOURCES += VectorRealizer.h
 BUILT_SOURCES += WignerJointPdf.h
 BUILT_SOURCES += WignerVectorRV.h
 BUILT_SOURCES += WignerVectorRealizer.h
+BUILT_SOURCES += InterpolationSurrogateBase.h
+BUILT_SOURCES += SurrogateBase.h
 BUILT_SOURCES += config_queso.h
 BUILT_SOURCES += queso.h
 
@@ -528,6 +530,10 @@ WignerJointPdf.h: $(top_srcdir)/src/stats/inc/WignerJointPdf.h
 WignerVectorRV.h: $(top_srcdir)/src/stats/inc/WignerVectorRV.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 WignerVectorRealizer.h: $(top_srcdir)/src/stats/inc/WignerVectorRealizer.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+InterpolationSurrogateBase.h: $(top_srcdir)/src/surrogates/inc/InterpolationSurrogateBase.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+SurrogateBase.h: $(top_srcdir)/src/surrogates/inc/SurrogateBase.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 config_queso.h: $(top_builddir)/config_queso.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -249,6 +249,7 @@ libqueso_la_SOURCES += stats/src/GaussianLikelihoodBlockDiagonalCovarianceRandom
 # Sources from surrogates/src
 libqueso_la_SOURCES += surrogates/src/InterpolationSurrogateBase.C
 libqueso_la_SOURCES += surrogates/src/LinearLagrangeInterpolationSurrogate.C
+libqueso_la_SOURCES += surrogates/src/InterpolationSurrogateBuilder.C
 
 # Sources from gp/src
 
@@ -445,6 +446,8 @@ libqueso_include_HEADERS += stats/inc/GaussianLikelihoodBlockDiagonalCovarianceR
 libqueso_include_HEADERS += surrogates/inc/SurrogateBase.h
 libqueso_include_HEADERS += surrogates/inc/InterpolationSurrogateBase.h
 libqueso_include_HEADERS += surrogates/inc/LinearLagrangeInterpolationSurrogate.h
+libqueso_include_HEADERS += surrogates/inc/SurrogateBuilderBase.h
+libqueso_include_HEADERS += surrogates/inc/InterpolationSurrogateBuilder.h
 
 # Headers to install from gp/inc
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -248,6 +248,7 @@ libqueso_la_SOURCES += stats/src/GaussianLikelihoodBlockDiagonalCovarianceRandom
 
 # Sources from surrogates/src
 libqueso_la_SOURCES += surrogates/src/InterpolationSurrogateBase.C
+libqueso_la_SOURCES += surrogates/src/LinearLagrangeInterpolationSurrogate.C
 
 # Sources from gp/src
 
@@ -443,6 +444,7 @@ libqueso_include_HEADERS += stats/inc/GaussianLikelihoodBlockDiagonalCovarianceR
 # Headers to install from surrogates/inc
 libqueso_include_HEADERS += surrogates/inc/SurrogateBase.h
 libqueso_include_HEADERS += surrogates/inc/InterpolationSurrogateBase.h
+libqueso_include_HEADERS += surrogates/inc/LinearLagrangeInterpolationSurrogate.h
 
 # Headers to install from gp/inc
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -247,6 +247,7 @@ libqueso_la_SOURCES += stats/src/GaussianLikelihoodBlockDiagonalCovariance.C
 libqueso_la_SOURCES += stats/src/GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.C
 
 # Sources from surrogates/src
+libqueso_la_SOURCES += surrogates/src/InterpolationSurrogateData.C
 libqueso_la_SOURCES += surrogates/src/InterpolationSurrogateBase.C
 libqueso_la_SOURCES += surrogates/src/LinearLagrangeInterpolationSurrogate.C
 libqueso_la_SOURCES += surrogates/src/InterpolationSurrogateBuilder.C
@@ -444,6 +445,7 @@ libqueso_include_HEADERS += stats/inc/GaussianLikelihoodBlockDiagonalCovarianceR
 
 # Headers to install from surrogates/inc
 libqueso_include_HEADERS += surrogates/inc/SurrogateBase.h
+libqueso_include_HEADERS += surrogates/inc/InterpolationSurrogateData.h
 libqueso_include_HEADERS += surrogates/inc/InterpolationSurrogateBase.h
 libqueso_include_HEADERS += surrogates/inc/LinearLagrangeInterpolationSurrogate.h
 libqueso_include_HEADERS += surrogates/inc/SurrogateBuilderBase.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -246,6 +246,9 @@ libqueso_la_SOURCES += stats/src/GaussianLikelihoodFullCovarianceRandomCoefficie
 libqueso_la_SOURCES += stats/src/GaussianLikelihoodBlockDiagonalCovariance.C
 libqueso_la_SOURCES += stats/src/GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.C
 
+# Sources from surrogates/src
+libqueso_la_SOURCES += surrogates/src/InterpolationSurrogateBase.C
+
 # Sources from gp/src
 
 libqueso_la_SOURCES += gp/src/ExperimentModel.C
@@ -436,6 +439,10 @@ libqueso_include_HEADERS += stats/inc/GaussianLikelihoodFullCovariance.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodFullCovarianceRandomCoefficient.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodBlockDiagonalCovariance.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.h
+
+# Headers to install from surrogates/inc
+libqueso_include_HEADERS += surrogates/inc/SurrogateBase.h
+libqueso_include_HEADERS += surrogates/inc/InterpolationSurrogateBase.h
 
 # Headers to install from gp/inc
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -249,6 +249,7 @@ libqueso_la_SOURCES += stats/src/GaussianLikelihoodBlockDiagonalCovarianceRandom
 # Sources from surrogates/src
 libqueso_la_SOURCES += surrogates/src/InterpolationSurrogateData.C
 libqueso_la_SOURCES += surrogates/src/InterpolationSurrogateBase.C
+libqueso_la_SOURCES += surrogates/src/InterpolationSurrogateHelper.C
 libqueso_la_SOURCES += surrogates/src/LinearLagrangeInterpolationSurrogate.C
 libqueso_la_SOURCES += surrogates/src/InterpolationSurrogateBuilder.C
 
@@ -447,6 +448,7 @@ libqueso_include_HEADERS += stats/inc/GaussianLikelihoodBlockDiagonalCovarianceR
 libqueso_include_HEADERS += surrogates/inc/SurrogateBase.h
 libqueso_include_HEADERS += surrogates/inc/InterpolationSurrogateData.h
 libqueso_include_HEADERS += surrogates/inc/InterpolationSurrogateBase.h
+libqueso_include_HEADERS += surrogates/inc/InterpolationSurrogateHelper.h
 libqueso_include_HEADERS += surrogates/inc/LinearLagrangeInterpolationSurrogate.h
 libqueso_include_HEADERS += surrogates/inc/SurrogateBuilderBase.h
 libqueso_include_HEADERS += surrogates/inc/InterpolationSurrogateBuilder.h

--- a/src/surrogates/inc/InterpolationSurrogateBase.h
+++ b/src/surrogates/inc/InterpolationSurrogateBase.h
@@ -60,10 +60,24 @@ namespace QUESO
         This function will return the corresponding global index to which the value
         at i,j,k can be indexed. Ordering must be consistent between coord_indices
         and n_points. Must be ordered in increasing dimension. e.g. x,y,z,...
-        The user shouldn't need to call this method, this is public mainly to facilitate
-        testing. */
+        The user shouldn't need to call this method, this is public mainly to
+        facilitate testing. */
     unsigned int coordToGlobal( const std::vector<unsigned int>& coord_indices,
                                 const std::vector<unsigned int>& n_points ) const;
+
+    unsigned int dim() const
+    { return this->m_domain.vectorSpace().dimGlobal(); };
+
+    //! Lower bound of domain along dimension dim
+    double x_min( unsigned int dim ) const
+    { return this->m_domain.minValues()[dim]; };
+
+    //! Upper bound of domain along dimension dim
+    double x_max( unsigned int dim ) const
+    { return this->m_domain.maxValues()[dim]; };
+
+    //! Spacing between points along dimension dim
+    double spacing( unsigned int dim ) const;
 
   protected:
 

--- a/src/surrogates/inc/InterpolationSurrogateBase.h
+++ b/src/surrogates/inc/InterpolationSurrogateBase.h
@@ -54,16 +54,6 @@ namespace QUESO
 
     virtual ~InterpolationSurrogateBase(){};
 
-    //! Map coordinate indices to a singal global index.
-    /*! e.g. in 3-D, you pass in i,j,k and the n_points in each of the 3 directions.
-        This function will return the corresponding global index to which the value
-        at i,j,k can be indexed. Ordering must be consistent between coord_indices
-        and n_points. Must be ordered in increasing dimension. e.g. x,y,z,...
-        The user shouldn't need to call this method, this is public mainly to
-        facilitate testing. */
-    unsigned int coordToGlobal( const std::vector<unsigned int>& coord_indices,
-                                const std::vector<unsigned int>& n_points ) const;
-
   protected:
 
     const InterpolationSurrogateData<V,M>& m_data;

--- a/src/surrogates/inc/InterpolationSurrogateBase.h
+++ b/src/surrogates/inc/InterpolationSurrogateBase.h
@@ -28,6 +28,7 @@
 #include <queso/SurrogateBase.h>
 #include <queso/BoxSubset.h>
 #include <queso/VectorSpace.h>
+#include <queso/InterpolationSurrogateBuilder.h>
 
 namespace QUESO
 {
@@ -52,6 +53,11 @@ namespace QUESO
     InterpolationSurrogateBase(const BoxSubset<V,M> & domain,
                                const std::vector<unsigned int>& n_points,
                                const std::vector<double>& values);
+
+    //! Constructor
+    /*! We extract data from the SurrogateBuilder. Note that the builder
+        MUST live as long as this object since we only extract const&. */
+    InterpolationSurrogateBase( const InterpolationSurrogateBuilder<V,M>& builder );
 
     virtual ~InterpolationSurrogateBase(){};
 

--- a/src/surrogates/inc/InterpolationSurrogateBase.h
+++ b/src/surrogates/inc/InterpolationSurrogateBase.h
@@ -41,7 +41,7 @@ namespace QUESO
       index coordinates (i,j,k,...), where i runs from (0, n_points[0]-1),
       j run from (0,n_points[1]-1), etc. We use this indexing to build maps. */
   template<class V, class M>
-  class InterpolationSurrogateBase : public SurrogateBase<V,M>
+  class InterpolationSurrogateBase : public SurrogateBase<V>
   {
   public:
 

--- a/src/surrogates/inc/InterpolationSurrogateBase.h
+++ b/src/surrogates/inc/InterpolationSurrogateBase.h
@@ -52,9 +52,9 @@ namespace QUESO
   public:
 
     //! Constructor
-    /*! n_points should be a vector with dimension matching the dimension of
-        the parameter space and contain the number of points in each coordinate
-        direction for the interpolant. */
+    /*! The data object should be already fully populated when constructing
+        this object. The user can directly set values or use the
+        InterpolationSurrogateBuilder object to populate the data. */
     InterpolationSurrogateBase(const InterpolationSurrogateData<V,M>& data);
 
     virtual ~InterpolationSurrogateBase(){};

--- a/src/surrogates/inc/InterpolationSurrogateBase.h
+++ b/src/surrogates/inc/InterpolationSurrogateBase.h
@@ -28,7 +28,7 @@
 #include <queso/SurrogateBase.h>
 #include <queso/BoxSubset.h>
 #include <queso/VectorSpace.h>
-#include <queso/InterpolationSurrogateBuilder.h>
+#include <queso/InterpolationSurrogateData.h>
 
 namespace QUESO
 {
@@ -50,14 +50,7 @@ namespace QUESO
     /*! n_points should be a vector with dimension matching the dimension of
         the parameter space and contain the number of points in each coordinate
         direction for the interpolant. */
-    InterpolationSurrogateBase(const BoxSubset<V,M> & domain,
-                               const std::vector<unsigned int>& n_points,
-                               const std::vector<double>& values);
-
-    //! Constructor
-    /*! We extract data from the SurrogateBuilder. Note that the builder
-        MUST live as long as this object since we only extract const&. */
-    InterpolationSurrogateBase( const InterpolationSurrogateBuilder<V,M>& builder );
+    InterpolationSurrogateBase(const InterpolationSurrogateData<V,M>& data);
 
     virtual ~InterpolationSurrogateBase(){};
 
@@ -71,45 +64,13 @@ namespace QUESO
     unsigned int coordToGlobal( const std::vector<unsigned int>& coord_indices,
                                 const std::vector<unsigned int>& n_points ) const;
 
-    unsigned int dim() const
-    { return this->m_domain.vectorSpace().dimGlobal(); };
-
-    //! Lower bound of domain along dimension dim
-    double x_min( unsigned int dim ) const
-    { return this->m_domain.minValues()[dim]; };
-
-    //! Upper bound of domain along dimension dim
-    double x_max( unsigned int dim ) const
-    { return this->m_domain.maxValues()[dim]; };
-
-    //! Spacing between points along dimension dim
-    double spacing( unsigned int dim ) const;
-
   protected:
 
-    //! Parameter domain over which we use surrogate
-    const BoxSubset<V,M>& m_domain;
-
-    //! vector to store number of points in each coordinate direction
-    /*! We assume that the spacing in each coordinate direction is constant
-        so we only need to know the number of points. Then we can use the coordToGlobal
-        function to map coordinate indices to global index for access m_values. */
-    const std::vector<unsigned int>& m_n_points;
-
-    //! vector to store values to be interpolated
-    /*! These will be stored in a particular ordering. Subclasses
-        will provide a helper function to give the index into this
-        vector.
-        \todo We currently store all values reside on all processes. Generalization would
-              be to partition values across processes allocated for the subenvironment. */
-    const std::vector<double>& m_values;
+    const InterpolationSurrogateData<V,M>& m_data;
 
   private:
 
     InterpolationSurrogateBase();
-
-    //! Helper function for constructor
-    void check_dim_consistency() const;
 
   };
 

--- a/src/surrogates/inc/InterpolationSurrogateBase.h
+++ b/src/surrogates/inc/InterpolationSurrogateBase.h
@@ -34,6 +34,8 @@ namespace QUESO
 {
   //! Base class for interpolation-based surrogates
   /*! This class is used for surrogoate approximations of a model using interpolation.
+      These surrogates map an \f$ n\f$ dimensional parameter space to the reals.
+      That is \f$ f: \mathbb{R}^n \rightarrow \mathbb{R} \f$.
       Subclasses will define behavior of interpolant, but common assumptions
       are:
            -# Bounded domain; future work may extend behavior to unbounded domains.

--- a/src/surrogates/inc/InterpolationSurrogateBase.h
+++ b/src/surrogates/inc/InterpolationSurrogateBase.h
@@ -26,6 +26,8 @@
 #define UQ_INTERPOLATION_SURROGATE_BASE_H
 
 #include <queso/SurrogateBase.h>
+#include <queso/BoxSubset.h>
+#include <queso/VectorSpace.h>
 
 namespace QUESO
 {
@@ -47,8 +49,9 @@ namespace QUESO
     /*! n_points should be a vector with dimension matching the dimension of
         the parameter space and contain the number of points in each coordinate
         direction for the interpolant. */
-    InterpolationSurrogateBase(const VectorSet<V,M> & domain,
-                               const std::vector<unsigned int>& n_points );
+    InterpolationSurrogateBase(const BoxSubset<V,M> & domain,
+                               const std::vector<unsigned int>& n_points,
+                               const std::vector<double>& values);
 
     virtual ~InterpolationSurrogateBase(){};
 
@@ -63,6 +66,9 @@ namespace QUESO
                                 const std::vector<unsigned int>& n_points ) const;
 
   protected:
+
+    //! Parameter domain over which we use surrogate
+    const BoxSubset<V,M>& m_domain;
 
     //! vector to store number of points in each coordinate direction
     /*! We assume that the spacing in each coordinate direction is constant

--- a/src/surrogates/inc/InterpolationSurrogateBase.h
+++ b/src/surrogates/inc/InterpolationSurrogateBase.h
@@ -26,12 +26,13 @@
 #define UQ_INTERPOLATION_SURROGATE_BASE_H
 
 #include <queso/SurrogateBase.h>
-#include <queso/BoxSubset.h>
-#include <queso/VectorSpace.h>
-#include <queso/InterpolationSurrogateData.h>
 
 namespace QUESO
 {
+  // Forward declarations
+  template<typename V, typename M>
+  class InterpolationSurrogateData;
+
   //! Base class for interpolation-based surrogates
   /*! This class is used for surrogoate approximations of a model using interpolation.
       These surrogates map an \f$ n\f$ dimensional parameter space to the reals.

--- a/src/surrogates/inc/InterpolationSurrogateBase.h
+++ b/src/surrogates/inc/InterpolationSurrogateBase.h
@@ -35,9 +35,11 @@ namespace QUESO
   //! Base class for interpolation-based surrogates
   /*! This class is used for surrogoate approximations of a model using interpolation.
       Subclasses will define behavior of interpolant, but common assumptions
-      are: 1. Bounded domain; future work may extend behavior to unbounded domains.
-           2. Structured grids on the parameter domain. Subclasses will determine behavior
+      are:
+           -# Bounded domain; future work may extend behavior to unbounded domains.
+           -# Structured grids on the parameter domain. Subclasses will determine behavior
               of spacing (uniform vs. directionally-uniform, etc.).
+
       For the structured grid, we think of referencing each "node" in the box by its
       index coordinates (i,j,k,...), where i runs from (0, n_points[0]-1),
       j run from (0,n_points[1]-1), etc. We use this indexing to build maps. */

--- a/src/surrogates/inc/InterpolationSurrogateBase.h
+++ b/src/surrogates/inc/InterpolationSurrogateBase.h
@@ -1,0 +1,77 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef UQ_INTERPOLATION_SURROGATE_BASE_H
+#define UQ_INTERPOLATION_SURROGATE_BASE_H
+
+#include <queso/SurrogateBase.h>
+
+namespace QUESO
+{
+  //! Base class for interpolation-based surrogates
+  /*! This class is used for surrogoate approximations of a model using interpolation.
+      Subclasses will define behavior of interpolant, but common assumptions
+      are: 1. Bounded domain; future work may extend behavior to unbounded domains.
+           2. Structured grids on the parameter domain. Subclasses will determine behavior
+              of spacing (uniform vs. directionally-uniform, etc.). */
+  template<class V, class M>
+  class InterpolationSurrogateBase : public SurrogateBase<V,M>
+  {
+  public:
+
+    InterpolationSurrogateBase(const VectorSet<V,M> & domain )
+      : SurrogateBase<V,M>(domain)
+    {};
+
+    virtual ~InterpolationSurrogateBase(){};
+
+    //! Map coordinate indices to a singal global index.
+    /*! e.g. in 3-D, you pass in i,j,k and the n_points in each of the 3 directions.
+        This function will return the corresponding global index to which the value
+        at i,j,k can be indexed. Ordering must be consistent between coord_indices
+        and n_points. Must be ordered in increasing dimension. e.g. x,y,z,...
+        The user shouldn't need to call this method, this is public mainly to facilitate
+        testing. */
+    unsigned int coordToGlobal( const std::vector<unsigned int>& coord_indices,
+                                const std::vector<unsigned int>& n_points ) const;
+
+  protected:
+
+    //! vector to store values to be interpolated
+    /*! These will be stored in a particular ordering. Subclasses
+        will provide a helper function to give the index into this
+        vector.
+        \todo We currently store all values reside on all processes. Generalization would
+              be to partition values across processes allocated for the subenvironment. */
+    std::vector<double> m_values;
+
+  private:
+
+    InterpolationSurrogateBase();
+
+  };
+
+} // end namespace QUESO
+
+#endif // UQ_INTERPOLATION_SURROGATE_BASE_H

--- a/src/surrogates/inc/InterpolationSurrogateBase.h
+++ b/src/surrogates/inc/InterpolationSurrogateBase.h
@@ -40,9 +40,12 @@ namespace QUESO
   {
   public:
 
-    InterpolationSurrogateBase(const VectorSet<V,M> & domain )
-      : SurrogateBase<V,M>(domain)
-    {};
+    //! Constructor
+    /*! n_points should be a vector with dimension matching the dimension of
+        the parameter space and contain the number of points in each coordinate
+        direction for the interpolant. */
+    InterpolationSurrogateBase(const VectorSet<V,M> & domain,
+                               const std::vector<unsigned int>& n_points );
 
     virtual ~InterpolationSurrogateBase(){};
 
@@ -57,6 +60,12 @@ namespace QUESO
                                 const std::vector<unsigned int>& n_points ) const;
 
   protected:
+
+    //! vector to store number of points in each coordinate direction
+    /*! We assume that the spacing in each coordinate direction is constant
+        so we only need to know the number of points. Then we can use the coordToGlobal
+        function to map coordinate indices to global index for access m_values. */
+    std::vector<unsigned int> m_n_points;
 
     //! vector to store values to be interpolated
     /*! These will be stored in a particular ordering. Subclasses

--- a/src/surrogates/inc/InterpolationSurrogateBase.h
+++ b/src/surrogates/inc/InterpolationSurrogateBase.h
@@ -79,6 +79,9 @@ namespace QUESO
 
     InterpolationSurrogateBase();
 
+    //! Helper function for constructor
+    void check_dim_consistency() const;
+
   };
 
 } // end namespace QUESO

--- a/src/surrogates/inc/InterpolationSurrogateBase.h
+++ b/src/surrogates/inc/InterpolationSurrogateBase.h
@@ -34,7 +34,10 @@ namespace QUESO
       Subclasses will define behavior of interpolant, but common assumptions
       are: 1. Bounded domain; future work may extend behavior to unbounded domains.
            2. Structured grids on the parameter domain. Subclasses will determine behavior
-              of spacing (uniform vs. directionally-uniform, etc.). */
+              of spacing (uniform vs. directionally-uniform, etc.).
+      For the structured grid, we think of referencing each "node" in the box by its
+      index coordinates (i,j,k,...), where i runs from (0, n_points[0]-1),
+      j run from (0,n_points[1]-1), etc. We use this indexing to build maps. */
   template<class V, class M>
   class InterpolationSurrogateBase : public SurrogateBase<V,M>
   {

--- a/src/surrogates/inc/InterpolationSurrogateBase.h
+++ b/src/surrogates/inc/InterpolationSurrogateBase.h
@@ -88,7 +88,7 @@ namespace QUESO
     /*! We assume that the spacing in each coordinate direction is constant
         so we only need to know the number of points. Then we can use the coordToGlobal
         function to map coordinate indices to global index for access m_values. */
-    std::vector<unsigned int> m_n_points;
+    const std::vector<unsigned int>& m_n_points;
 
     //! vector to store values to be interpolated
     /*! These will be stored in a particular ordering. Subclasses
@@ -96,7 +96,7 @@ namespace QUESO
         vector.
         \todo We currently store all values reside on all processes. Generalization would
               be to partition values across processes allocated for the subenvironment. */
-    std::vector<double> m_values;
+    const std::vector<double>& m_values;
 
   private:
 

--- a/src/surrogates/inc/InterpolationSurrogateBuilder.h
+++ b/src/surrogates/inc/InterpolationSurrogateBuilder.h
@@ -56,7 +56,7 @@ namespace QUESO
     InterpolationSurrogateData<V,M>& m_data;
 
     //! Cache the amount of work for each subenvironment
-    std::vector<unsigned int> m_njobs;
+    std::vector<int> m_njobs;
 
     //! Ensure that if fullComm() size > 1, then n_subenvironments > 1
     /*! If not, this is a strange configuration and breaks things like inter0Comm

--- a/src/surrogates/inc/InterpolationSurrogateBuilder.h
+++ b/src/surrogates/inc/InterpolationSurrogateBuilder.h
@@ -80,6 +80,9 @@ namespace QUESO
     //! Provide the spatial coordinates for the global index n
     void set_domain_vector( unsigned int n, V& domain_vector ) const;
 
+    //! Helper function to compute strides needed for MPI_Gatherv
+    void compute_strides( std::vector<int>& strides ) const;
+
   private:
 
     InterpolationSurrogateBuilder();

--- a/src/surrogates/inc/InterpolationSurrogateBuilder.h
+++ b/src/surrogates/inc/InterpolationSurrogateBuilder.h
@@ -26,7 +26,7 @@
 #define UQ_INTERPOLATION_SURROGATE_BUILDER_H
 
 #include <queso/SurrogateBuilderBase.h>
-#include <queso/BoxSubset.h>
+#include <queso/InterpolationSurrogateData.h>
 
 namespace QUESO
 {
@@ -41,35 +41,19 @@ namespace QUESO
   {
   public:
 
-    InterpolationSurrogateBuilder( const BoxSubset<V,M> & domain,
-                                   const std::vector<unsigned int>& n_points );
+    //! Constructor
+    /*! We do not take a const& to the data because we want to compute and
+        set the values directly. */
+    InterpolationSurrogateBuilder( InterpolationSurrogateData<V,M>& data );
 
     virtual ~InterpolationSurrogateBuilder(){};
 
-    const BoxSubset<V,M>& paramDomain() const
-    { return this->m_domain; };
-
-    const std::vector<unsigned int>& n_points() const
-    { return this->m_n_points; };
-
-    const std::vector<double>& values() const
-    { return this->m_values; };
+    //! Execute the user's model and populate m_values for the given n_points
+    void build_values();
 
   protected:
 
-    //! Parameter domain over which we use surrogate
-    const BoxSubset<V,M>& m_domain;
-
-    //! vector to store number of points in each coordinate direction
-    /*! We assume that the spacing in each coordinate direction is constant
-        so we only need to know the number of points. Then we can use the coordToGlobal
-        function to map coordinate indices to global index for access m_values. */
-    const std::vector<unsigned int>& m_n_points;
-
-    //! vector to store values to be interpolated
-    std::vector<double> m_values;
-
-    void init_values( const std::vector<unsigned int>& n_points );
+    InterpolationSurrogateData<V,M>& m_data;
 
   private:
 

--- a/src/surrogates/inc/InterpolationSurrogateBuilder.h
+++ b/src/surrogates/inc/InterpolationSurrogateBuilder.h
@@ -1,0 +1,82 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef UQ_INTERPOLATION_SURROGATE_BUILDER_H
+#define UQ_INTERPOLATION_SURROGATE_BUILDER_H
+
+#include <queso/SurrogateBuilderBase.h>
+#include <queso/BoxSubset.h>
+
+namespace QUESO
+{
+  //! Build interpolation-based surrogate
+  /*! Interpolation surrogates assume a structured grid. So, given the domain
+      and the number of equally space points desired in each dimension, this
+      class will handle calling the user's model to populate the values needed
+      by the surrogate objects. User should subclass this object and implement
+      the evaluate_model method. */
+  template<class V, class M>
+  class InterpolationSurrogateBuilder : public SurrogateBuilderBase<V>
+  {
+  public:
+
+    InterpolationSurrogateBuilder( const BoxSubset<V,M> & domain,
+                                   const std::vector<unsigned int>& n_points );
+
+    virtual ~InterpolationSurrogateBuilder(){};
+
+    const BoxSubset<V,M>& paramDomain() const
+    { return this->m_domain; };
+
+    const std::vector<unsigned int>& n_points() const
+    { return this->m_n_points; };
+
+    const std::vector<double>& values() const
+    { return this->m_values; };
+
+  protected:
+
+    //! Parameter domain over which we use surrogate
+    const BoxSubset<V,M>& m_domain;
+
+    //! vector to store number of points in each coordinate direction
+    /*! We assume that the spacing in each coordinate direction is constant
+        so we only need to know the number of points. Then we can use the coordToGlobal
+        function to map coordinate indices to global index for access m_values. */
+    const std::vector<unsigned int>& m_n_points;
+
+    //! vector to store values to be interpolated
+    std::vector<double> m_values;
+
+    void init_values( const std::vector<unsigned int>& n_points );
+
+  private:
+
+    InterpolationSurrogateBuilder();
+
+  };
+
+} // end namespace QUESO
+
+#endif // UQ_INTERPOLATION_SURROGATE_BUILDER_H

--- a/src/surrogates/inc/InterpolationSurrogateBuilder.h
+++ b/src/surrogates/inc/InterpolationSurrogateBuilder.h
@@ -62,7 +62,8 @@ namespace QUESO
 
     void set_work_bounds( unsigned int& n_begin, unsigned int& n_end ) const;
 
-    void set_value( unsigned int n, double value );
+    void sync_data( std::vector<unsigned int>& local_n,
+                    std::vector<double>& local_values );
 
     void set_domain_vector( unsigned int n, V& domain_vector ) const;
 

--- a/src/surrogates/inc/InterpolationSurrogateBuilder.h
+++ b/src/surrogates/inc/InterpolationSurrogateBuilder.h
@@ -55,6 +55,11 @@ namespace QUESO
 
     InterpolationSurrogateData<V,M>& m_data;
 
+    //! Cache the amount of work for each subenvironment
+    std::vector<unsigned int> m_njobs;
+
+    void partition_work();
+
     void set_work_bounds( unsigned int& n_begin, unsigned int& n_end ) const;
 
     void set_value( unsigned int n, double value );

--- a/src/surrogates/inc/InterpolationSurrogateBuilder.h
+++ b/src/surrogates/inc/InterpolationSurrogateBuilder.h
@@ -58,6 +58,12 @@ namespace QUESO
     //! Cache the amount of work for each subenvironment
     std::vector<unsigned int> m_njobs;
 
+    //! Ensure that if fullComm() size > 1, then n_subenvironments > 1
+    /*! If not, this is a strange configuration and breaks things like inter0Comm
+        and would induce redundant work. Thus, this configuration is not supported and
+        we error out. */
+    void check_process_config();
+
     //! Partition the workload of model evaluations across the subenvironments
     void partition_work();
 

--- a/src/surrogates/inc/InterpolationSurrogateBuilder.h
+++ b/src/surrogates/inc/InterpolationSurrogateBuilder.h
@@ -55,6 +55,12 @@ namespace QUESO
 
     InterpolationSurrogateData<V,M>& m_data;
 
+    void set_work_bounds( unsigned int& n_begin, unsigned int& n_end ) const;
+
+    void set_value( unsigned int n, double value );
+
+    void set_domain_vector( unsigned int n, V& domain_vector ) const;
+
   private:
 
     InterpolationSurrogateBuilder();

--- a/src/surrogates/inc/InterpolationSurrogateBuilder.h
+++ b/src/surrogates/inc/InterpolationSurrogateBuilder.h
@@ -58,13 +58,20 @@ namespace QUESO
     //! Cache the amount of work for each subenvironment
     std::vector<unsigned int> m_njobs;
 
+    //! Partition the workload of model evaluations across the subenvironments
     void partition_work();
 
+    //! Set the starting and ending global indices for the current subenvironment
+    /*! This environment will evaluate the model for indices [n_begin,n_end) */
     void set_work_bounds( unsigned int& n_begin, unsigned int& n_end ) const;
 
+    //! Take the local values computed from each process and communicate
+    /*! The end result will be that all processes have all the data.
+        I.e. m_values will be completely populated on all processes. */
     void sync_data( std::vector<unsigned int>& local_n,
                     std::vector<double>& local_values );
 
+    //! Provide the spatial coordinates for the global index n
     void set_domain_vector( unsigned int n, V& domain_vector ) const;
 
   private:

--- a/src/surrogates/inc/InterpolationSurrogateData.h
+++ b/src/surrogates/inc/InterpolationSurrogateData.h
@@ -39,14 +39,18 @@ namespace QUESO
 
     ~InterpolationSurrogateData();
 
-    const BoxSubset<V,M>& paramDomain() const
+    const BoxSubset<V,M>& get_paramDomain() const
     { return this->m_domain; };
 
-    const std::vector<unsigned int>& n_points() const
+    const std::vector<unsigned int>& get_n_points() const
     { return this->m_n_points; };
 
-    const std::vector<double>& values() const
+    const std::vector<double>& get_values() const
     { return this->m_values; };
+
+    double get_value( unsigned int n ) const
+    { queso_assert_less(n,this->m_values.size());
+      return this->m_values[n]; };
 
     void set_values( std::vector<double>& values );
 

--- a/src/surrogates/inc/InterpolationSurrogateData.h
+++ b/src/surrogates/inc/InterpolationSurrogateData.h
@@ -72,6 +72,9 @@ namespace QUESO
     //! Helper function for constructor
     void check_dim_consistency() const;
 
+    //! Helper function for sizing m_values
+    void init_values( const std::vector<unsigned int>& n_points );
+
     //! Parameter domain over which we use surrogate
     const BoxSubset<V,M>& m_domain;
 

--- a/src/surrogates/inc/InterpolationSurrogateData.h
+++ b/src/surrogates/inc/InterpolationSurrogateData.h
@@ -48,6 +48,9 @@ namespace QUESO
     const std::vector<double>& get_values() const
     { return this->m_values; };
 
+    std::vector<double>& get_values()
+    { return this->m_values; };
+
     double get_value( unsigned int n ) const
     { queso_assert_less(n,this->m_values.size());
       return this->m_values[n]; };

--- a/src/surrogates/inc/InterpolationSurrogateData.h
+++ b/src/surrogates/inc/InterpolationSurrogateData.h
@@ -37,7 +37,7 @@ namespace QUESO
     InterpolationSurrogateData( const BoxSubset<V,M>& domain,
                                 const std::vector<unsigned int>& n_points );
 
-    ~InterpolationSurrogateData();
+    ~InterpolationSurrogateData(){};
 
     const BoxSubset<V,M>& get_paramDomain() const
     { return this->m_domain; };

--- a/src/surrogates/inc/InterpolationSurrogateData.h
+++ b/src/surrogates/inc/InterpolationSurrogateData.h
@@ -52,6 +52,9 @@ namespace QUESO
     { queso_assert_less(n,this->m_values.size());
       return this->m_values[n]; };
 
+    unsigned int n_values() const
+    { return this->m_values.size(); };
+
     //! Set all values. Dimension must be consistent with internal m_values.
     /*! This does a full copy of the values vector. This is mainly for testing,
         users are encouraged to use the InterpolationSurrogateBuilder. */

--- a/src/surrogates/inc/InterpolationSurrogateData.h
+++ b/src/surrogates/inc/InterpolationSurrogateData.h
@@ -52,7 +52,12 @@ namespace QUESO
     { queso_assert_less(n,this->m_values.size());
       return this->m_values[n]; };
 
+    //! Set all values. Dimension must be consistent with internal m_values.
+    /*! This does a full copy of the values vector. This is mainly for testing,
+        users are encouraged to use the InterpolationSurrogateBuilder. */
     void set_values( std::vector<double>& values );
+
+    void set_value( unsigned int n, double value );
 
     //! Dimension of parameter space
     unsigned int dim() const

--- a/src/surrogates/inc/InterpolationSurrogateData.h
+++ b/src/surrogates/inc/InterpolationSurrogateData.h
@@ -77,6 +77,9 @@ namespace QUESO
     //! Spacing between points along dimension dim
     double spacing( unsigned int dim ) const;
 
+    //! Get spatial coordinate value at the node index along coordinate direction dim
+    double get_x( unsigned int dim, unsigned int index ) const;
+
   private:
 
     InterpolationSurrogateData();

--- a/src/surrogates/inc/InterpolationSurrogateData.h
+++ b/src/surrogates/inc/InterpolationSurrogateData.h
@@ -1,0 +1,94 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef UQ_INTERPOLATION_SURROGATE_DATA_H
+#define UQ_INTERPOLATION_SURROGATE_DATA_H
+
+#include <queso/BoxSubset.h>
+
+namespace QUESO
+{
+  template<class V, class M>
+  class InterpolationSurrogateData
+  {
+  public:
+
+    InterpolationSurrogateData( const BoxSubset<V,M>& domain,
+                                const std::vector<unsigned int>& n_points );
+
+    ~InterpolationSurrogateData();
+
+    const BoxSubset<V,M>& paramDomain() const
+    { return this->m_domain; };
+
+    const std::vector<unsigned int>& n_points() const
+    { return this->m_n_points; };
+
+    const std::vector<double>& values() const
+    { return this->m_values; };
+
+    void set_values( std::vector<double>& values );
+
+    //! Dimension of parameter space
+    unsigned int dim() const
+    { return this->m_domain.vectorSpace().dimGlobal(); };
+
+    //! Lower bound of domain along dimension dim
+    double x_min( unsigned int dim ) const
+    { return this->m_domain.minValues()[dim]; };
+
+    //! Upper bound of domain along dimension dim
+    double x_max( unsigned int dim ) const
+    { return this->m_domain.maxValues()[dim]; };
+
+    //! Spacing between points along dimension dim
+    double spacing( unsigned int dim ) const;
+
+  private:
+
+    InterpolationSurrogateData();
+
+    //! Helper function for constructor
+    void check_dim_consistency() const;
+
+    //! Parameter domain over which we use surrogate
+    const BoxSubset<V,M>& m_domain;
+
+    //! vector to store number of points in each coordinate direction
+    /*! We assume that the spacing in each coordinate direction is constant
+        so we only need to know the number of points. */
+    const std::vector<unsigned int>& m_n_points;
+
+    //! vector to store values to be interpolated
+    /*! These will be stored in a particular ordering. Helper functions will provide
+        mapping between grid coordinates and a global coordinate; the global coordinate
+        will be used to index into the values.
+        \todo We currently store all values reside on all processes. Generalization would
+              be to partition values across processes allocated for the subenvironment. */
+    std::vector<double> m_values;
+  };
+
+} // end namespace QUESO
+
+#endif // UQ_INTERPOLATION_SURROGATE_DATA_H

--- a/src/surrogates/inc/InterpolationSurrogateHelper.h
+++ b/src/surrogates/inc/InterpolationSurrogateHelper.h
@@ -47,6 +47,23 @@ namespace QUESO
         facilitate testing. */
     static unsigned int coordToGlobal( const std::vector<unsigned int>& coord_indices,
                                        const std::vector<unsigned int>& n_points );
+
+    //! Inverse of coordToGlobal map
+    /*! Given the global index and the n_points in each direction, we
+        back out the coordinate indices and return them in coord_indices. */
+    static void globalToCoord( unsigned int global,
+                               const std::vector<unsigned int>& n_points,
+                               std::vector<unsigned int>& coord_indices );
+
+  private:
+
+    //! Helper function
+    /*! coordToGlobal computes: i + j*n_points[0] + k*n_points[0]*n_points[1] + ...
+        To compute inverse we need the product of n_points terms, depending on which
+        term we are computing. So, given n_points and the current term, we
+        compute the correct number of products of n_points. */
+    static unsigned int compute_npoints_factor( const std::vector<unsigned int>& n_points,
+                                                unsigned int term );
   };
 
 } // end namespace QUESO

--- a/src/surrogates/inc/InterpolationSurrogateHelper.h
+++ b/src/surrogates/inc/InterpolationSurrogateHelper.h
@@ -1,0 +1,54 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef UQ_INTERPOLATION_SURROGATE_HELPER_H
+#define UQ_INTERPOLATION_SURROGATE_HELPER_H
+
+// C++
+#include <vector>
+
+namespace QUESO
+{
+  class InterpolationSurrogateHelper
+  {
+  public:
+
+    InterpolationSurrogateHelper(){};
+
+    ~InterpolationSurrogateHelper(){};
+
+    //! Map coordinate indices to a singal global index.
+    /*! e.g. in 3-D, you pass in i,j,k and the n_points in each of the 3 directions.
+        This function will return the corresponding global index to which the value
+        at i,j,k can be indexed. Ordering must be consistent between coord_indices
+        and n_points. Must be ordered in increasing dimension. e.g. x,y,z,...
+        The user shouldn't need to call this method, this is public mainly to
+        facilitate testing. */
+    static unsigned int coordToGlobal( const std::vector<unsigned int>& coord_indices,
+                                       const std::vector<unsigned int>& n_points );
+  };
+
+} // end namespace QUESO
+
+#endif // UQ_INTERPOLATION_SURROGATE_HELPER_H

--- a/src/surrogates/inc/LinearLagrangeInterpolationSurrogate.h
+++ b/src/surrogates/inc/LinearLagrangeInterpolationSurrogate.h
@@ -1,0 +1,111 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef UQ_LINEAR_LAGRANGE_INTERPOLATION_SURROGATE_H
+#define UQ_LINEAR_LAGRANGE_INTERPOLATION_SURROGATE_H
+
+#include <queso/InterpolationSurrogateBase.h>
+
+namespace QUESO
+{
+  template<class V, class M>
+  class LinearLagrangeInterpolationSurrogate : public InterpolationSurrogateBase<V,M>
+  {
+  public:
+
+    LinearLagrangeInterpolationSurrogate(const BoxSubset<V,M> & domain,
+                                         const std::vector<unsigned int>& n_points,
+                                         const std::vector<double>& values);
+
+    virtual ~LinearLagrangeInterpolationSurrogate(){};
+
+    //! Evaluates value of the interpolant for the given domainVector
+    virtual double evaluate(const V & domainVector) const;
+
+    //! The number of coeffs for interpolating
+    unsigned int n_coeffs() const
+    { return std::pow( 2, this->dim() ); };
+
+  protected:
+
+    //! Helper function to get lower bound indices for each dimension
+    /*! domainVector contains the current value at which want want to interpolate.
+        We use that to figure out the bounding values in each dimension. Then
+        we populate indices with the lower index. */
+    void compute_interval_indices(const V & domainVector,
+                                  std::vector<unsigned int>& indices) const;
+
+    //! Helper function to populate bounding values for the intervales in each dimension
+    /*! By convention, it is assumed that the indices vector contains the lower
+        bound index. See compute_interval_indices. */
+    void compute_interval_values( const std::vector<unsigned int>& indices,
+                                  std::vector<double>& x_min,
+                                  std::vector<double>& x_max,
+                                  std::vector<double>& values ) const;
+
+    //! Evaluate multidimensional linear Lagrange interpolant
+    /*! This is just a tensor product of one-dimensional interpolants */
+    double eval_interpolant( const std::vector<double>& x_min,
+                             const std::vector<double>& x_max,
+                             const std::vector<double>& values,
+                             const V & domainVector ) const;
+
+    //! Covert local indices to single "global" index
+    /*! This is for handling the local ordering of an arbitrary dimensional
+        linear Lagrange elements. The function will look like
+        \f$ \sum_{ijkl...} f_{ijkl...} N_{ijkl...} \f$ so we want a
+        convenient way to map \f$ ijkl... \f$ to a single integer. Then, we
+        can order all our data this way and easily index into it. We can
+        do this since each of \f$ ijkl... \f$ is either 0 or 1. */
+    unsigned int coordsToSingle( const std::vector<unsigned int>& indices ) const;
+
+    //! Inverse of map computed in coordsToSingle
+    void singleToCoords( unsigned int global, std::vector<unsigned int>& indices ) const;
+
+    //! Compute multidimensional Lagrange polynomial as tensor product of 1D polynomials
+    /*! \f$ N_{ijkl...} (\xi, \eta, \zeta,...) = N_i(\eta) N_j(\eta) N_k(\zeta) ... \f$
+      The indices vector contains the i,j,k,... values */
+    double tensor_product_lagrange( const std::vector<double>& x_min,
+                                    const std::vector<double>& x_max,
+                                    const std::vector<unsigned int>& indices,
+                                    const V & domainVector ) const;
+
+    //! Evaluate a 1-D Lagrange polynomial at point x
+    /*! index tells us which of the two Lagrange functions to use.
+      index must be 0 or 1. */
+    double lagrange_poly( double x0, double x1, double x, unsigned int index ) const;
+
+    //! Compute x0 and x1 given the dimension and the point index along dim
+    void compute_x0_x1( unsigned int dim, unsigned int index,
+                        double& x0, double& x1 ) const;
+
+  private:
+
+    LinearLagrangeInterpolationSurrogate();
+
+  };
+
+} // end namespace QUESO
+
+#endif // UQ_LINEAR_LAGRANGE_INTERPOLATION_SURROGATE_H

--- a/src/surrogates/inc/LinearLagrangeInterpolationSurrogate.h
+++ b/src/surrogates/inc/LinearLagrangeInterpolationSurrogate.h
@@ -94,10 +94,6 @@ namespace QUESO
       index must be 0 or 1. */
     double lagrange_poly( double x0, double x1, double x, unsigned int index ) const;
 
-    //! Compute x0 and x1 given the dimension and the point index along dim
-    void compute_x0_x1( unsigned int dim, unsigned int index,
-                        double& x0, double& x1 ) const;
-
   private:
 
     LinearLagrangeInterpolationSurrogate();

--- a/src/surrogates/inc/LinearLagrangeInterpolationSurrogate.h
+++ b/src/surrogates/inc/LinearLagrangeInterpolationSurrogate.h
@@ -38,6 +38,8 @@ namespace QUESO
                                          const std::vector<unsigned int>& n_points,
                                          const std::vector<double>& values);
 
+    LinearLagrangeInterpolationSurrogate( const InterpolationSurrogateBuilder<V,M>& builder );
+
     virtual ~LinearLagrangeInterpolationSurrogate(){};
 
     //! Evaluates value of the interpolant for the given domainVector

--- a/src/surrogates/inc/LinearLagrangeInterpolationSurrogate.h
+++ b/src/surrogates/inc/LinearLagrangeInterpolationSurrogate.h
@@ -25,7 +25,12 @@
 #ifndef UQ_LINEAR_LAGRANGE_INTERPOLATION_SURROGATE_H
 #define UQ_LINEAR_LAGRANGE_INTERPOLATION_SURROGATE_H
 
+// QUESO
 #include <queso/InterpolationSurrogateBase.h>
+
+// C++
+#include <vector>
+#include <cmath>
 
 namespace QUESO
 {

--- a/src/surrogates/inc/LinearLagrangeInterpolationSurrogate.h
+++ b/src/surrogates/inc/LinearLagrangeInterpolationSurrogate.h
@@ -34,11 +34,7 @@ namespace QUESO
   {
   public:
 
-    LinearLagrangeInterpolationSurrogate(const BoxSubset<V,M> & domain,
-                                         const std::vector<unsigned int>& n_points,
-                                         const std::vector<double>& values);
-
-    LinearLagrangeInterpolationSurrogate( const InterpolationSurrogateBuilder<V,M>& builder );
+    LinearLagrangeInterpolationSurrogate(const InterpolationSurrogateData<V,M>& data);
 
     virtual ~LinearLagrangeInterpolationSurrogate(){};
 
@@ -47,7 +43,7 @@ namespace QUESO
 
     //! The number of coeffs for interpolating
     unsigned int n_coeffs() const
-    { return std::pow( 2, this->dim() ); };
+    { return std::pow( 2, this->m_data.dim() ); };
 
   protected:
 

--- a/src/surrogates/inc/LinearLagrangeInterpolationSurrogate.h
+++ b/src/surrogates/inc/LinearLagrangeInterpolationSurrogate.h
@@ -34,11 +34,18 @@
 
 namespace QUESO
 {
+  //! Linear Lagrange interpolation surrogate
+  /*! Aribritary dimension linear Lagrange interpolant. Uses a structured
+      grid to interpolate values given by data passed to the constructor. */
   template<class V, class M>
   class LinearLagrangeInterpolationSurrogate : public InterpolationSurrogateBase<V,M>
   {
   public:
 
+    //! Constructor
+    /*! The data object should be already fully populated when constructing
+        this object. The user can directly set values or use the
+        InterpolationSurrogateBuilder object to populate the data. */
     LinearLagrangeInterpolationSurrogate(const InterpolationSurrogateData<V,M>& data);
 
     virtual ~LinearLagrangeInterpolationSurrogate(){};
@@ -59,7 +66,7 @@ namespace QUESO
     void compute_interval_indices(const V & domainVector,
                                   std::vector<unsigned int>& indices) const;
 
-    //! Helper function to populate bounding values for the intervales in each dimension
+    //! Helper function to populate bounding values for the intervals in each dimension
     /*! By convention, it is assumed that the indices vector contains the lower
         bound index. See compute_interval_indices. */
     void compute_interval_values( const std::vector<unsigned int>& indices,
@@ -74,7 +81,7 @@ namespace QUESO
                              const std::vector<double>& values,
                              const V & domainVector ) const;
 
-    //! Covert local indices to single "global" index
+    //! Convert local indices to single "global" index
     /*! This is for handling the local ordering of an arbitrary dimensional
         linear Lagrange elements. The function will look like
         \f$ \sum_{ijkl...} f_{ijkl...} N_{ijkl...} \f$ so we want a

--- a/src/surrogates/inc/SurrogateBase.h
+++ b/src/surrogates/inc/SurrogateBase.h
@@ -1,0 +1,65 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef UQ_SURROGATE_BASE_H
+#define UQ_SURROGATE_BASE_H
+
+#include <queso/VectorSet.h>
+
+namespace QUESO
+{
+  //! Base class for surrogates of models
+  /*! Defines basic interface for using surrogates of models. The idea
+      is that we have some surrogate of the parameter-to-data map so that
+      it can be used in the likelihood classes. Subclasses will define the
+      particular surrogate model. Other classes will be used to build up the
+      surrogate from the user's model. */
+  template<class V, class M>
+  class SurrogateBase
+  {
+  public:
+
+    SurrogateBase(const VectorSet<V,M>& domain)
+      : m_domain(domain)
+    {};
+
+    virtual ~SurrogateBase(){};
+
+    //! Method to return value given the parameter vector
+    virtual double evaluate(const V & domainVector) const =0;
+
+  protected:
+
+    //! Parameter domain over which we use surrogate
+    const VectorSet<V,M>& m_domain;
+
+  private:
+
+    SurrogateBase();
+
+  };
+
+} // end namespace QUESO
+
+#endif // UQ_SURROGATE_BASE_H

--- a/src/surrogates/inc/SurrogateBase.h
+++ b/src/surrogates/inc/SurrogateBase.h
@@ -33,7 +33,7 @@ namespace QUESO
       it can be used in the likelihood classes. Subclasses will define the
       particular surrogate model. Other classes will be used to build up the
       surrogate from the user's model. */
-  template<class V, class M>
+  template<class V>
   class SurrogateBase
   {
   public:

--- a/src/surrogates/inc/SurrogateBase.h
+++ b/src/surrogates/inc/SurrogateBase.h
@@ -28,7 +28,9 @@
 namespace QUESO
 {
   //! Base class for surrogates of models
-  /*! Defines basic interface for using surrogates of models. The idea
+  /*! Defines basic interface for using surrogates of models. These surrogates
+      map an \f$ n\f$ dimensional parameter space to the reals. That is
+      \f$ f: \mathbb{R}^n \rightarrow \mathbb{R} \f$. The idea
       is that we have some surrogate of the parameter-to-data map so that
       it can be used in the likelihood classes. Subclasses will define the
       particular surrogate model. Other classes will be used to build up the

--- a/src/surrogates/inc/SurrogateBase.h
+++ b/src/surrogates/inc/SurrogateBase.h
@@ -25,8 +25,6 @@
 #ifndef UQ_SURROGATE_BASE_H
 #define UQ_SURROGATE_BASE_H
 
-#include <queso/VectorSet.h>
-
 namespace QUESO
 {
   //! Base class for surrogates of models
@@ -40,23 +38,12 @@ namespace QUESO
   {
   public:
 
-    SurrogateBase(const VectorSet<V,M>& domain)
-      : m_domain(domain)
-    {};
+    SurrogateBase(){};
 
     virtual ~SurrogateBase(){};
 
     //! Method to return value given the parameter vector
     virtual double evaluate(const V & domainVector) const =0;
-
-  protected:
-
-    //! Parameter domain over which we use surrogate
-    const VectorSet<V,M>& m_domain;
-
-  private:
-
-    SurrogateBase();
 
   };
 

--- a/src/surrogates/inc/SurrogateBuilderBase.h
+++ b/src/surrogates/inc/SurrogateBuilderBase.h
@@ -1,0 +1,48 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef UQ_SURROGATE_BUILDER_BASE_H
+#define UQ_SURROGATE_BUILDER_BASE_H
+
+namespace QUESO
+{
+  //! Base class for builders of surrogates
+  /*! This class provides the interface to the user's model for which
+      we are constructing a surrogate. */
+  template<class V>
+  class SurrogateBuilderBase
+  {
+  public:
+
+    SurrogateBuilderBase(){};
+
+    virtual ~SurrogateBuilderBase(){};
+
+    virtual double evaluate_model( const V & domainVector ) const =0;
+
+  };
+
+} // end namespace QUESO
+
+#endif // UQ_SURROGATE_BUILDER_BASE_H

--- a/src/surrogates/src/InterpolationSurrogateBase.C
+++ b/src/surrogates/src/InterpolationSurrogateBase.C
@@ -35,35 +35,17 @@
 namespace QUESO
 {
   template<class V, class M>
-  InterpolationSurrogateBase<V,M>::InterpolationSurrogateBase(const BoxSubset<V,M> & domain,
-                                                              const std::vector<unsigned int>& n_points,
-                                                              const std::vector<double>& values)
+  InterpolationSurrogateBase<V,M>::InterpolationSurrogateBase(const InterpolationSurrogateData<V,M>& data)
     : SurrogateBase<V>(),
-    m_domain(domain),
-    m_n_points(n_points),
-    m_values(values)
-    {
-      // This checks that the dimension of n_points and the domain are consistent
-      this->check_dim_consistency();
-    }
-
-  template<class V, class M>
-  InterpolationSurrogateBase<V,M>::InterpolationSurrogateBase(const InterpolationSurrogateBuilder<V,M>& builder )
-    : SurrogateBase<V>(),
-    m_domain(builder.paramDomain()),
-    m_n_points(builder.n_points()),
-    m_values(builder.values())
-    {
-      // This checks that the dimension of n_points and the domain are consistent
-      this->check_dim_consistency();
-    }
+    m_data(data)
+    {}
 
   template<class V, class M>
   unsigned int InterpolationSurrogateBase<V,M>::coordToGlobal( const std::vector<unsigned int>& coord_indices,
                                                                const std::vector<unsigned int>& n_points ) const
   {
-    queso_assert_equal_to( coord_indices.size(), this->dim() );
-    queso_assert_equal_to( n_points.size(), this->dim() );
+    queso_assert_equal_to( coord_indices.size(), this->m_data.dim() );
+    queso_assert_equal_to( n_points.size(), this->m_data.dim() );
 
     /* Mapping is: i + j*n_i + k*n_i*n_j + l*n_i*n_j*n_k + ...
        Initialize global_index to "i".
@@ -72,7 +54,7 @@ namespace QUESO
 
     unsigned int global_index = coord_indices[0];
 
-    for( unsigned int d = 1; d < this->dim(); d++ )
+    for( unsigned int d = 1; d < this->m_data.dim(); d++ )
       {
         queso_assert_less( coord_indices[d], n_points[d] );
 
@@ -88,35 +70,6 @@ namespace QUESO
       }
 
     return global_index;
-  }
-
-  template<class V, class M>
-  void InterpolationSurrogateBase<V,M>::check_dim_consistency() const
-  {
-    if( this->dim() != this->m_n_points.size() )
-      {
-        std::stringstream vspace_dim;
-        vspace_dim << this->m_domain.vectorSpace().dimGlobal();
-
-        std::stringstream n_points_dim;
-        n_points_dim << this->m_n_points.size();
-
-        std::string error = "ERROR: Mismatch between dimension of parameter space and number of points\n.";
-        error += "        domain dimension = " + vspace_dim.str() + "\n";
-        error += "        points dimension = " + n_points_dim.str() + "\n";
-
-        queso_error_msg(error);
-      }
-  }
-
-  template<class V, class M>
-  double InterpolationSurrogateBase<V,M>::spacing( unsigned int dim ) const
-  {
-    unsigned int n_intervals = this->m_n_points[dim]-1;
-    double x_min = this->x_min(dim);
-    double x_max = this->x_max(dim);
-
-    return (x_max-x_min)/n_intervals;
   }
 
 } // end namespace QUESO

--- a/src/surrogates/src/InterpolationSurrogateBase.C
+++ b/src/surrogates/src/InterpolationSurrogateBase.C
@@ -28,7 +28,6 @@
 // QUESO
 #include <queso/GslVector.h>
 #include <queso/GslMatrix.h>
-#include <queso/VectorSpace.h>
 
 // C++
 #include <sstream>
@@ -53,19 +52,17 @@ namespace QUESO
                                                                const std::vector<unsigned int>& n_points ) const
   {
     // Make sure dimension is consistent between inputs
-    queso_assert_equal_to( coord_indices.size(), n_points.size() );
+    queso_assert_equal_to( coord_indices.size(), this->dim() );
 
     // Make sure dimension is consisent with parameter space
-    queso_assert_equal_to( coord_indices.size(), this->m_domain.vectorSpace().dimGlobal() );
-
-    unsigned int dim = this->m_domain.vectorSpace().dimGlobal();
+    queso_assert_equal_to( coord_indices.size(), this->dim() );
 
     /* Mapping is: i + j*n_i + k*n_i*n_j + l*n_i*n_j*n_k + ...
        Initialize global_index to "i".
        Then loop and build up each term.*/
     unsigned int global_index = coord_indices[0];
 
-    for( unsigned int d = 1; d < dim; d++ )
+    for( unsigned int d = 1; d < this->dim(); d++ )
       {
         // Accumulate the current term
         unsigned int idx = coord_indices[d];
@@ -85,7 +82,7 @@ namespace QUESO
   template<class V, class M>
   void InterpolationSurrogateBase<V,M>::check_dim_consistency() const
   {
-    if( this->m_domain.vectorSpace().dimGlobal() != this->m_n_points.size() )
+    if( this->dim() != this->m_n_points.size() )
       {
         std::stringstream vspace_dim;
         vspace_dim << this->m_domain.vectorSpace().dimGlobal();

--- a/src/surrogates/src/InterpolationSurrogateBase.C
+++ b/src/surrogates/src/InterpolationSurrogateBase.C
@@ -38,7 +38,7 @@ namespace QUESO
   InterpolationSurrogateBase<V,M>::InterpolationSurrogateBase(const BoxSubset<V,M> & domain,
                                                               const std::vector<unsigned int>& n_points,
                                                               const std::vector<double>& values)
-    : SurrogateBase<V,M>(),
+    : SurrogateBase<V>(),
     m_domain(domain),
     m_n_points(n_points),
     m_values(values)

--- a/src/surrogates/src/InterpolationSurrogateBase.C
+++ b/src/surrogates/src/InterpolationSurrogateBase.C
@@ -33,6 +33,14 @@
 namespace QUESO
 {
   template<class V, class M>
+  InterpolationSurrogateBase<V,M>::InterpolationSurrogateBase(const VectorSet<V,M> & domain,
+                                                              const std::vector<unsigned int>& n_points )
+      : SurrogateBase<V,M>(domain),
+        m_n_points(n_points)
+    {
+    }
+
+  template<class V, class M>
   unsigned int InterpolationSurrogateBase<V,M>::coordToGlobal( const std::vector<unsigned int>& coord_indices,
                                                                const std::vector<unsigned int>& n_points ) const
   {

--- a/src/surrogates/src/InterpolationSurrogateBase.C
+++ b/src/surrogates/src/InterpolationSurrogateBase.C
@@ -66,12 +66,12 @@ namespace QUESO
       {
         // Accumulate the current term
         unsigned int idx = coord_indices[d];
-        unsigned int local_d = d-1;
-        do
+
+        for( int local_d = d-1; local_d >=0; local_d -= 1)
           {
             idx *= n_points[local_d];
             local_d -= 1;
-          } while( local_d >= 0 );
+          }
 
         global_index += idx;
       }

--- a/src/surrogates/src/InterpolationSurrogateBase.C
+++ b/src/surrogates/src/InterpolationSurrogateBase.C
@@ -30,6 +30,9 @@
 #include <queso/GslMatrix.h>
 #include <queso/VectorSpace.h>
 
+// C++
+#include <sstream>
+
 namespace QUESO
 {
   template<class V, class M>
@@ -38,6 +41,8 @@ namespace QUESO
       : SurrogateBase<V,M>(domain),
         m_n_points(n_points)
     {
+      // This checks that the dimension of n_points and the domain are consistent
+      this->check_dim_consistency();
     }
 
   template<class V, class M>
@@ -73,6 +78,26 @@ namespace QUESO
 
     return global_index;
   }
+
+  template<class V, class M>
+  void InterpolationSurrogateBase<V,M>::check_dim_consistency() const
+  {
+    if( this->m_domain.vectorSpace().dimGlobal() != this->m_n_points.size() )
+      {
+        std::stringstream vspace_dim;
+        vspace_dim << this->m_domain.vectorSpace().dimGlobal();
+
+        std::stringstream n_points_dim;
+        n_points_dim << this->m_n_points.size();
+
+        std::string error = "ERROR: Mismatch between dimension of parameter space and number of points\n.";
+        error += "        domain dimension = " + vspace_dim.str() + "\n";
+        error += "        points dimension = " + n_points_dim.str() + "\n";
+
+        queso_error_msg(error);
+      }
+  }
+
 } // end namespace QUESO
 
 // Instantiate

--- a/src/surrogates/src/InterpolationSurrogateBase.C
+++ b/src/surrogates/src/InterpolationSurrogateBase.C
@@ -1,0 +1,71 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// This class
+#include <queso/InterpolationSurrogateBase.h>
+
+// QUESO
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/VectorSpace.h>
+
+namespace QUESO
+{
+  template<class V, class M>
+  unsigned int InterpolationSurrogateBase<V,M>::coordToGlobal( const std::vector<unsigned int>& coord_indices,
+                                                               const std::vector<unsigned int>& n_points ) const
+  {
+    // Make sure dimension is consistent between inputs
+    queso_assert_equal_to( coord_indices.size(), n_points.size() );
+
+    // Make sure dimension is consisent with parameter space
+    queso_assert_equal_to( coord_indices.size(), this->m_domain.vectorSpace().dimGlobal() );
+
+    unsigned int dim = this->m_domain.vectorSpace().dimGlobal();
+
+    /* Mapping is: i + j*n_i + k*n_i*n_j + l*n_i*n_j*n_k + ...
+       Initialize global_index to "i".
+       Then loop and build up each term.*/
+    unsigned int global_index = coord_indices[0];
+
+    for( unsigned int d = 1; d < dim; d++ )
+      {
+        // Accumulate the current term
+        unsigned int idx = coord_indices[d];
+        unsigned int local_d = d-1;
+        do
+          {
+            idx *= n_points[local_d];
+            local_d -= 1;
+          } while( local_d >= 0 );
+
+        global_index += idx;
+      }
+
+    return global_index;
+  }
+} // end namespace QUESO
+
+// Instantiate
+template class QUESO::InterpolationSurrogateBase<QUESO::GslVector,QUESO::GslMatrix>;

--- a/src/surrogates/src/InterpolationSurrogateBase.C
+++ b/src/surrogates/src/InterpolationSurrogateBase.C
@@ -28,6 +28,7 @@
 // QUESO
 #include <queso/GslVector.h>
 #include <queso/GslMatrix.h>
+#include <queso/InterpolationSurrogateData.h>
 
 // C++
 #include <sstream>

--- a/src/surrogates/src/InterpolationSurrogateBase.C
+++ b/src/surrogates/src/InterpolationSurrogateBase.C
@@ -48,6 +48,17 @@ namespace QUESO
     }
 
   template<class V, class M>
+  InterpolationSurrogateBase<V,M>::InterpolationSurrogateBase(const InterpolationSurrogateBuilder<V,M>& builder )
+    : SurrogateBase<V>(),
+    m_domain(builder.paramDomain()),
+    m_n_points(builder.n_points()),
+    m_values(builder.values())
+    {
+      // This checks that the dimension of n_points and the domain are consistent
+      this->check_dim_consistency();
+    }
+
+  template<class V, class M>
   unsigned int InterpolationSurrogateBase<V,M>::coordToGlobal( const std::vector<unsigned int>& coord_indices,
                                                                const std::vector<unsigned int>& n_points ) const
   {

--- a/src/surrogates/src/InterpolationSurrogateBase.C
+++ b/src/surrogates/src/InterpolationSurrogateBase.C
@@ -40,38 +40,6 @@ namespace QUESO
     m_data(data)
     {}
 
-  template<class V, class M>
-  unsigned int InterpolationSurrogateBase<V,M>::coordToGlobal( const std::vector<unsigned int>& coord_indices,
-                                                               const std::vector<unsigned int>& n_points ) const
-  {
-    queso_assert_equal_to( coord_indices.size(), this->m_data.dim() );
-    queso_assert_equal_to( n_points.size(), this->m_data.dim() );
-
-    /* Mapping is: i + j*n_i + k*n_i*n_j + l*n_i*n_j*n_k + ...
-       Initialize global_index to "i".
-       Then loop and build up each term.*/
-    queso_assert_less( coord_indices[0], n_points[0] );
-
-    unsigned int global_index = coord_indices[0];
-
-    for( unsigned int d = 1; d < this->m_data.dim(); d++ )
-      {
-        queso_assert_less( coord_indices[d], n_points[d] );
-
-        // Accumulate the current term
-        unsigned int idx = coord_indices[d];
-
-        for( int local_d = d-1; local_d >=0; local_d -= 1)
-          {
-            idx *= n_points[local_d];
-          }
-
-        global_index += idx;
-      }
-
-    return global_index;
-  }
-
 } // end namespace QUESO
 
 // Instantiate

--- a/src/surrogates/src/InterpolationSurrogateBase.C
+++ b/src/surrogates/src/InterpolationSurrogateBase.C
@@ -51,19 +51,20 @@ namespace QUESO
   unsigned int InterpolationSurrogateBase<V,M>::coordToGlobal( const std::vector<unsigned int>& coord_indices,
                                                                const std::vector<unsigned int>& n_points ) const
   {
-    // Make sure dimension is consistent between inputs
     queso_assert_equal_to( coord_indices.size(), this->dim() );
-
-    // Make sure dimension is consisent with parameter space
-    queso_assert_equal_to( coord_indices.size(), this->dim() );
+    queso_assert_equal_to( n_points.size(), this->dim() );
 
     /* Mapping is: i + j*n_i + k*n_i*n_j + l*n_i*n_j*n_k + ...
        Initialize global_index to "i".
        Then loop and build up each term.*/
+    queso_assert_less( coord_indices[0], n_points[0] );
+
     unsigned int global_index = coord_indices[0];
 
     for( unsigned int d = 1; d < this->dim(); d++ )
       {
+        queso_assert_less( coord_indices[d], n_points[d] );
+
         // Accumulate the current term
         unsigned int idx = coord_indices[d];
 

--- a/src/surrogates/src/InterpolationSurrogateBase.C
+++ b/src/surrogates/src/InterpolationSurrogateBase.C
@@ -101,6 +101,16 @@ namespace QUESO
       }
   }
 
+  template<class V, class M>
+  double InterpolationSurrogateBase<V,M>::spacing( unsigned int dim ) const
+  {
+    unsigned int n_intervals = this->m_n_points[dim]-1;
+    double x_min = this->x_min(dim);
+    double x_max = this->x_max(dim);
+
+    return (x_max-x_min)/n_intervals;
+  }
+
 } // end namespace QUESO
 
 // Instantiate

--- a/src/surrogates/src/InterpolationSurrogateBase.C
+++ b/src/surrogates/src/InterpolationSurrogateBase.C
@@ -71,7 +71,6 @@ namespace QUESO
         for( int local_d = d-1; local_d >=0; local_d -= 1)
           {
             idx *= n_points[local_d];
-            local_d -= 1;
           }
 
         global_index += idx;

--- a/src/surrogates/src/InterpolationSurrogateBase.C
+++ b/src/surrogates/src/InterpolationSurrogateBase.C
@@ -36,10 +36,13 @@
 namespace QUESO
 {
   template<class V, class M>
-  InterpolationSurrogateBase<V,M>::InterpolationSurrogateBase(const VectorSet<V,M> & domain,
-                                                              const std::vector<unsigned int>& n_points )
-      : SurrogateBase<V,M>(domain),
-        m_n_points(n_points)
+  InterpolationSurrogateBase<V,M>::InterpolationSurrogateBase(const BoxSubset<V,M> & domain,
+                                                              const std::vector<unsigned int>& n_points,
+                                                              const std::vector<double>& values)
+    : SurrogateBase<V,M>(),
+    m_domain(domain),
+    m_n_points(n_points),
+    m_values(values)
     {
       // This checks that the dimension of n_points and the domain are consistent
       this->check_dim_consistency();

--- a/src/surrogates/src/InterpolationSurrogateBuilder.C
+++ b/src/surrogates/src/InterpolationSurrogateBuilder.C
@@ -99,8 +99,14 @@ namespace QUESO
   template<class V, class M>
   void InterpolationSurrogateBuilder<V,M>::set_work_bounds( unsigned int& n_begin, unsigned int& n_end ) const
   {
+    unsigned int my_subid = this->m_data.get_paramDomain().env().subId();
+
+    /* Starting index will be the sum of the all the previous num jobs */
     n_begin = 0;
-    n_end = this->m_data.n_values();
+    for( unsigned int n = 0; n < my_subid; n++ )
+      n_begin += m_njobs[n];
+
+    n_end = n_begin + m_njobs[my_subid];
   }
 
   template<class V, class M>

--- a/src/surrogates/src/InterpolationSurrogateBuilder.C
+++ b/src/surrogates/src/InterpolationSurrogateBuilder.C
@@ -205,6 +205,27 @@ namespace QUESO
       }
   }
 
+  template<class V, class M>
+  void InterpolationSurrogateBuilder<V,M>::compute_strides( std::vector<int>& strides ) const
+  {
+    unsigned int n_subenvs = this->m_data.get_paramDomain().env().numSubEnvironments();
+
+    strides.resize(n_subenvs);
+
+    // Don't stride the first entry
+    strides[0] = 0;
+
+    long int stride = 0;
+    for( unsigned int n = 1; n < n_subenvs; n++ )
+      {
+        // The stride is measured agaisnt the beginning of the buffer
+        // We want things packed tightly together so just stride
+        // by the number of entries from the previous group.
+        stride += this->m_njobs[n-1];
+        strides[n] = stride;
+      }
+  }
+
 } // end namespace QUESO
 
 // Instantiate

--- a/src/surrogates/src/InterpolationSurrogateBuilder.C
+++ b/src/surrogates/src/InterpolationSurrogateBuilder.C
@@ -41,7 +41,30 @@ namespace QUESO
     m_data(data),
     m_njobs(data.get_paramDomain().env().numSubEnvironments(), 0)
   {
+    this->check_process_config();
+
     this->partition_work();
+  }
+
+  template<class V, class M>
+  void InterpolationSurrogateBuilder<V,M>::check_process_config()
+  {
+    /* If fullComm() > 1 and n_subenvironments == 1 this is strange and means
+       the user is doing redundant work. So, let's make that an error.
+       This could happen if, for example the user forgets to change the number
+       of subenvironments to > 1 and runs with multiple MPI processes. */
+    unsigned int full_comm_size = this->m_data.get_paramDomain().env().fullComm().NumProc();
+    unsigned int n_subenvs = this->m_data.get_paramDomain().env().numSubEnvironments();
+
+    if( (full_comm_size > 1) &&  (n_subenvs == 1) )
+      {
+        std::string error = "ERROR: fullComm() size is greater than 1 and the number\n";
+        error += "       of subenvrionments = 1. InterpolationSurrogateBuilder\n";
+        error += "       is not compatible with this configuration.\n";
+        error += "       Did you forget to change the number of subenvironments?\n";
+
+        queso_error_msg(error);
+      }
   }
 
   template<class V, class M>

--- a/src/surrogates/src/InterpolationSurrogateBuilder.C
+++ b/src/surrogates/src/InterpolationSurrogateBuilder.C
@@ -1,0 +1,60 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// This class
+#include <queso/InterpolationSurrogateBuilder.h>
+
+// QUESO
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+
+namespace QUESO
+{
+  template<class V, class M>
+  InterpolationSurrogateBuilder<V,M>::InterpolationSurrogateBuilder( const BoxSubset<V,M> & domain,
+                                                                     const std::vector<unsigned int>& n_points )
+    : SurrogateBuilderBase<V>(),
+    m_domain(domain),
+    m_n_points(n_points)
+  {
+    this->init_values(this->m_n_points);
+  }
+
+  template<class V, class M>
+  void InterpolationSurrogateBuilder<V,M>::init_values( const std::vector<unsigned int>& n_points )
+  {
+    unsigned int n_total_points = 0;
+    for( std::vector<unsigned int>::const_iterator it = n_points.begin();
+         it != n_points.end(); ++it )
+      {
+        n_total_points += *it;
+      }
+
+    this->m_values.resize(n_total_points);
+  }
+
+} // end namespace QUESO
+
+// Instantiate
+template class QUESO::InterpolationSurrogateBuilder<QUESO::GslVector,QUESO::GslMatrix>;

--- a/src/surrogates/src/InterpolationSurrogateBuilder.C
+++ b/src/surrogates/src/InterpolationSurrogateBuilder.C
@@ -189,7 +189,6 @@ namespace QUESO
 
     // Now broadcast the values data to all other processes
     const MpiComm& fullcomm = this->m_data.get_paramDomain().env().fullComm();
-    fullcomm.Barrier();
 
     std::vector<double>& values = this->m_data.get_values();
     fullcomm.Bcast( &values[0], values.size(), MPI_DOUBLE,

--- a/src/surrogates/src/InterpolationSurrogateBuilder.C
+++ b/src/surrogates/src/InterpolationSurrogateBuilder.C
@@ -32,27 +32,10 @@
 namespace QUESO
 {
   template<class V, class M>
-  InterpolationSurrogateBuilder<V,M>::InterpolationSurrogateBuilder( const BoxSubset<V,M> & domain,
-                                                                     const std::vector<unsigned int>& n_points )
+  InterpolationSurrogateBuilder<V,M>::InterpolationSurrogateBuilder( InterpolationSurrogateData<V,M>& data )
     : SurrogateBuilderBase<V>(),
-    m_domain(domain),
-    m_n_points(n_points)
-  {
-    this->init_values(this->m_n_points);
-  }
-
-  template<class V, class M>
-  void InterpolationSurrogateBuilder<V,M>::init_values( const std::vector<unsigned int>& n_points )
-  {
-    unsigned int n_total_points = 0;
-    for( std::vector<unsigned int>::const_iterator it = n_points.begin();
-         it != n_points.end(); ++it )
-      {
-        n_total_points += *it;
-      }
-
-    this->m_values.resize(n_total_points);
-  }
+    m_data(data)
+  {}
 
 } // end namespace QUESO
 

--- a/src/surrogates/src/InterpolationSurrogateBuilder.C
+++ b/src/surrogates/src/InterpolationSurrogateBuilder.C
@@ -131,11 +131,14 @@ namespace QUESO
 
       MPI_Comm comm = this->m_data.get_paramDomain().env().inter0Comm().Comm();
 
-      int ierr = MPI_Allgather(&local_n[0], local_n.size(), MPI_UNSIGNED, &all_indices[0], all_indices.size(), MPI_UNSIGNED, comm );
+      // Gather the local data all together on each subrank 0 processor.
+      int ierr = MPI_Allgather(&local_n[0], local_n.size(), MPI_UNSIGNED,
+                               &all_indices[0], local_n.size(), MPI_UNSIGNED, comm );
       if( ierr != 0 )
         queso_error_msg("ERROR: Something bad happened in the MPI_Allgather");
 
-      ierr = MPI_Allgather(&local_values[0], local_values.size(), MPI_DOUBLE, &all_values[0], all_values.size(), MPI_DOUBLE, comm );
+      ierr = MPI_Allgather(&local_values[0], local_values.size(), MPI_DOUBLE,
+                           &all_values[0], local_values.size(), MPI_DOUBLE, comm );
       if( ierr != 0 )
         queso_error_msg("ERROR: Something bad happened in the MPI_Allgather");
 

--- a/src/surrogates/src/InterpolationSurrogateData.C
+++ b/src/surrogates/src/InterpolationSurrogateData.C
@@ -105,6 +105,15 @@ namespace QUESO
     return (x_max-x_min)/n_intervals;
   }
 
+  template<class V, class M>
+  double InterpolationSurrogateData<V,M>::get_x( unsigned int dim, unsigned int index ) const
+  {
+    double x_min = this->x_min(dim);
+    double spacing = this->spacing(dim);
+
+    return x_min + spacing*index;
+  }
+
 } // end namespace QUESO
 
 // Instantiate

--- a/src/surrogates/src/InterpolationSurrogateData.C
+++ b/src/surrogates/src/InterpolationSurrogateData.C
@@ -69,11 +69,11 @@ namespace QUESO
   template<class V, class M>
   void InterpolationSurrogateData<V,M>::init_values( const std::vector<unsigned int>& n_points )
   {
-    unsigned int n_total_points = 0;
+    unsigned int n_total_points = 1.0;
     for( std::vector<unsigned int>::const_iterator it = n_points.begin();
          it != n_points.end(); ++it )
       {
-        n_total_points += *it;
+        n_total_points *= *it;
       }
 
     this->m_values.resize(n_total_points);

--- a/src/surrogates/src/InterpolationSurrogateData.C
+++ b/src/surrogates/src/InterpolationSurrogateData.C
@@ -1,0 +1,79 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// This class
+#include <queso/InterpolationSurrogateData.h>
+
+// QUESO
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+
+// C++
+#include <sstream>
+
+namespace QUESO
+{
+  template<class V, class M>
+  InterpolationSurrogateData<V,M>::InterpolationSurrogateData(const BoxSubset<V,M> & domain,
+                                                              const std::vector<unsigned int>& n_points )
+    : m_domain(domain),
+      m_n_points(n_points)
+  {
+    // This checks that the dimension of n_points and the domain are consistent
+    this->check_dim_consistency();
+  }
+
+  template<class V, class M>
+  void InterpolationSurrogateData<V,M>::check_dim_consistency() const
+  {
+    if( this->dim() != this->m_n_points.size() )
+      {
+        std::stringstream vspace_dim;
+        vspace_dim << this->m_domain.vectorSpace().dimGlobal();
+
+        std::stringstream n_points_dim;
+        n_points_dim << this->m_n_points.size();
+
+        std::string error = "ERROR: Mismatch between dimension of parameter space and number of points\n.";
+        error += "        domain dimension = " + vspace_dim.str() + "\n";
+        error += "        points dimension = " + n_points_dim.str() + "\n";
+
+        queso_error_msg(error);
+      }
+  }
+
+  template<class V, class M>
+  double InterpolationSurrogateData<V,M>::spacing( unsigned int dim ) const
+  {
+    unsigned int n_intervals = this->m_n_points[dim]-1;
+    double x_min = this->x_min(dim);
+    double x_max = this->x_max(dim);
+
+    return (x_max-x_min)/n_intervals;
+  }
+
+} // end namespace QUESO
+
+// Instantiate
+template class QUESO::InterpolationSurrogateData<QUESO::GslVector,QUESO::GslMatrix>;

--- a/src/surrogates/src/InterpolationSurrogateData.C
+++ b/src/surrogates/src/InterpolationSurrogateData.C
@@ -42,6 +42,9 @@ namespace QUESO
   {
     // This checks that the dimension of n_points and the domain are consistent
     this->check_dim_consistency();
+
+    // Size m_values
+    this->init_values(this->m_n_points);
   }
 
   template<class V, class M>
@@ -61,6 +64,19 @@ namespace QUESO
 
         queso_error_msg(error);
       }
+  }
+
+  template<class V, class M>
+  void InterpolationSurrogateData<V,M>::init_values( const std::vector<unsigned int>& n_points )
+  {
+    unsigned int n_total_points = 0;
+    for( std::vector<unsigned int>::const_iterator it = n_points.begin();
+         it != n_points.end(); ++it )
+      {
+        n_total_points += *it;
+      }
+
+    this->m_values.resize(n_total_points);
   }
 
   template<class V, class M>

--- a/src/surrogates/src/InterpolationSurrogateData.C
+++ b/src/surrogates/src/InterpolationSurrogateData.C
@@ -80,6 +80,22 @@ namespace QUESO
   }
 
   template<class V, class M>
+  void InterpolationSurrogateData<V,M>::set_values( std::vector<double>& values )
+  {
+    queso_assert_equal_to( values.size(), m_values.size() );
+
+    this->m_values = values;
+  }
+
+  template<class V, class M>
+  void InterpolationSurrogateData<V,M>::set_value( unsigned int n, double value )
+  {
+    queso_assert_less( n, m_values.size() );
+
+    this->m_values[n] = value;
+  }
+
+  template<class V, class M>
   double InterpolationSurrogateData<V,M>::spacing( unsigned int dim ) const
   {
     unsigned int n_intervals = this->m_n_points[dim]-1;

--- a/src/surrogates/src/InterpolationSurrogateHelper.C
+++ b/src/surrogates/src/InterpolationSurrogateHelper.C
@@ -65,4 +65,44 @@ namespace QUESO
     return global_index;
   }
 
+  void InterpolationSurrogateHelper::globalToCoord( unsigned int global,
+                                                    const std::vector<unsigned int>& n_points,
+                                                    std::vector<unsigned int>& coord_indices )
+  {
+    // The input object implicitly carry's the dimension
+    unsigned int dim = n_points.size();
+
+    coord_indices.resize(dim);
+
+    /* coordToGlobal computes: i + j*n_points[0] + k*n_points[0]*n_points[1] + ...
+       so we use integer arithmetic and work backwards. */
+    unsigned int tmp = global;
+
+    for( int d = dim-1; d > 0; d -= 1 )
+      {
+        unsigned int np = compute_npoints_factor( n_points, d );
+        coord_indices[d] = tmp/np;
+        tmp -= coord_indices[d]*np;
+      }
+
+    // What's left should be our starting index
+    coord_indices[0] = tmp;
+
+    // Sanity check: the indices we determined should map back to the global
+    queso_assert_equal_to( global, coordToGlobal(coord_indices,n_points) );
+  }
+
+  unsigned int InterpolationSurrogateHelper::compute_npoints_factor( const std::vector<unsigned int>& n_points,
+                                                                     unsigned int term )
+  {
+    unsigned int value = 1;
+
+    for( unsigned int d = 0; d < term; d++ )
+      {
+        value *= n_points[d];
+      }
+
+    return value;
+  }
+
 } // end namespace QUESO

--- a/src/surrogates/src/InterpolationSurrogateHelper.C
+++ b/src/surrogates/src/InterpolationSurrogateHelper.C
@@ -1,0 +1,68 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// This class
+#include <queso/InterpolationSurrogateHelper.h>
+
+// QUESO
+#include <queso/asserts.h>
+
+namespace QUESO
+{
+
+  unsigned int InterpolationSurrogateHelper::coordToGlobal( const std::vector<unsigned int>& coord_indices,
+                                                            const std::vector<unsigned int>& n_points )
+  {
+    // Make sure the dimension is consisent
+    queso_assert_equal_to( coord_indices.size(), n_points.size() );
+
+    // The input objects implicitly carry the dimension with them
+    unsigned int dim = coord_indices.size();
+
+    /* Mapping is: i + j*n_i + k*n_i*n_j + l*n_i*n_j*n_k + ...
+       Initialize global_index to "i".
+       Then loop and build up each term.*/
+    queso_assert_less( coord_indices[0], n_points[0] );
+
+    unsigned int global_index = coord_indices[0];
+
+    for( unsigned int d = 1; d < dim; d++ )
+      {
+        queso_assert_less( coord_indices[d], n_points[d] );
+
+        // Accumulate the current term
+        unsigned int idx = coord_indices[d];
+
+        for( int local_d = d-1; local_d >=0; local_d -= 1)
+          {
+            idx *= n_points[local_d];
+          }
+
+        global_index += idx;
+      }
+
+    return global_index;
+  }
+
+} // end namespace QUESO

--- a/src/surrogates/src/LinearLagrangeInterpolationSurrogate.C
+++ b/src/surrogates/src/LinearLagrangeInterpolationSurrogate.C
@@ -39,6 +39,11 @@ namespace QUESO
   {}
 
   template<class V, class M>
+  LinearLagrangeInterpolationSurrogate<V,M>::LinearLagrangeInterpolationSurrogate( const InterpolationSurrogateBuilder<V,M>& builder )
+    : InterpolationSurrogateBase<V,M>(builder)
+  {}
+
+  template<class V, class M>
   double LinearLagrangeInterpolationSurrogate<V,M>::evaluate(const V & domainVector) const
   {
     /* Populate indices. These are the lower bound global indices for the

--- a/src/surrogates/src/LinearLagrangeInterpolationSurrogate.C
+++ b/src/surrogates/src/LinearLagrangeInterpolationSurrogate.C
@@ -91,7 +91,8 @@ namespace QUESO
     // First, use the lower bound (global) indices to populate x_min, x_max
     for( unsigned int d = 0; d < this->m_data.dim(); d++ )
       {
-        this->compute_x0_x1( d, indices[d], x_min[d], x_max[d] );
+        x_min[d] = this->m_data.get_x( d, indices[d] );
+        x_max[d] = x_min[d] + this->m_data.spacing( d );
       }
 
     // Now populate the values.
@@ -232,18 +233,6 @@ namespace QUESO
       value = (x-x0)/(x1-x0);
 
     return value;
-  }
-
-  template<class V, class M>
-  void LinearLagrangeInterpolationSurrogate<V,M>::compute_x0_x1( unsigned int dim, unsigned int index,
-                                                                 double& x0, double& x1 ) const
-  {
-    double x_min = this->m_data.x_min(dim);
-
-    double spacing = this->m_data.spacing(dim);
-
-    x0 = x_min + spacing*index;
-    x1 = x0 + spacing;
   }
 
 } // end namespace QUESO

--- a/src/surrogates/src/LinearLagrangeInterpolationSurrogate.C
+++ b/src/surrogates/src/LinearLagrangeInterpolationSurrogate.C
@@ -28,6 +28,7 @@
 // QUESO
 #include <queso/GslVector.h>
 #include <queso/GslMatrix.h>
+#include <queso/InterpolationSurrogateHelper.h>
 
 namespace QUESO
 {
@@ -128,7 +129,7 @@ namespace QUESO
         /* Now that we have the global indices for each coordinate,
            we get the "global" index. This is the index into the global
            values array */
-        unsigned int global = this->coordToGlobal( global_indices, this->m_data.get_n_points() );
+        unsigned int global = InterpolationSurrogateHelper::coordToGlobal( global_indices, this->m_data.get_n_points() );
         values[n] = this->m_data.get_value(global);
       }
   }
@@ -168,30 +169,18 @@ namespace QUESO
 
     /* We're abusing this function as it does what we need to with local_dim = 2
        for all entries of n_points. */
-    return this->coordToGlobal( indices, n_points );
+    return InterpolationSurrogateHelper::coordToGlobal( indices, n_points );
   }
 
   template<class V, class M>
   void LinearLagrangeInterpolationSurrogate<V,M>::singleToCoords( unsigned int global, std::vector<unsigned int>& indices ) const
   {
     unsigned int local_dim = 2;
+    std::vector<unsigned int> n_points( this->m_data.dim(), local_dim );
 
-    /* coordsToSingle computes: i + j*local_dim + k*local_dim*local_dim + ...
-       so we use integer arithmetic and work backwards. */
-    unsigned int tmp = global;
-
-    for( int d = this->m_data.dim()-1; d > 0; d -= 1 )
-      {
-        unsigned int dp = std::pow(local_dim, d);
-        indices[d] = tmp/dp;
-        tmp -= indices[d]*dp;
-      }
-
-    // What's left should be our starting index
-    indices[0] = tmp;
-
-    // Sanity check: the indices we determined should map back to the global
-    queso_assert_equal_to( global, this->coordsToSingle(indices) );
+    /* We're abusing this function as it does what we need to with local_dim = 2
+       for all entries of n_points. */
+    return InterpolationSurrogateHelper::globalToCoord( global, n_points, indices );
   }
 
   template<class V, class M>

--- a/src/surrogates/src/LinearLagrangeInterpolationSurrogate.C
+++ b/src/surrogates/src/LinearLagrangeInterpolationSurrogate.C
@@ -1,0 +1,254 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// This class
+#include <queso/LinearLagrangeInterpolationSurrogate.h>
+
+// QUESO
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+
+namespace QUESO
+{
+  template<class V, class M>
+  LinearLagrangeInterpolationSurrogate<V,M>::LinearLagrangeInterpolationSurrogate(const BoxSubset<V,M> & domain,
+                                                                                  const std::vector<unsigned int>& n_points,
+                                                                                  const std::vector<double>& values)
+    : InterpolationSurrogateBase<V,M>(domain,n_points,values)
+  {}
+
+  template<class V, class M>
+  double LinearLagrangeInterpolationSurrogate<V,M>::evaluate(const V & domainVector) const
+  {
+    /* Populate indices. These are the lower bound global indices for the
+       "element" containing the domainVector */
+    std::vector<unsigned int> indices(this->dim());
+    this->compute_interval_indices(domainVector, indices);
+
+    // lower bound coordinates
+    std::vector<double> x_min(this->dim());
+
+    // upper bound coordinates
+    std::vector<double> x_max(this->dim());
+
+    // Function value at each of the "nodes" for the "element"
+    std::vector<double> values(this->n_coeffs());
+
+    // Use the indices to populate the x_min, etc. structures
+    this->compute_interval_values( indices, x_min, x_max, values );
+
+    // Now evaluate the interpolant
+    return this->eval_interpolant( x_min, x_max, values, domainVector );
+  }
+
+  template<class V, class M>
+  void LinearLagrangeInterpolationSurrogate<V,M>::compute_interval_indices(const V & domainVector,
+                                                                           std::vector<unsigned int>& indices) const
+  {
+    queso_assert_equal_to( domainVector.sizeGlobal(), this->dim() );
+    queso_assert_equal_to( indices.size(), this->dim() );
+
+    for( unsigned int d = 0; d < this->dim(); d++ )
+      {
+        double spacing = this->spacing(d);
+        indices[d] = std::floor( domainVector[d]/spacing );
+
+        // Index should be less than the number of point along this dimension
+        queso_assert_less( indices[d], this->m_n_points[d] );
+      }
+  }
+
+  template<class V, class M>
+  void LinearLagrangeInterpolationSurrogate<V,M>::compute_interval_values( const std::vector<unsigned int>& indices,
+                                                                           std::vector<double>& x_min,
+                                                                           std::vector<double>& x_max,
+                                                                           std::vector<double>& values ) const
+  {
+    queso_assert_equal_to( x_min.size(), this->dim() );
+    queso_assert_equal_to( x_max.size(), this->dim() );
+    queso_assert_equal_to( values.size(), this->n_coeffs() );
+    queso_assert_equal_to( indices.size(), this->dim() );
+
+    // First, use the lower bound (global) indices to populate x_min, x_max
+    for( unsigned int d = 0; d < this->dim(); d++ )
+      {
+        this->compute_x0_x1( d, indices[d], x_min[d], x_max[d] );
+      }
+
+    // Now populate the values.
+    std::vector<unsigned int> local_indices(this->dim());
+    std::vector<unsigned int> global_indices(this->dim());
+    for( unsigned int n = 0 ; n < this->n_coeffs(); n++ )
+      {
+        // Figure out local indices (each coordinate is 0 or 1)
+        this->singleToCoords(n,local_indices);
+
+        /* For each dimension, if the local index is 0, use the lower
+           bound of the global index. If the local index is 1, use the
+           "upper" global index.
+
+           In 2-D:
+           The lower left corner of the element will have local_indices = [0,0];
+           Then, global_indices = [ indices[0], indices[1] ];
+           The upper right corner will have local_indices = [1,1];
+           Then, global_indices = [ indices[0]+1, indices[1]+1 ]; */
+        for( unsigned int d = 0; d < this->dim(); d++ )
+          {
+            if( local_indices[d] == 0 )
+              global_indices[d] = indices[d];
+
+            else if( local_indices[d] == 1 )
+              global_indices[d] = indices[d]+1;
+
+            // This shouldn't happen
+            else
+              queso_error();
+          }
+
+        /* Now that we have the global indices for each coordinate,
+           we get the "global" index. This is the index into the global
+           values array */
+        unsigned int global = this->coordToGlobal( global_indices, this->m_n_points );
+        values[n] = this->m_values[global];
+      }
+  }
+
+  template<class V, class M>
+  double LinearLagrangeInterpolationSurrogate<V,M>::eval_interpolant( const std::vector<double>& x_min,
+                                                                      const std::vector<double>& x_max,
+                                                                      const std::vector<double>& values,
+                                                                      const V & domainVector ) const
+  {
+    queso_assert_equal_to( x_min.size(), this->dim() );
+    queso_assert_equal_to( x_max.size(), this->dim() );
+    queso_assert_equal_to( values.size(), this->n_coeffs() );
+    queso_assert_equal_to( domainVector.sizeGlobal(), this->dim() );
+
+    double interp_value = 0.0;
+
+    std::vector<unsigned int> indices( this->dim() );
+
+    for( unsigned int n = 0; n < this->n_coeffs(); n++ )
+      {
+        this->singleToCoords( n, indices );
+
+        double shape_fn = this->tensor_product_lagrange( x_min, x_max, indices, domainVector );
+
+        interp_value += values[n]*shape_fn;
+      }
+
+    return interp_value;
+  }
+
+  template<class V, class M>
+  unsigned int LinearLagrangeInterpolationSurrogate<V,M>::coordsToSingle( const std::vector<unsigned int>& indices ) const
+  {
+    unsigned int local_dim = 2;
+    std::vector<unsigned int> n_points( this->dim(), local_dim );
+
+    /* We're abusing this function as it does what we need to with local_dim = 2
+       for all entries of n_points. */
+    return this->coordToGlobal( indices, n_points );
+  }
+
+  template<class V, class M>
+  void LinearLagrangeInterpolationSurrogate<V,M>::singleToCoords( unsigned int global, std::vector<unsigned int>& indices ) const
+  {
+    unsigned int local_dim = 2;
+
+    /* coordsToSingle computes: i + j*local_dim + k*local_dim*local_dim + ...
+       so we use integer arithmetic and work backwards. */
+    unsigned int tmp = global;
+
+    for( unsigned int d = this->dim()-1; d > 0; d -= 1 )
+      {
+        unsigned int dp = std::pow(local_dim, d);
+        indices[d] = tmp/dp;
+        tmp -= indices[d]*dp;
+      }
+
+    // What's left should be our starting index
+    indices[0] = tmp;
+
+    // Sanity check: the indices we determined should map back to the global
+    queso_assert_equal_to( global, this->coordsToSingle(indices) );
+  }
+
+  template<class V, class M>
+  double LinearLagrangeInterpolationSurrogate<V,M>::tensor_product_lagrange( const std::vector<double>& x_min,
+                                                                             const std::vector<double>& x_max,
+                                                                             const std::vector<unsigned int>& indices,
+                                                                             const V & domainVector ) const
+  {
+    queso_assert_equal_to( x_min.size(), this->dim() );
+    queso_assert_equal_to( x_max.size(), this->dim() );
+    queso_assert_equal_to( indices.size(), this->dim() );
+    queso_assert_equal_to( domainVector.sizeGlobal(), this->dim() );
+
+    double value = 1.0;
+
+    for( unsigned int d = 0; d < this->dim(); d++ )
+      {
+        value *= this->lagrange_poly( x_min[d], x_max[d], domainVector[d], indices[d] );
+      }
+
+    return value;
+  }
+
+  template<class V, class M>
+  double LinearLagrangeInterpolationSurrogate<V,M>::lagrange_poly( double x0, double x1, double x, unsigned int index ) const
+  {
+    // Make sure we're trying to interpolate between the given points
+    queso_assert_less_equal( x, x1 );
+    queso_assert_greater_equal( x, x0 );
+
+    // Make sure index is either 0 or 1
+    queso_assert( (index == 0) || (index == 1) );
+
+    double value = 0.0;
+
+    if( index == 0 )
+      value = (x-x1)/(x0-x1);
+    else
+      value = (x-x0)/(x1-x0);
+
+    return value;
+  }
+
+  template<class V, class M>
+  void LinearLagrangeInterpolationSurrogate<V,M>::compute_x0_x1( unsigned int dim, unsigned int index,
+                                                                 double& x0, double& x1 ) const
+  {
+    double x_min = this->x_min(dim);
+
+    double spacing = this->spacing(dim);
+
+    x0 = x_min + spacing*index;
+    x1 = x0 + spacing;
+  }
+
+} // end namespace QUESO
+
+// Instantiate
+template class QUESO::LinearLagrangeInterpolationSurrogate<QUESO::GslVector,QUESO::GslMatrix>;

--- a/src/surrogates/src/LinearLagrangeInterpolationSurrogate.C
+++ b/src/surrogates/src/LinearLagrangeInterpolationSurrogate.C
@@ -72,7 +72,7 @@ namespace QUESO
     for( unsigned int d = 0; d < this->dim(); d++ )
       {
         double spacing = this->spacing(d);
-        indices[d] = std::floor( domainVector[d]/spacing );
+        indices[d] = std::floor( (domainVector[d] - this->x_min(d))/spacing );
 
         // Index should be less than the number of point along this dimension
         queso_assert_less( indices[d], this->m_n_points[d] );

--- a/src/surrogates/src/LinearLagrangeInterpolationSurrogate.C
+++ b/src/surrogates/src/LinearLagrangeInterpolationSurrogate.C
@@ -29,6 +29,7 @@
 #include <queso/GslVector.h>
 #include <queso/GslMatrix.h>
 #include <queso/InterpolationSurrogateHelper.h>
+#include <queso/InterpolationSurrogateData.h>
 
 namespace QUESO
 {

--- a/src/surrogates/src/LinearLagrangeInterpolationSurrogate.C
+++ b/src/surrogates/src/LinearLagrangeInterpolationSurrogate.C
@@ -181,7 +181,7 @@ namespace QUESO
        so we use integer arithmetic and work backwards. */
     unsigned int tmp = global;
 
-    for( unsigned int d = this->dim()-1; d > 0; d -= 1 )
+    for( int d = this->dim()-1; d > 0; d -= 1 )
       {
         unsigned int dp = std::pow(local_dim, d);
         indices[d] = tmp/dp;

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -46,6 +46,7 @@ check_PROGRAMS += test_scalarCovarianceChain
 check_PROGRAMS += test_blockDiagonalCovarianceChain
 check_PROGRAMS += test_1D_LinearLagrangeInterpolationSurrogate
 check_PROGRAMS += test_2D_LinearLagrangeInterpolationSurrogate
+check_PROGRAMS += test_3D_LinearLagrangeInterpolationSurrogate
 
 LDADD       = $(top_builddir)/src/libqueso.la
 
@@ -117,6 +118,7 @@ test_scalarCovarianceChain_SOURCES = test_gaussian_likelihoods/test_scalarCovari
 test_blockDiagonalCovarianceChain_SOURCES = test_gaussian_likelihoods/test_blockDiagonalCovarianceChain.C
 test_1D_LinearLagrangeInterpolationSurrogate_SOURCES = test_InterpolationSurrogate/test_1D_LinearLagrangeInterpolationSurrogate.C
 test_2D_LinearLagrangeInterpolationSurrogate_SOURCES = test_InterpolationSurrogate/test_2D_LinearLagrangeInterpolationSurrogate.C
+test_3D_LinearLagrangeInterpolationSurrogate_SOURCES = test_InterpolationSurrogate/test_3D_LinearLagrangeInterpolationSurrogate.C
 
 # Files to freedom stamp
 srcstamp =
@@ -159,6 +161,7 @@ srcstamp += $(test_fullCovarianceRandomCoefficient_SOURCES)
 srcstamp += $(test_blockDiagonalCovarianceRandomCoefficients_SOURCES)
 srcstamp += $(test_1D_LinearLagrangeInterpolationSurrogate_SOURCES)
 srcstamp += $(test_2D_LinearLagrangeInterpolationSurrogate_SOURCES)
+srcstamp += $(test_3D_LinearLagrangeInterpolationSurrogate_SOURCES)
 
 TESTS =
 TESTS += $(top_builddir)/test/test_uqEnvironmentNonFatal
@@ -202,6 +205,7 @@ TESTS += $(top_builddir)/test/test_scalarCovarianceChain
 TESTS += $(top_builddir)/test/test_blockDiagonalCovarianceChain
 TESTS += $(top_builddir)/test/test_1D_LinearLagrangeInterpolationSurrogate
 TESTS += $(top_builddir)/test/test_2D_LinearLagrangeInterpolationSurrogate
+TESTS += $(top_builddir)/test/test_3D_LinearLagrangeInterpolationSurrogate
 
 XFAIL_TESTS = $(top_builddir)/test/test_SequenceOfVectorsErase
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -47,6 +47,7 @@ check_PROGRAMS += test_blockDiagonalCovarianceChain
 check_PROGRAMS += test_1D_LinearLagrangeInterpolationSurrogate
 check_PROGRAMS += test_2D_LinearLagrangeInterpolationSurrogate
 check_PROGRAMS += test_3D_LinearLagrangeInterpolationSurrogate
+check_PROGRAMS += test_4D_LinearLagrangeInterpolationSurrogate
 
 LDADD       = $(top_builddir)/src/libqueso.la
 
@@ -119,6 +120,7 @@ test_blockDiagonalCovarianceChain_SOURCES = test_gaussian_likelihoods/test_block
 test_1D_LinearLagrangeInterpolationSurrogate_SOURCES = test_InterpolationSurrogate/test_1D_LinearLagrangeInterpolationSurrogate.C
 test_2D_LinearLagrangeInterpolationSurrogate_SOURCES = test_InterpolationSurrogate/test_2D_LinearLagrangeInterpolationSurrogate.C
 test_3D_LinearLagrangeInterpolationSurrogate_SOURCES = test_InterpolationSurrogate/test_3D_LinearLagrangeInterpolationSurrogate.C
+test_4D_LinearLagrangeInterpolationSurrogate_SOURCES = test_InterpolationSurrogate/test_4D_LinearLagrangeInterpolationSurrogate.C
 
 # Files to freedom stamp
 srcstamp =
@@ -162,6 +164,7 @@ srcstamp += $(test_blockDiagonalCovarianceRandomCoefficients_SOURCES)
 srcstamp += $(test_1D_LinearLagrangeInterpolationSurrogate_SOURCES)
 srcstamp += $(test_2D_LinearLagrangeInterpolationSurrogate_SOURCES)
 srcstamp += $(test_3D_LinearLagrangeInterpolationSurrogate_SOURCES)
+srcstamp += $(test_4D_LinearLagrangeInterpolationSurrogate_SOURCES)
 
 TESTS =
 TESTS += $(top_builddir)/test/test_uqEnvironmentNonFatal
@@ -206,6 +209,7 @@ TESTS += $(top_builddir)/test/test_blockDiagonalCovarianceChain
 TESTS += $(top_builddir)/test/test_1D_LinearLagrangeInterpolationSurrogate
 TESTS += $(top_builddir)/test/test_2D_LinearLagrangeInterpolationSurrogate
 TESTS += $(top_builddir)/test/test_3D_LinearLagrangeInterpolationSurrogate
+TESTS += $(top_builddir)/test/test_4D_LinearLagrangeInterpolationSurrogate
 
 XFAIL_TESTS = $(top_builddir)/test/test_SequenceOfVectorsErase
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -45,6 +45,7 @@ check_PROGRAMS += test_diagonalCovarianceChain
 check_PROGRAMS += test_scalarCovarianceChain
 check_PROGRAMS += test_blockDiagonalCovarianceChain
 check_PROGRAMS += test_1D_LinearLagrangeInterpolationSurrogate
+check_PROGRAMS += test_2D_LinearLagrangeInterpolationSurrogate
 
 LDADD       = $(top_builddir)/src/libqueso.la
 
@@ -115,6 +116,7 @@ test_diagonalCovarianceChain_SOURCES = test_gaussian_likelihoods/test_diagonalCo
 test_scalarCovarianceChain_SOURCES = test_gaussian_likelihoods/test_scalarCovarianceChain.C
 test_blockDiagonalCovarianceChain_SOURCES = test_gaussian_likelihoods/test_blockDiagonalCovarianceChain.C
 test_1D_LinearLagrangeInterpolationSurrogate_SOURCES = test_InterpolationSurrogate/test_1D_LinearLagrangeInterpolationSurrogate.C
+test_2D_LinearLagrangeInterpolationSurrogate_SOURCES = test_InterpolationSurrogate/test_2D_LinearLagrangeInterpolationSurrogate.C
 
 # Files to freedom stamp
 srcstamp =
@@ -156,6 +158,7 @@ srcstamp += $(test_unifiedPositionsOfMaximum_SOURCES)
 srcstamp += $(test_fullCovarianceRandomCoefficient_SOURCES)
 srcstamp += $(test_blockDiagonalCovarianceRandomCoefficients_SOURCES)
 srcstamp += $(test_1D_LinearLagrangeInterpolationSurrogate_SOURCES)
+srcstamp += $(test_2D_LinearLagrangeInterpolationSurrogate_SOURCES)
 
 TESTS =
 TESTS += $(top_builddir)/test/test_uqEnvironmentNonFatal
@@ -198,6 +201,7 @@ TESTS += $(top_builddir)/test/test_diagonalCovarianceChain
 TESTS += $(top_builddir)/test/test_scalarCovarianceChain
 TESTS += $(top_builddir)/test/test_blockDiagonalCovarianceChain
 TESTS += $(top_builddir)/test/test_1D_LinearLagrangeInterpolationSurrogate
+TESTS += $(top_builddir)/test/test_2D_LinearLagrangeInterpolationSurrogate
 
 XFAIL_TESTS = $(top_builddir)/test/test_SequenceOfVectorsErase
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -48,6 +48,7 @@ check_PROGRAMS += test_1D_LinearLagrangeInterpolationSurrogate
 check_PROGRAMS += test_2D_LinearLagrangeInterpolationSurrogate
 check_PROGRAMS += test_3D_LinearLagrangeInterpolationSurrogate
 check_PROGRAMS += test_4D_LinearLagrangeInterpolationSurrogate
+check_PROGRAMS += test_build_InterpolationSurrogateBuilder
 
 LDADD       = $(top_builddir)/src/libqueso.la
 
@@ -121,6 +122,7 @@ test_1D_LinearLagrangeInterpolationSurrogate_SOURCES = test_InterpolationSurroga
 test_2D_LinearLagrangeInterpolationSurrogate_SOURCES = test_InterpolationSurrogate/test_2D_LinearLagrangeInterpolationSurrogate.C
 test_3D_LinearLagrangeInterpolationSurrogate_SOURCES = test_InterpolationSurrogate/test_3D_LinearLagrangeInterpolationSurrogate.C
 test_4D_LinearLagrangeInterpolationSurrogate_SOURCES = test_InterpolationSurrogate/test_4D_LinearLagrangeInterpolationSurrogate.C
+test_build_InterpolationSurrogateBuilder_SOURCES = test_InterpolationSurrogate/test_build_InterpolationSurrogateBuilder.C
 
 # Files to freedom stamp
 srcstamp =
@@ -165,6 +167,7 @@ srcstamp += $(test_1D_LinearLagrangeInterpolationSurrogate_SOURCES)
 srcstamp += $(test_2D_LinearLagrangeInterpolationSurrogate_SOURCES)
 srcstamp += $(test_3D_LinearLagrangeInterpolationSurrogate_SOURCES)
 srcstamp += $(test_4D_LinearLagrangeInterpolationSurrogate_SOURCES)
+srcstamp += $(test_build_InterpolationSurrogateBuilder_SOURCES)
 
 TESTS =
 TESTS += $(top_builddir)/test/test_uqEnvironmentNonFatal
@@ -210,6 +213,7 @@ TESTS += $(top_builddir)/test/test_1D_LinearLagrangeInterpolationSurrogate
 TESTS += $(top_builddir)/test/test_2D_LinearLagrangeInterpolationSurrogate
 TESTS += $(top_builddir)/test/test_3D_LinearLagrangeInterpolationSurrogate
 TESTS += $(top_builddir)/test/test_4D_LinearLagrangeInterpolationSurrogate
+TESTS += $(top_builddir)/test/test_build_InterpolationSurrogateBuilder
 
 XFAIL_TESTS = $(top_builddir)/test/test_SequenceOfVectorsErase
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -44,6 +44,7 @@ check_PROGRAMS += test_fullCovarianceChain
 check_PROGRAMS += test_diagonalCovarianceChain
 check_PROGRAMS += test_scalarCovarianceChain
 check_PROGRAMS += test_blockDiagonalCovarianceChain
+check_PROGRAMS += test_1D_LinearLagrangeInterpolationSurrogate
 
 LDADD       = $(top_builddir)/src/libqueso.la
 
@@ -113,6 +114,7 @@ test_fullCovarianceChain_SOURCES = test_gaussian_likelihoods/test_fullCovariance
 test_diagonalCovarianceChain_SOURCES = test_gaussian_likelihoods/test_diagonalCovarianceChain.C
 test_scalarCovarianceChain_SOURCES = test_gaussian_likelihoods/test_scalarCovarianceChain.C
 test_blockDiagonalCovarianceChain_SOURCES = test_gaussian_likelihoods/test_blockDiagonalCovarianceChain.C
+test_1D_LinearLagrangeInterpolationSurrogate_SOURCES = test_InterpolationSurrogate/test_1D_LinearLagrangeInterpolationSurrogate.C
 
 # Files to freedom stamp
 srcstamp =
@@ -153,6 +155,7 @@ srcstamp += $(test_GslBlockMatrixInvertMultiply_SOURCES)
 srcstamp += $(test_unifiedPositionsOfMaximum_SOURCES)
 srcstamp += $(test_fullCovarianceRandomCoefficient_SOURCES)
 srcstamp += $(test_blockDiagonalCovarianceRandomCoefficients_SOURCES)
+srcstamp += $(test_1D_LinearLagrangeInterpolationSurrogate_SOURCES)
 
 TESTS =
 TESTS += $(top_builddir)/test/test_uqEnvironmentNonFatal
@@ -194,6 +197,7 @@ TESTS += $(top_builddir)/test/test_fullCovarianceChain
 TESTS += $(top_builddir)/test/test_diagonalCovarianceChain
 TESTS += $(top_builddir)/test/test_scalarCovarianceChain
 TESTS += $(top_builddir)/test/test_blockDiagonalCovarianceChain
+TESTS += $(top_builddir)/test/test_1D_LinearLagrangeInterpolationSurrogate
 
 XFAIL_TESTS = $(top_builddir)/test/test_SequenceOfVectorsErase
 
@@ -218,6 +222,7 @@ EXTRA_DIST += test_Regression/test_jeffreys_samples_diff.sh.in
 EXTRA_DIST += test_Regression/test_jeffreys_samples.m.in
 EXTRA_DIST += test_Regression/adaptedcov_input.txt.in
 EXTRA_DIST += test_gaussian_likelihoods/queso_input.txt.in
+EXTRA_DIST += test_InterpolationSurrogate/queso_input.txt.in
 EXTRA_DIST += test_SequenceOfVectors/test_unifiedPositionsOfMaximum.sh.in
 
 CLEANFILES =

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -48,6 +48,7 @@ check_PROGRAMS += test_1D_LinearLagrangeInterpolationSurrogate
 check_PROGRAMS += test_2D_LinearLagrangeInterpolationSurrogate
 check_PROGRAMS += test_3D_LinearLagrangeInterpolationSurrogate
 check_PROGRAMS += test_4D_LinearLagrangeInterpolationSurrogate
+check_PROGRAMS += test_InterpolationSurrogateHelper
 check_PROGRAMS += test_build_InterpolationSurrogateBuilder
 
 LDADD       = $(top_builddir)/src/libqueso.la
@@ -122,6 +123,7 @@ test_1D_LinearLagrangeInterpolationSurrogate_SOURCES = test_InterpolationSurroga
 test_2D_LinearLagrangeInterpolationSurrogate_SOURCES = test_InterpolationSurrogate/test_2D_LinearLagrangeInterpolationSurrogate.C
 test_3D_LinearLagrangeInterpolationSurrogate_SOURCES = test_InterpolationSurrogate/test_3D_LinearLagrangeInterpolationSurrogate.C
 test_4D_LinearLagrangeInterpolationSurrogate_SOURCES = test_InterpolationSurrogate/test_4D_LinearLagrangeInterpolationSurrogate.C
+test_InterpolationSurrogateHelper_SOURCES = test_InterpolationSurrogate/test_InterpolationSurrogateHelper.C
 test_build_InterpolationSurrogateBuilder_SOURCES = test_InterpolationSurrogate/test_build_InterpolationSurrogateBuilder.C
 
 # Files to freedom stamp
@@ -167,6 +169,7 @@ srcstamp += $(test_1D_LinearLagrangeInterpolationSurrogate_SOURCES)
 srcstamp += $(test_2D_LinearLagrangeInterpolationSurrogate_SOURCES)
 srcstamp += $(test_3D_LinearLagrangeInterpolationSurrogate_SOURCES)
 srcstamp += $(test_4D_LinearLagrangeInterpolationSurrogate_SOURCES)
+srcstamp += $(test_InterpolationSurrogateHelper_SOURCES)
 srcstamp += $(test_build_InterpolationSurrogateBuilder_SOURCES)
 
 TESTS =
@@ -213,6 +216,7 @@ TESTS += $(top_builddir)/test/test_1D_LinearLagrangeInterpolationSurrogate
 TESTS += $(top_builddir)/test/test_2D_LinearLagrangeInterpolationSurrogate
 TESTS += $(top_builddir)/test/test_3D_LinearLagrangeInterpolationSurrogate
 TESTS += $(top_builddir)/test/test_4D_LinearLagrangeInterpolationSurrogate
+TESTS += $(top_builddir)/test/test_InterpolationSurrogateHelper
 TESTS += $(top_builddir)/test/test_build_InterpolationSurrogateBuilder
 
 XFAIL_TESTS = $(top_builddir)/test/test_SequenceOfVectorsErase

--- a/test/test_InterpolationSurrogate/queso_input.txt.in
+++ b/test/test_InterpolationSurrogate/queso_input.txt.in
@@ -1,0 +1,48 @@
+###############################################
+# UQ Environment
+###############################################
+env_help                 = 1
+env_numSubEnvironments   = 1
+env_subDisplayFileName   = test_output_interp_surrogates/display
+env_subDisplayAllowAll   = 0
+env_subDisplayAllowedSet = 0
+env_displayVerbosity     = 1000
+env_syncVerbosity        = 0
+env_seed                 = 0
+
+###############################################
+# Statistical inverse problem (ip)
+###############################################
+ip_help                 = anything
+ip_computeSolution      = 1
+ip_dataOutputFileName   = test_output_interp_surrogates/sipOutput
+ip_dataOutputAllowedSet = 0
+
+###############################################
+# 'ip_': information for Metropolis-Hastings algorithm
+###############################################
+ip_mh_help                 = anything
+ip_mh_dataOutputFileName   = test_output_interp_surrogates/sipOutput
+ip_mh_dataOutputAllowedSet = 0 1
+
+ip_mh_rawChain_dataInputFileName    = .
+ip_mh_rawChain_size                 = 1
+ip_mh_rawChain_generateExtra        = 0
+ip_mh_rawChain_displayPeriod        = 2000
+ip_mh_rawChain_measureRunTimes      = 1
+ip_mh_rawChain_dataOutputFileName   = test_output_interp_surrogates/ip_raw_chain
+ip_mh_rawChain_dataOutputAllowedSet = 0 1
+ip_mh_rawChain_computeStats         = 1
+
+ip_mh_displayCandidates             = 0
+ip_mh_putOutOfBoundsInChain         = 0
+ip_mh_tk_useLocalHessian            = 0
+ip_mh_tk_useNewtonComponent         = 0
+ip_mh_dr_maxNumExtraStages          = 0
+ip_mh_dr_listOfScalesForExtraStages = 5. 10. 20.
+ip_mh_am_initialNonAdaptInterval    = 10
+ip_mh_am_adaptInterval              = 1
+ip_mh_am_eta                        = 0.384
+ip_mh_am_epsilon                    = 1.e-5
+
+ip_mh_filteredChain_generate        = 0

--- a/test/test_InterpolationSurrogate/test_1D_LinearLagrangeInterpolationSurrogate.C
+++ b/test/test_InterpolationSurrogate/test_1D_LinearLagrangeInterpolationSurrogate.C
@@ -26,6 +26,7 @@
 #include <queso/GslMatrix.h>
 #include <queso/BoxSubset.h>
 #include <queso/LinearLagrangeInterpolationSurrogate.h>
+#include <queso/InterpolationSurrogateData.h>
 
 double one_d_fn( double x );
 

--- a/test/test_InterpolationSurrogate/test_1D_LinearLagrangeInterpolationSurrogate.C
+++ b/test/test_InterpolationSurrogate/test_1D_LinearLagrangeInterpolationSurrogate.C
@@ -1,0 +1,96 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/BoxSubset.h>
+#include <queso/LinearLagrangeInterpolationSurrogate.h>
+
+double one_d_fn( double x );
+
+int main(int argc, char ** argv)
+{
+  MPI_Init(&argc, &argv);
+  QUESO::FullEnvironment env(MPI_COMM_WORLD, "test_InterpolationSurrogate/queso_input.txt", "", NULL);
+
+  int return_flag = 0;
+
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>
+    paramSpace(env,"param_", 1, NULL);
+
+  double min_val = -5;
+  double max_val = 3;
+
+  QUESO::GslVector paramMins(paramSpace.zeroVector());
+  paramMins.cwSet(min_val);
+  QUESO::GslVector paramMaxs(paramSpace.zeroVector());
+  paramMaxs.cwSet(max_val);
+
+  QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix>
+    paramDomain("param_", paramSpace, paramMins, paramMaxs);
+
+  std::vector<unsigned int> n_points(1, 101);
+  std::vector<double> values(n_points[0]);
+
+  double spacing = (max_val - min_val)/(n_points[0]-1);
+
+  for( unsigned int i = 0; i < n_points[0]; i++ )
+    {
+      double x = min_val + i*spacing;
+      values[i] = one_d_fn(x);
+    }
+
+  QUESO::LinearLagrangeInterpolationSurrogate<QUESO::GslVector,QUESO::GslMatrix>
+    one_d_surrogate( paramDomain, n_points, values );
+
+  QUESO::GslVector domainVector(paramSpace.zeroVector());
+  domainVector.cwSet(1.221);
+
+  double test_val = one_d_surrogate.evaluate(domainVector);
+
+  double exact_val = one_d_fn(1.221);
+
+  double tol = 2.0*std::numeric_limits<double>::epsilon();
+
+  double rel_error = (test_val - exact_val)/exact_val;
+
+  if( std::fabs(rel_error) > tol )
+    {
+      std::cerr << "ERROR: Tolerance exceeded for 1D Lagrange interpolation test."
+                << std::endl
+                << " test_val  = " << test_val << std::endl
+                << " exact_val = " << exact_val << std::endl
+                << " rel_error = " << rel_error << std::endl
+                << " tol       = " << tol << std::endl;
+
+      return_flag = 1;
+    }
+
+  return return_flag;
+}
+
+double one_d_fn( double x )
+{
+  return 3.0 + 2.5*x;
+}

--- a/test/test_InterpolationSurrogate/test_1D_LinearLagrangeInterpolationSurrogate.C
+++ b/test/test_InterpolationSurrogate/test_1D_LinearLagrangeInterpolationSurrogate.C
@@ -51,6 +51,10 @@ int main(int argc, char ** argv)
     paramDomain("param_", paramSpace, paramMins, paramMaxs);
 
   std::vector<unsigned int> n_points(1, 101);
+
+  QUESO::InterpolationSurrogateData<QUESO::GslVector, QUESO::GslMatrix>
+    data(paramDomain,n_points);
+
   std::vector<double> values(n_points[0]);
 
   double spacing = (max_val - min_val)/(n_points[0]-1);
@@ -61,8 +65,10 @@ int main(int argc, char ** argv)
       values[i] = one_d_fn(x);
     }
 
+  data.set_values( values );
+
   QUESO::LinearLagrangeInterpolationSurrogate<QUESO::GslVector,QUESO::GslMatrix>
-    one_d_surrogate( paramDomain, n_points, values );
+    one_d_surrogate( data );
 
   QUESO::GslVector domainVector(paramSpace.zeroVector());
   domainVector.cwSet(1.221);

--- a/test/test_InterpolationSurrogate/test_2D_LinearLagrangeInterpolationSurrogate.C
+++ b/test/test_InterpolationSurrogate/test_2D_LinearLagrangeInterpolationSurrogate.C
@@ -1,0 +1,108 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/BoxSubset.h>
+#include <queso/LinearLagrangeInterpolationSurrogate.h>
+
+double two_d_fn( double x, double y );
+
+int main(int argc, char ** argv)
+{
+  MPI_Init(&argc, &argv);
+  QUESO::FullEnvironment env(MPI_COMM_WORLD, "test_InterpolationSurrogate/queso_input.txt", "", NULL);
+
+  int return_flag = 0;
+
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>
+    paramSpace(env,"param_", 2, NULL);
+
+  QUESO::GslVector paramMins(paramSpace.zeroVector());
+  paramMins[0] = -2.5;
+  paramMins[1] = 3.0;
+
+  QUESO::GslVector paramMaxs(paramSpace.zeroVector());
+  paramMaxs[0] = 1.4;
+  paramMaxs[1] = 4.1;
+
+  QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix>
+    paramDomain("param_", paramSpace, paramMins, paramMaxs);
+
+  std::vector<unsigned int> n_points(2);
+  n_points[0] = 101;
+  n_points[1] = 51;
+
+  std::vector<double> values(n_points[0]*n_points[1]);
+
+  double spacing_x = (paramMaxs[0] - paramMins[0])/(n_points[0]-1);
+  double spacing_y = (paramMaxs[1] - paramMins[1])/(n_points[1]-1);
+
+  for( unsigned int i = 0; i < n_points[0]; i++ )
+    {
+      for( unsigned int j = 0; j < n_points[1]; j++ )
+        {
+          unsigned int n = i + j*n_points[0];
+
+          double x = paramMins[0] + i*spacing_x;
+          double y = paramMins[1] + j*spacing_y;
+
+          values[n] = two_d_fn(x,y);
+        }
+    }
+
+  QUESO::LinearLagrangeInterpolationSurrogate<QUESO::GslVector,QUESO::GslMatrix>
+    two_d_surrogate( paramDomain, n_points, values );
+
+  QUESO::GslVector domainVector(paramSpace.zeroVector());
+  domainVector[0] = -0.4;
+  domainVector[1] = 3.764;
+
+  double test_val = two_d_surrogate.evaluate(domainVector);
+
+  double exact_val = two_d_fn(domainVector[0],domainVector[1]);
+
+  double tol = 2.0*std::numeric_limits<double>::epsilon();
+
+  double rel_error = (test_val - exact_val)/exact_val;
+
+  if( std::fabs(rel_error) > tol )
+    {
+      std::cerr << "ERROR: Tolerance exceeded for 2D Lagrange interpolation test."
+                << std::endl
+                << " test_val  = " << test_val << std::endl
+                << " exact_val = " << exact_val << std::endl
+                << " rel_error = " << rel_error << std::endl
+                << " tol       = " << tol << std::endl;
+
+      return_flag = 1;
+    }
+
+  return return_flag;
+}
+
+double two_d_fn( double x, double y )
+{
+  return 3.0 + 2.5*x - 3.1*y +0.1*x*y;
+}

--- a/test/test_InterpolationSurrogate/test_2D_LinearLagrangeInterpolationSurrogate.C
+++ b/test/test_InterpolationSurrogate/test_2D_LinearLagrangeInterpolationSurrogate.C
@@ -26,6 +26,7 @@
 #include <queso/GslMatrix.h>
 #include <queso/BoxSubset.h>
 #include <queso/LinearLagrangeInterpolationSurrogate.h>
+#include <queso/InterpolationSurrogateData.h>
 
 double two_d_fn( double x, double y );
 

--- a/test/test_InterpolationSurrogate/test_2D_LinearLagrangeInterpolationSurrogate.C
+++ b/test/test_InterpolationSurrogate/test_2D_LinearLagrangeInterpolationSurrogate.C
@@ -54,6 +54,9 @@ int main(int argc, char ** argv)
   n_points[0] = 101;
   n_points[1] = 51;
 
+  QUESO::InterpolationSurrogateData<QUESO::GslVector, QUESO::GslMatrix>
+    data(paramDomain,n_points);
+
   std::vector<double> values(n_points[0]*n_points[1]);
 
   double spacing_x = (paramMaxs[0] - paramMins[0])/(n_points[0]-1);
@@ -72,8 +75,10 @@ int main(int argc, char ** argv)
         }
     }
 
+  data.set_values( values );
+
   QUESO::LinearLagrangeInterpolationSurrogate<QUESO::GslVector,QUESO::GslMatrix>
-    two_d_surrogate( paramDomain, n_points, values );
+    two_d_surrogate( data );
 
   QUESO::GslVector domainVector(paramSpace.zeroVector());
   domainVector[0] = -0.4;

--- a/test/test_InterpolationSurrogate/test_3D_LinearLagrangeInterpolationSurrogate.C
+++ b/test/test_InterpolationSurrogate/test_3D_LinearLagrangeInterpolationSurrogate.C
@@ -1,0 +1,117 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/BoxSubset.h>
+#include <queso/LinearLagrangeInterpolationSurrogate.h>
+
+double three_d_fn( double x, double y, double z );
+
+int main(int argc, char ** argv)
+{
+  MPI_Init(&argc, &argv);
+  QUESO::FullEnvironment env(MPI_COMM_WORLD, "test_InterpolationSurrogate/queso_input.txt", "", NULL);
+
+  int return_flag = 0;
+
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>
+    paramSpace(env,"param_", 3, NULL);
+
+  QUESO::GslVector paramMins(paramSpace.zeroVector());
+  paramMins[0] = -1;
+  paramMins[1] = -0.5;
+  paramMins[2] = 1.1;
+
+  QUESO::GslVector paramMaxs(paramSpace.zeroVector());
+  paramMaxs[0] = 0.9;
+  paramMaxs[1] = 3.14;
+  paramMaxs[2] = 2.1;
+
+  QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix>
+    paramDomain("param_", paramSpace, paramMins, paramMaxs);
+
+  std::vector<unsigned int> n_points(3);
+  n_points[0] = 101;
+  n_points[1] = 51;
+  n_points[2] = 31;
+
+  std::vector<double> values(n_points[0]*n_points[1]*n_points[2]);
+
+  double spacing_x = (paramMaxs[0] - paramMins[0])/(n_points[0]-1);
+  double spacing_y = (paramMaxs[1] - paramMins[1])/(n_points[1]-1);
+  double spacing_z = (paramMaxs[2] - paramMins[2])/(n_points[2]-1);
+
+  for( unsigned int i = 0; i < n_points[0]; i++ )
+    {
+      for( unsigned int j = 0; j < n_points[1]; j++ )
+        {
+          for( unsigned int k = 0; k < n_points[2]; k++ )
+            {
+              unsigned int n = i + j*n_points[0] + k*n_points[0]*n_points[1];
+
+              double x = paramMins[0] + i*spacing_x;
+              double y = paramMins[1] + j*spacing_y;
+              double z = paramMins[2] + k*spacing_z;
+
+              values[n] = three_d_fn(x,y,z);
+            }
+        }
+    }
+
+  QUESO::LinearLagrangeInterpolationSurrogate<QUESO::GslVector,QUESO::GslMatrix>
+    three_d_surrogate( paramDomain, n_points, values );
+
+  QUESO::GslVector domainVector(paramSpace.zeroVector());
+  domainVector[0] = -0.4;
+  domainVector[1] = 3.0;
+  domainVector[2] = 1.5;
+
+  double test_val = three_d_surrogate.evaluate(domainVector);
+
+  double exact_val = three_d_fn(domainVector[0],domainVector[1],domainVector[2]);
+
+  double tol = 2.0*std::numeric_limits<double>::epsilon();
+
+  double rel_error = (test_val - exact_val)/exact_val;
+
+  if( std::fabs(rel_error) > tol )
+    {
+      std::cerr << "ERROR: Tolerance exceeded for 3D Lagrange interpolation test."
+                << std::endl
+                << " test_val  = " << test_val << std::endl
+                << " exact_val = " << exact_val << std::endl
+                << " rel_error = " << rel_error << std::endl
+                << " tol       = " << tol << std::endl;
+
+      return_flag = 1;
+    }
+
+  return return_flag;
+}
+
+double three_d_fn( double x, double y, double z )
+{
+  return 3.0 + 2.5*x - 3.1*y + 2.71*z + 0.1*x*y + 1.2*x*z + 0.5*y*z + 2.5*x*y*z;
+}

--- a/test/test_InterpolationSurrogate/test_3D_LinearLagrangeInterpolationSurrogate.C
+++ b/test/test_InterpolationSurrogate/test_3D_LinearLagrangeInterpolationSurrogate.C
@@ -26,6 +26,7 @@
 #include <queso/GslMatrix.h>
 #include <queso/BoxSubset.h>
 #include <queso/LinearLagrangeInterpolationSurrogate.h>
+#include <queso/InterpolationSurrogateData.h>
 
 double three_d_fn( double x, double y, double z );
 

--- a/test/test_InterpolationSurrogate/test_3D_LinearLagrangeInterpolationSurrogate.C
+++ b/test/test_InterpolationSurrogate/test_3D_LinearLagrangeInterpolationSurrogate.C
@@ -57,6 +57,9 @@ int main(int argc, char ** argv)
   n_points[1] = 51;
   n_points[2] = 31;
 
+  QUESO::InterpolationSurrogateData<QUESO::GslVector, QUESO::GslMatrix>
+    data(paramDomain,n_points);
+
   std::vector<double> values(n_points[0]*n_points[1]*n_points[2]);
 
   double spacing_x = (paramMaxs[0] - paramMins[0])/(n_points[0]-1);
@@ -80,8 +83,10 @@ int main(int argc, char ** argv)
         }
     }
 
+  data.set_values( values );
+
   QUESO::LinearLagrangeInterpolationSurrogate<QUESO::GslVector,QUESO::GslMatrix>
-    three_d_surrogate( paramDomain, n_points, values );
+    three_d_surrogate( data );
 
   QUESO::GslVector domainVector(paramSpace.zeroVector());
   domainVector[0] = -0.4;

--- a/test/test_InterpolationSurrogate/test_4D_LinearLagrangeInterpolationSurrogate.C
+++ b/test/test_InterpolationSurrogate/test_4D_LinearLagrangeInterpolationSurrogate.C
@@ -60,6 +60,9 @@ int main(int argc, char ** argv)
   n_points[2] = 31;
   n_points[3] = 41;
 
+  QUESO::InterpolationSurrogateData<QUESO::GslVector, QUESO::GslMatrix>
+    data(paramDomain,n_points);
+
   std::vector<double> values(n_points[0]*n_points[1]*n_points[2]*n_points[3]);
 
   double spacing_x = (paramMaxs[0] - paramMins[0])/(n_points[0]-1);
@@ -89,8 +92,10 @@ int main(int argc, char ** argv)
         }
     }
 
+  data.set_values( values );
+
   QUESO::LinearLagrangeInterpolationSurrogate<QUESO::GslVector,QUESO::GslMatrix>
-    four_d_surrogate( paramDomain, n_points, values );
+    four_d_surrogate( data );
 
   QUESO::GslVector domainVector(paramSpace.zeroVector());
   domainVector[0] = -0.4;

--- a/test/test_InterpolationSurrogate/test_4D_LinearLagrangeInterpolationSurrogate.C
+++ b/test/test_InterpolationSurrogate/test_4D_LinearLagrangeInterpolationSurrogate.C
@@ -26,6 +26,7 @@
 #include <queso/GslMatrix.h>
 #include <queso/BoxSubset.h>
 #include <queso/LinearLagrangeInterpolationSurrogate.h>
+#include <queso/InterpolationSurrogateData.h>
 
 double four_d_fn( double x, double y, double z, double a );
 

--- a/test/test_InterpolationSurrogate/test_4D_LinearLagrangeInterpolationSurrogate.C
+++ b/test/test_InterpolationSurrogate/test_4D_LinearLagrangeInterpolationSurrogate.C
@@ -1,0 +1,130 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/BoxSubset.h>
+#include <queso/LinearLagrangeInterpolationSurrogate.h>
+
+double four_d_fn( double x, double y, double z, double a );
+
+int main(int argc, char ** argv)
+{
+  MPI_Init(&argc, &argv);
+  QUESO::FullEnvironment env(MPI_COMM_WORLD, "test_InterpolationSurrogate/queso_input.txt", "", NULL);
+
+  int return_flag = 0;
+
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>
+    paramSpace(env,"param_", 4, NULL);
+
+  QUESO::GslVector paramMins(paramSpace.zeroVector());
+  paramMins[0] = -1;
+  paramMins[1] = -0.5;
+  paramMins[2] = 1.1;
+  paramMins[3] = -2.1;
+
+  QUESO::GslVector paramMaxs(paramSpace.zeroVector());
+  paramMaxs[0] = 0.9;
+  paramMaxs[1] = 3.14;
+  paramMaxs[2] = 2.1;
+  paramMaxs[3] = 4.1;
+
+  QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix>
+    paramDomain("param_", paramSpace, paramMins, paramMaxs);
+
+  std::vector<unsigned int> n_points(4);
+  n_points[0] = 101;
+  n_points[1] = 51;
+  n_points[2] = 31;
+  n_points[3] = 41;
+
+  std::vector<double> values(n_points[0]*n_points[1]*n_points[2]*n_points[3]);
+
+  double spacing_x = (paramMaxs[0] - paramMins[0])/(n_points[0]-1);
+  double spacing_y = (paramMaxs[1] - paramMins[1])/(n_points[1]-1);
+  double spacing_z = (paramMaxs[2] - paramMins[2])/(n_points[2]-1);
+  double spacing_a = (paramMaxs[3] - paramMins[3])/(n_points[3]-1);
+
+  for( unsigned int i = 0; i < n_points[0]; i++ )
+    {
+      for( unsigned int j = 0; j < n_points[1]; j++ )
+        {
+          for( unsigned int k = 0; k < n_points[2]; k++ )
+            {
+              for( unsigned int l = 0; l < n_points[3]; l++ )
+                {
+                  unsigned int n = i + j*n_points[0] + k*n_points[0]*n_points[1]
+                    + l*n_points[0]*n_points[1]*n_points[2];
+
+                  double x = paramMins[0] + i*spacing_x;
+                  double y = paramMins[1] + j*spacing_y;
+                  double z = paramMins[2] + k*spacing_z;
+                  double a = paramMins[3] + l*spacing_a;
+
+                  values[n] = four_d_fn(x,y,z,a);
+                }
+            }
+        }
+    }
+
+  QUESO::LinearLagrangeInterpolationSurrogate<QUESO::GslVector,QUESO::GslMatrix>
+    four_d_surrogate( paramDomain, n_points, values );
+
+  QUESO::GslVector domainVector(paramSpace.zeroVector());
+  domainVector[0] = -0.4;
+  domainVector[1] = 3.0;
+  domainVector[2] = 1.5;
+  domainVector[3] = 1.65;
+
+  double test_val = four_d_surrogate.evaluate(domainVector);
+
+  double exact_val = four_d_fn(domainVector[0],domainVector[1],domainVector[2],domainVector[3]);
+
+  double tol = 2.0*std::numeric_limits<double>::epsilon();
+
+  double rel_error = (test_val - exact_val)/exact_val;
+
+  if( std::fabs(rel_error) > tol )
+    {
+      std::cerr << "ERROR: Tolerance exceeded for 3D Lagrange interpolation test."
+                << std::endl
+                << " test_val  = " << test_val << std::endl
+                << " exact_val = " << exact_val << std::endl
+                << " rel_error = " << rel_error << std::endl
+                << " tol       = " << tol << std::endl;
+
+      return_flag = 1;
+    }
+
+  return return_flag;
+}
+
+double four_d_fn( double x, double y, double z, double a )
+{
+  return 3.0 + 2.5*x - 3.1*y + 2.71*z + 3.14*a
+    + 0.1*x*y + 1.2*x*z + 0.5*y*z + 0.1*x*a + 1.1*y*a + 2.1*z*a
+    + 0.3*x*y*a + 0.5*x*z*a + 1.2*y*z*a + 0.9*x*y*z
+    + 2.5*x*y*z*a;
+}

--- a/test/test_InterpolationSurrogate/test_InterpolationSurrogateHelper.C
+++ b/test/test_InterpolationSurrogate/test_InterpolationSurrogateHelper.C
@@ -1,0 +1,68 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/InterpolationSurrogateHelper.h>
+
+// C++
+#include <iostream>
+
+int main()
+{
+  std::vector<unsigned int> n_points(5);
+
+  n_points[0] = 11;
+  n_points[1] = 21;
+  n_points[2] = 31;
+  n_points[3] = 41;
+  n_points[4] = 51;
+
+  std::vector<unsigned int> indices(5);
+  indices[0] = 1;
+  indices[1] = 2;
+  indices[2] = 3;
+  indices[3] = 4;
+  indices[4] = 5;
+
+  unsigned int global_exact =
+    indices[0] +
+    indices[1]*n_points[0] +
+    indices[2]*n_points[0]*n_points[1] +
+    indices[3]*n_points[0]*n_points[1]*n_points[2] +
+    indices[4]*n_points[0]*n_points[1]*n_points[2]*n_points[3];
+
+  int return_flag = 0;
+
+  unsigned int global = QUESO::InterpolationSurrogateHelper::coordToGlobal( indices, n_points );
+
+  // This is integer arithmetic so it should be exactly zero error
+  if( (global - global_exact) != 0 )
+    {
+      std::cerr << "ERROR: mismatch in InterpolationSurrogateHelper::coordToGlobal test." << std::endl
+                << "       test  = " << global << std::endl
+                << "       exact = " << global_exact << std::endl;
+      return_flag = 1;
+    }
+
+  return return_flag;
+}

--- a/test/test_InterpolationSurrogate/test_InterpolationSurrogateHelper.C
+++ b/test/test_InterpolationSurrogate/test_InterpolationSurrogateHelper.C
@@ -64,5 +64,35 @@ int main()
       return_flag = 1;
     }
 
+  std::vector<unsigned int> indices_test;
+  QUESO::InterpolationSurrogateHelper::globalToCoord( global, n_points, indices_test );
+
+  unsigned int test_indices = 0;
+  for( unsigned int d = 0; d < 5; d++ )
+    {
+      if( indices[d] != indices_test[d] )
+        test_indices = 1;
+    }
+
+  if( test_indices == 1 )
+    {
+      std::cerr << "ERROR: mismatch in InterpolationSurrogateHelper::globalToCoord test." << std::endl
+                << "       test  = ";
+      for( unsigned int d = 0; d < 5; d++ )
+        {
+           std::cerr << indices_test[d] << " ";
+        }
+      std::cerr << std::endl;
+
+      std::cerr << "       exact = ";
+      for( unsigned int d = 0; d < 5; d++ )
+        {
+          std::cerr << indices[d] << " ";
+        }
+      std::cerr << std::endl;
+
+      return_flag = 1;
+    }
+
   return return_flag;
 }

--- a/test/test_InterpolationSurrogate/test_build_InterpolationSurrogateBuilder.C
+++ b/test/test_InterpolationSurrogate/test_build_InterpolationSurrogateBuilder.C
@@ -67,11 +67,14 @@ int main(int argc, char ** argv)
 
   std::vector<unsigned int> n_points(1, 101);
 
+  QUESO::InterpolationSurrogateData<QUESO::GslVector, QUESO::GslMatrix>
+    data(paramDomain,n_points);
+
   MyInterpolationBuilder<QUESO::GslVector,QUESO::GslMatrix>
     builder( paramDomain, n_points );
 
   QUESO::LinearLagrangeInterpolationSurrogate<QUESO::GslVector,QUESO::GslMatrix>
-    one_d_surrogate( builder );
+    one_d_surrogate( data );
 
   return return_flag;
 }

--- a/test/test_InterpolationSurrogate/test_build_InterpolationSurrogateBuilder.C
+++ b/test/test_InterpolationSurrogate/test_build_InterpolationSurrogateBuilder.C
@@ -28,6 +28,8 @@
 #include <queso/LinearLagrangeInterpolationSurrogate.h>
 #include <queso/InterpolationSurrogateBuilder.h>
 
+double four_d_fn( double x, double y, double z, double a );
+
 template<class V, class M>
 class MyInterpolationBuilder : public QUESO::InterpolationSurrogateBuilder<V,M>
 {
@@ -39,8 +41,8 @@ public:
   virtual ~MyInterpolationBuilder(){};
 
   virtual double evaluate_model( const V & domainVector ) const
-  { queso_not_implemented();
-    return 0.0; };
+  { queso_assert_equal_to( domainVector.sizeGlobal(), 4);
+    return four_d_fn(domainVector[0],domainVector[1],domainVector[2],domainVector[3]); };
 };
 
 int main(int argc, char ** argv)
@@ -51,20 +53,28 @@ int main(int argc, char ** argv)
   int return_flag = 0;
 
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>
-    paramSpace(env,"param_", 1, NULL);
-
-  double min_val = -5;
-  double max_val = 3;
+    paramSpace(env,"param_", 4, NULL);
 
   QUESO::GslVector paramMins(paramSpace.zeroVector());
-  paramMins.cwSet(min_val);
+  paramMins[0] = -1;
+  paramMins[1] = -0.5;
+  paramMins[2] = 1.1;
+  paramMins[3] = -2.1;
+
   QUESO::GslVector paramMaxs(paramSpace.zeroVector());
-  paramMaxs.cwSet(max_val);
+  paramMaxs[0] = 0.9;
+  paramMaxs[1] = 3.14;
+  paramMaxs[2] = 2.1;
+  paramMaxs[3] = 4.1;
 
   QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix>
     paramDomain("param_", paramSpace, paramMins, paramMaxs);
 
-  std::vector<unsigned int> n_points(1, 101);
+  std::vector<unsigned int> n_points(4);
+  n_points[0] = 101;
+  n_points[1] = 51;
+  n_points[2] = 31;
+  n_points[3] = 41;
 
   QUESO::InterpolationSurrogateData<QUESO::GslVector, QUESO::GslMatrix>
     data(paramDomain,n_points);
@@ -72,8 +82,44 @@ int main(int argc, char ** argv)
   MyInterpolationBuilder<QUESO::GslVector,QUESO::GslMatrix>
     builder( data );
 
+  builder.build_values();
+
   QUESO::LinearLagrangeInterpolationSurrogate<QUESO::GslVector,QUESO::GslMatrix>
-    one_d_surrogate( data );
+    four_d_surrogate( data );
+
+  QUESO::GslVector domainVector(paramSpace.zeroVector());
+  domainVector[0] = -0.4;
+  domainVector[1] = 3.0;
+  domainVector[2] = 1.5;
+  domainVector[3] = 1.65;
+
+  double test_val = four_d_surrogate.evaluate(domainVector);
+
+  double exact_val = four_d_fn(domainVector[0],domainVector[1],domainVector[2],domainVector[3]);
+
+  double tol = 2.0*std::numeric_limits<double>::epsilon();
+
+  double rel_error = (test_val - exact_val)/exact_val;
+
+  if( std::fabs(rel_error) > tol )
+    {
+      std::cerr << "ERROR: Tolerance exceeded for 4D Lagrange interpolation test."
+                << std::endl
+                << " test_val  = " << test_val << std::endl
+                << " exact_val = " << exact_val << std::endl
+                << " rel_error = " << rel_error << std::endl
+                << " tol       = " << tol << std::endl;
+
+      return_flag = 1;
+    }
 
   return return_flag;
+}
+
+double four_d_fn( double x, double y, double z, double a )
+{
+  return 3.0 + 2.5*x - 3.1*y + 2.71*z + 3.14*a
+    + 0.1*x*y + 1.2*x*z + 0.5*y*z + 0.1*x*a + 1.1*y*a + 2.1*z*a
+    + 0.3*x*y*a + 0.5*x*z*a + 1.2*y*z*a + 0.9*x*y*z
+    + 2.5*x*y*z*a;
 }

--- a/test/test_InterpolationSurrogate/test_build_InterpolationSurrogateBuilder.C
+++ b/test/test_InterpolationSurrogate/test_build_InterpolationSurrogateBuilder.C
@@ -1,0 +1,77 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/BoxSubset.h>
+#include <queso/LinearLagrangeInterpolationSurrogate.h>
+#include <queso/InterpolationSurrogateBuilder.h>
+
+template<class V, class M>
+class MyInterpolationBuilder : public QUESO::InterpolationSurrogateBuilder<V,M>
+{
+public:
+  MyInterpolationBuilder( const QUESO::BoxSubset<V,M> & domain,
+                          const std::vector<unsigned int>& n_points )
+    : QUESO::InterpolationSurrogateBuilder<V,M>(domain,n_points)
+  {};
+
+  virtual ~MyInterpolationBuilder(){};
+
+  virtual double evaluate_model( const V & domainVector ) const
+  { queso_not_implemented();
+    return 0.0; };
+};
+
+int main(int argc, char ** argv)
+{
+  MPI_Init(&argc, &argv);
+  QUESO::FullEnvironment env(MPI_COMM_WORLD, "test_InterpolationSurrogate/queso_input.txt", "", NULL);
+
+  int return_flag = 0;
+
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>
+    paramSpace(env,"param_", 1, NULL);
+
+  double min_val = -5;
+  double max_val = 3;
+
+  QUESO::GslVector paramMins(paramSpace.zeroVector());
+  paramMins.cwSet(min_val);
+  QUESO::GslVector paramMaxs(paramSpace.zeroVector());
+  paramMaxs.cwSet(max_val);
+
+  QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix>
+    paramDomain("param_", paramSpace, paramMins, paramMaxs);
+
+  std::vector<unsigned int> n_points(1, 101);
+
+  MyInterpolationBuilder<QUESO::GslVector,QUESO::GslMatrix>
+    builder( paramDomain, n_points );
+
+  QUESO::LinearLagrangeInterpolationSurrogate<QUESO::GslVector,QUESO::GslMatrix>
+    one_d_surrogate( builder );
+
+  return return_flag;
+}

--- a/test/test_InterpolationSurrogate/test_build_InterpolationSurrogateBuilder.C
+++ b/test/test_InterpolationSurrogate/test_build_InterpolationSurrogateBuilder.C
@@ -27,6 +27,7 @@
 #include <queso/BoxSubset.h>
 #include <queso/LinearLagrangeInterpolationSurrogate.h>
 #include <queso/InterpolationSurrogateBuilder.h>
+#include <queso/InterpolationSurrogateData.h>
 
 double four_d_fn( double x, double y, double z, double a );
 

--- a/test/test_InterpolationSurrogate/test_build_InterpolationSurrogateBuilder.C
+++ b/test/test_InterpolationSurrogate/test_build_InterpolationSurrogateBuilder.C
@@ -32,9 +32,8 @@ template<class V, class M>
 class MyInterpolationBuilder : public QUESO::InterpolationSurrogateBuilder<V,M>
 {
 public:
-  MyInterpolationBuilder( const QUESO::BoxSubset<V,M> & domain,
-                          const std::vector<unsigned int>& n_points )
-    : QUESO::InterpolationSurrogateBuilder<V,M>(domain,n_points)
+  MyInterpolationBuilder( QUESO::InterpolationSurrogateData<V,M>& data )
+    : QUESO::InterpolationSurrogateBuilder<V,M>(data)
   {};
 
   virtual ~MyInterpolationBuilder(){};
@@ -71,7 +70,7 @@ int main(int argc, char ** argv)
     data(paramDomain,n_points);
 
   MyInterpolationBuilder<QUESO::GslVector,QUESO::GslMatrix>
-    builder( paramDomain, n_points );
+    builder( data );
 
   QUESO::LinearLagrangeInterpolationSurrogate<QUESO::GslVector,QUESO::GslMatrix>
     one_d_surrogate( data );


### PR DESCRIPTION
Adds linear Lagrange interpolant surrogate for arbitrary dimension. Note I've defined a hierarchy of classes to promote an interface and reusability. In particular, I intended to create subclasses of the Gaussian likelihoods, for example, that take a pointer to `SurrogateBase`, then it becomes that much easier for the user to use surrogate models in their likelihood. I'd appreciate feedback on this point, particularly since there's some GP work underway already --- we'd want GP model surrogates to subclass this base. Future spectral projection surrogates would also subclass `SurrogateBase`.

@dmcdougall I'd appreciate you taking a good look through the comments and make sure that they make sense and you can follow the code. The equations to code translation may not be obvious everywhere here and I want to make sure the documentation is clear.

I still plan on adding a `Generator` (other name suggestions welcome) that will let the user supply their model and then QUESO can farm off filling in the values over subenvironments (in the QUESO parlance) over many processors. Also want to add constructors that take objects that will populate the surrogate. But at least this can start getting a review.

I have unit tests out to 4D. This won't be of much utility beyond that number of dimensions I don't think, but at least gives some warm and fuzzies about the correctness.