### PR TITLE
Fix overloaded virtual warnings

### DIFF
--- a/src/core/inc/Matrix.h
+++ b/src/core/inc/Matrix.h
@@ -109,8 +109,8 @@ public:
   //@}
 
 protected:
-  //! Copies matrix \c src to \c this matrix.
-  virtual void                    copy                (const Matrix& src);
+  //! Copies base data from matrix \c src to \c this matrix.
+  virtual void                    base_copy           (const Matrix& src);
 
   //! QUESO environment variable.
   const   BaseEnvironment& m_env;

--- a/src/core/inc/Vector.h
+++ b/src/core/inc/Vector.h
@@ -110,8 +110,8 @@ public:
 
 protected:
 
-  //! Copies vector \c src to \c this matrix.
-  virtual void                    copy                (const Vector& src);
+  //! Copies base data from vector \c src to \c this vector
+  virtual void                    base_copy           (const Vector& src);
 
   //! Environment variable.
   const BaseEnvironment& m_env;

--- a/src/core/src/GslMatrix.C
+++ b/src/core/src/GslMatrix.C
@@ -153,7 +153,7 @@ GslMatrix::GslMatrix(const GslMatrix& B) // can be a rectangular matrix
   m_isSingular   (false)
 {
   queso_require_msg(m_mat, "null vector generated");
-  this->Matrix::copy(B);
+  this->Matrix::base_copy(B);
   this->copy(B);
 }
 
@@ -244,6 +244,7 @@ GslMatrix::operator()(unsigned int i, unsigned int j) const
 void
 GslMatrix::copy(const GslMatrix& src)
 {
+  // FIXME - should we be calling Matrix::base_copy here? - RHS
   this->resetLU();
   int iRC;
   iRC = gsl_matrix_memcpy(this->m_mat, src.m_mat);

--- a/src/core/src/GslVector.C
+++ b/src/core/src/GslVector.C
@@ -240,7 +240,7 @@ GslVector::operator[](unsigned int i) const
 void
 GslVector::copy(const GslVector& src)
 {
-  this->Vector::copy(src); // prudenci 2010-06-17 mox
+  this->Vector::base_copy(src);
   int iRC;
   iRC = gsl_vector_memcpy(this->m_vec, src.m_vec);
   queso_require_msg(!(iRC), "failed");

--- a/src/core/src/Matrix.C
+++ b/src/core/src/Matrix.C
@@ -96,7 +96,7 @@ Matrix::getInDebugMode() const
 
 // --------------------------------------------------
 void
-Matrix::copy(const Matrix& src)
+Matrix::base_copy(const Matrix& src)
 {
   //m_env = src.env;
   //m_map = src.map;

--- a/src/core/src/TeuchosMatrix.C
+++ b/src/core/src/TeuchosMatrix.C
@@ -165,7 +165,7 @@ TeuchosMatrix::TeuchosMatrix(const TeuchosMatrix& B) // can be a rectangular mat
   m_mat.shape    (B.numRowsLocal(),B.numCols());
   m_LU.shape(0,0);
 
-  this->Matrix::copy(B);
+  this->Matrix::base_copy(B);
   this->copy(B);
 }
 
@@ -1930,6 +1930,7 @@ TeuchosMatrix::subWriteContents(
 void
 TeuchosMatrix::copy(const TeuchosMatrix& src) //dummy
 {
+  // FIXME - should we be calling Matrix::base_copy here? - RHS
   this->resetLU();
   unsigned int i,j, nrows=src.numRowsLocal(), ncols=src.numCols();
 

--- a/src/core/src/TeuchosVector.C
+++ b/src/core/src/TeuchosVector.C
@@ -1157,7 +1157,7 @@ TeuchosVector::subWriteContents(
 void
 TeuchosVector::copy(const TeuchosVector& rhs)
 {
-  this->Vector::copy(rhs);
+  this->Vector::base_copy(rhs);
 
   unsigned int size1 = m_vec.length();
   unsigned int size2 = rhs.sizeLocal();

--- a/src/core/src/Vector.C
+++ b/src/core/src/Vector.C
@@ -98,7 +98,7 @@ Vector::getPrintScientific() const
 }
 // --------------------------------------------------
 void
-Vector::copy(const Vector& src)
+Vector::base_copy(const Vector& src)
 {
   //m_env               = src.env;
   //m_map               = src.map; // prudenci 2010-06-17


### PR DESCRIPTION
This is a little more self-documenting too IMHO - Vector::copy didn't actually copy a Vector subclass.