### PR TITLE
Add ScopedPtr

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -123,6 +123,7 @@ AC_CACHE_SAVE
 AC_LANG([C++])
 BOOST_REQUIRE([1.35])
 BOOST_PROGRAM_OPTIONS
+BOOST_FIND_HEADER([boost/scoped_ptr.hpp])
 AC_CACHE_SAVE
 
 # Check for GLPK (optional)

--- a/inc/queso/Makefile.am
+++ b/inc/queso/Makefile.am
@@ -58,6 +58,7 @@ BUILT_SOURCES += OptimizerMonitor.h
 BUILT_SOURCES += RngBase.h
 BUILT_SOURCES += RngBoost.h
 BUILT_SOURCES += RngGsl.h
+BUILT_SOURCES += ScopedPtr.h
 BUILT_SOURCES += TeuchosMatrix.h
 BUILT_SOURCES += TeuchosVector.h
 BUILT_SOURCES += Vector.h
@@ -295,6 +296,8 @@ RngBase.h: $(top_srcdir)/src/core/inc/RngBase.h
 RngBoost.h: $(top_srcdir)/src/core/inc/RngBoost.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 RngGsl.h: $(top_srcdir)/src/core/inc/RngGsl.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+ScopedPtr.h: $(top_srcdir)/src/core/inc/ScopedPtr.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 TeuchosMatrix.h: $(top_srcdir)/src/core/inc/TeuchosMatrix.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -316,6 +316,7 @@ libqueso_include_HEADERS += core/inc/InfiniteDimensionalMCMCSamplerOptions.h
 libqueso_include_HEADERS += core/inc/InfiniteDimensionalLikelihoodBase.h
 libqueso_include_HEADERS += core/inc/FunctionOperatorBuilder.h
 libqueso_include_HEADERS += core/inc/GslBlockMatrix.h
+libqueso_include_HEADERS += core/inc/ScopedPtr.h
 
 # Headers to install from misc/inc
 

--- a/src/core/inc/ScopedPtr.h
+++ b/src/core/inc/ScopedPtr.h
@@ -1,0 +1,64 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef UQ_SCOPED_PTR_H
+#define UQ_SCOPED_PTR_H
+
+#include <queso/config_queso.h>
+
+#ifdef QUESO_HAVE_CXX11_UNIQUE_PTR
+#include <memory>
+#elif QUESO_HAVE_BOOST_SCOPED_PTR_HPP
+#include <boost/scoped_ptr.hpp>
+#elif QUESO_HAVE_CXX_AUTO_PTR
+#include <memory>
+#endif
+
+namespace QUESO
+{
+#ifdef QUESO_HAVE_CXX11_UNIQUE_PTR
+  template<typename T>
+  struct ScopedPtr
+  {
+    typedef std::unique_ptr<T> Type;
+  };
+#elif QUESO_HAVE_BOOST_SCOPED_PTR_HPP
+  template<typename T>
+  struct ScopedPtr
+  {
+    typedef boost::scoped_ptr<T> Type;
+  };
+#elif QUESO_HAVE_CXX_AUTO_PTR
+  template<typename T>
+  struct ScopedPtr
+  {
+    typedef std::auto_ptr<T> Type;
+  };
+#else
+#     error "No valid definition for ScopedPtr found!"
+#endif
+
+} // end namespace QUESO
+
+#endif // UQ_SCOPED_PTR_H


### PR DESCRIPTION
In my interp-surrogate-writer branch, I want to be able to use a smart pointer to manage memory of pointers inside an object. `std::unique_ptr` is the natural choice, but that requires C++11. `boost::scoped_ptr` is there, but I'm hoping we can remove the Boost requirement one of these days. `std::auto_ptr` is deprecated. So, what this PR does is use a template typedef idiom to define ScopedPtr using `std::unique_ptr`, then `boost::scoped_ptr` if `std::unique_ptr` is not available, then `std::auto_ptr` if the previous two are not available. ([Similar idea for SharedPtr](http://stackoverflow.com/questions/2937351/how-to-use-autoconf-with-c0x-features?answertab=active#tab-top).) This covers the case when we enable C++11 (even optionally, `std::unique_ptr` has been around for awhile in the compilers) and the case if we don't require C++11, but remove the Boost mandatory dependency. I used the name `ScopedPtr` to indicate that a possible fallback is `boost::scoped_ptr` and that does not have move semantics (where as `std::unique_ptr` does). But once we require C++11, we can search/replace `ScopedPtr` to `std::unique_ptr` and remove this wrapper. I gather `std::unique_ptr` and `boost::unique_ptr` have some differences, but I haven't looked deeply into it, so I was just avoiding that altogether since I don't need move semantics, just a very basic smart pointer.

We do not yet test for C++11 and I've not added it, nor the test for `std::auto_ptr`; those autoconf tests are a PITA to write and I'm trying to move fast. But, we require boost, so this will work as is while Boost is mandatory. And the Boost autoconf macro had already wrapped up tests for headers, so there's now an autoconf check for `boost::scoped_ptr`.

Although there's no test, and this doesn't actually compile anything yet that uses it, I can vouch that I'm already using this on the aforementioned branch and objects that are using it are compiling. I wasn't sure if this would be controversial or not, so I gave it its own PR instead of tucking it inside the aforementioned branch.

An example of declaring this would look like `QUESO::ScopedPtr<GslVector>::Type vector;`

Thoughts @dmcdougall @roystgnr?