### PR TITLE
Generalize Interpolation Surrogate

### DIFF
--- a/examples/interpolation_surrogate/4d_interp.C
+++ b/examples/interpolation_surrogate/4d_interp.C
@@ -117,9 +117,15 @@ int main(int argc, char ** argv)
 
   // Write each datasets separately. We'll be able to read each one in
   // individually and construct separate LinearLagrangeInterpolationSurrogate
-  // objects.
-  //data_writer.write( "4d_interp_data_1.dat", data.get_dataset(0) );
-  //data_writer.write( "4d_interp_data_2.dat", data.get_dataset(1) );
+  // objects. If we have more than 1 processor at our disposal, have the
+  // second data set written out by someone other than processor 0 since
+  // processor 0 will be writing out the first data set.
+  data_writer.write( "4d_interp_data_1.dat", data.get_dataset(0) );
+
+  if( env.fullComm().NumProc() > 1 )
+    data_writer.write( "4d_interp_data_2.dat", data.get_dataset(1), 1 );
+  else
+    data_writer.write( "4d_interp_data_2.dat", data.get_dataset(1) );
 
   // The builder put the model values into the data, so now we can give the data
   // to the interpolation surrogate. This object can now be used in a likelihood

--- a/inc/queso/Makefile.am
+++ b/inc/queso/Makefile.am
@@ -183,6 +183,7 @@ BUILT_SOURCES += WignerVectorRealizer.h
 BUILT_SOURCES += InterpolationSurrogateBase.h
 BUILT_SOURCES += InterpolationSurrogateBuilder.h
 BUILT_SOURCES += InterpolationSurrogateData.h
+BUILT_SOURCES += InterpolationSurrogateDataSet.h
 BUILT_SOURCES += InterpolationSurrogateHelper.h
 BUILT_SOURCES += InterpolationSurrogateIOASCII.h
 BUILT_SOURCES += InterpolationSurrogateIOBase.h
@@ -549,6 +550,8 @@ InterpolationSurrogateBase.h: $(top_srcdir)/src/surrogates/inc/InterpolationSurr
 InterpolationSurrogateBuilder.h: $(top_srcdir)/src/surrogates/inc/InterpolationSurrogateBuilder.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 InterpolationSurrogateData.h: $(top_srcdir)/src/surrogates/inc/InterpolationSurrogateData.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+InterpolationSurrogateDataSet.h: $(top_srcdir)/src/surrogates/inc/InterpolationSurrogateDataSet.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 InterpolationSurrogateHelper.h: $(top_srcdir)/src/surrogates/inc/InterpolationSurrogateHelper.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -249,6 +249,7 @@ libqueso_la_SOURCES += stats/src/GaussianLikelihoodBlockDiagonalCovarianceRandom
 
 # Sources from surrogates/src
 libqueso_la_SOURCES += surrogates/src/InterpolationSurrogateData.C
+libqueso_la_SOURCES += surrogates/src/InterpolationSurrogateDataSet.C
 libqueso_la_SOURCES += surrogates/src/InterpolationSurrogateBase.C
 libqueso_la_SOURCES += surrogates/src/InterpolationSurrogateHelper.C
 libqueso_la_SOURCES += surrogates/src/LinearLagrangeInterpolationSurrogate.C
@@ -452,6 +453,7 @@ libqueso_include_HEADERS += stats/inc/GaussianLikelihoodBlockDiagonalCovarianceR
 # Headers to install from surrogates/inc
 libqueso_include_HEADERS += surrogates/inc/SurrogateBase.h
 libqueso_include_HEADERS += surrogates/inc/InterpolationSurrogateData.h
+libqueso_include_HEADERS += surrogates/inc/InterpolationSurrogateDataSet.h
 libqueso_include_HEADERS += surrogates/inc/InterpolationSurrogateBase.h
 libqueso_include_HEADERS += surrogates/inc/InterpolationSurrogateHelper.h
 libqueso_include_HEADERS += surrogates/inc/LinearLagrangeInterpolationSurrogate.h

--- a/src/surrogates/inc/InterpolationSurrogateBuilder.h
+++ b/src/surrogates/inc/InterpolationSurrogateBuilder.h
@@ -61,12 +61,6 @@ namespace QUESO
     //! Cache the amount of work for each subenvironment
     std::vector<int> m_njobs;
 
-    //! Ensure that if fullComm() size > 1, then n_subenvironments > 1
-    /*! If not, this is a strange configuration and breaks things like inter0Comm
-        and would induce redundant work. Thus, this configuration is not supported and
-        we error out. */
-    void check_process_config();
-
     //! Partition the workload of model evaluations across the subenvironments
     void partition_work();
 

--- a/src/surrogates/inc/InterpolationSurrogateBuilder.h
+++ b/src/surrogates/inc/InterpolationSurrogateBuilder.h
@@ -26,7 +26,7 @@
 #define UQ_INTERPOLATION_SURROGATE_BUILDER_H
 
 #include <queso/SurrogateBuilderBase.h>
-#include <queso/InterpolationSurrogateData.h>
+#include <queso/InterpolationSurrogateDataSet.h>
 
 namespace QUESO
 {
@@ -47,7 +47,7 @@ namespace QUESO
     //! Constructor
     /*! We do not take a const& to the data because we want to compute and
         set the values directly. */
-    InterpolationSurrogateBuilder( InterpolationSurrogateData<V,M>& data );
+    InterpolationSurrogateBuilder( InterpolationSurrogateDataSet<V,M>& data );
 
     virtual ~InterpolationSurrogateBuilder(){};
 
@@ -56,7 +56,7 @@ namespace QUESO
 
   protected:
 
-    InterpolationSurrogateData<V,M>& m_data;
+    InterpolationSurrogateDataSet<V,M>& m_data;
 
     //! Cache the amount of work for each subenvironment
     std::vector<int> m_njobs;
@@ -76,15 +76,24 @@ namespace QUESO
 
     //! Take the local values computed from each process and communicate
     /*! The end result will be that all processes have all the data.
-        I.e. m_values will be completely populated on all processes. */
+        I.e. m_values will be completely populated on all processes.
+        This is done on the InterpolationSurrogateData passed to the
+        function. */
     void sync_data( std::vector<unsigned int>& local_n,
-                    std::vector<double>& local_values );
+                    std::vector<double>& local_values,
+                    InterpolationSurrogateData<V,M>& data );
 
     //! Provide the spatial coordinates for the global index n
     void set_domain_vector( unsigned int n, V& domain_vector ) const;
 
     //! Helper function to compute strides needed for MPI_Gatherv
     void compute_strides( std::vector<int>& strides ) const;
+
+    //! Helper function to grab representative dataset from m_data
+    /*! We only grab the first data set since the environments are guaranteed
+      to be consistent by the nature of constructing an InterpolationSurrogateDataSet. */
+    const InterpolationSurrogateData<V,M>& get_default_data() const
+    { return m_data.get_dataset(0); }
 
   private:
 

--- a/src/surrogates/inc/InterpolationSurrogateDataSet.h
+++ b/src/surrogates/inc/InterpolationSurrogateDataSet.h
@@ -1,0 +1,89 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef UQ_INTERPOLATION_SURROGATE_DATA_SET_H
+#define UQ_INTERPOLATION_SURROGATE_DATA_SET_H
+
+#include <queso/InterpolationSurrogateData.h>
+
+namespace QUESO
+{
+  class GslVector;
+  class GslMatrix;
+
+  //! Container class for multiple, consistent InterpolationSurrogateData objects
+  /*! This is mostly a convenience object to build and hold multiple
+      InterpolationSurrogateData objects that will have the domian and
+      n_points in each dimension. This is useful for building the surrogates
+      using the InterpolationSurrogateBuilder. */
+  template<class V = GslVector, class M = GslMatrix>
+  class InterpolationSurrogateDataSet
+  {
+  public:
+
+    InterpolationSurrogateDataSet( const BoxSubset<V,M>& domain,
+                                   const std::vector<unsigned int>& n_points,
+                                   unsigned int n_datasets );
+
+    ~InterpolationSurrogateDataSet();
+
+    const InterpolationSurrogateData<V,M>& get_dataset( unsigned int s ) const;
+
+    InterpolationSurrogateData<V,M>& get_dataset( unsigned int s );
+
+    unsigned int size() const
+    { return m_datasets.size(); }
+
+  private:
+
+    InterpolationSurrogateDataSet();
+
+    //! Data structure to hold all data sets
+    std::vector<InterpolationSurrogateData<V,M>*> m_datasets;
+
+  };
+
+  template<class V, class M>
+  inline
+  const InterpolationSurrogateData<V,M>& InterpolationSurrogateDataSet<V,M>::get_dataset( unsigned int s ) const
+  {
+    queso_require_less( s, m_datasets.size() );
+    queso_assert( m_datasets[s] );
+
+    return *(m_datasets[s]);
+  }
+
+  template<class V, class M>
+  inline
+  InterpolationSurrogateData<V,M>& InterpolationSurrogateDataSet<V,M>::get_dataset( unsigned int s )
+  {
+    queso_require_less( s, m_datasets.size() );
+    queso_assert( m_datasets[s] );
+
+    return *(m_datasets[s]);
+  }
+
+} // end namespace QUESO
+
+#endif // UQ_INTERPOLATION_SURROGATE_DATA_SET_H

--- a/src/surrogates/inc/InterpolationSurrogateIOASCII.h
+++ b/src/surrogates/inc/InterpolationSurrogateIOASCII.h
@@ -38,12 +38,23 @@ namespace QUESO
 
     virtual ~InterpolationSurrogateIOASCII(){};
 
+    //! Read Interpolation surrogate data from filename using processor reading_rank
+    /*! This will read the data the file given by filename and setup all
+        the infrastructure for InterpolationSurrogateData so that the user
+        can then call the data() method. This can then be used to construct
+        an Interpolation object. env.fullRank() must contain reading_rank.
+        By default, processor 0 reads the data. */
     virtual void read( const std::string& filename,
                        const FullEnvironment& env,
-                       const std::string& vector_space_prefix );
+                       const std::string& vector_space_prefix,
+                       int reading_rank = 0 );
 
+    //! Write interpolation surrogate data to filename using processor writing_rank
+    /*! env.fullRank() must contain writing_rank. By default processor 0
+        writes the data. */
     virtual void write( const std::string& filename,
-                        const InterpolationSurrogateData<V,M>& data ) const;
+                        const InterpolationSurrogateData<V,M>& data,
+                        int writing_rank = 0 ) const;
 
   };
 } // end namespace QUESO

--- a/src/surrogates/inc/InterpolationSurrogateIOBase.h
+++ b/src/surrogates/inc/InterpolationSurrogateIOBase.h
@@ -42,10 +42,12 @@ namespace QUESO
 
     virtual void read( const std::string& filename,
                        const FullEnvironment& env,
-                       const std::string& vector_space_prefix ) =0;
+                       const std::string& vector_space_prefix,
+                       int reading_rank ) =0;
 
     virtual void write( const std::string& filename,
-                        const InterpolationSurrogateData<V,M>& data ) const =0;
+                        const InterpolationSurrogateData<V,M>& data,
+                        int writing_rank ) const =0;
 
     //! Reference to data object
     /*! If we read the data, then use this method to grab

--- a/src/surrogates/inc/SurrogateBuilderBase.h
+++ b/src/surrogates/inc/SurrogateBuilderBase.h
@@ -25,6 +25,9 @@
 #ifndef UQ_SURROGATE_BUILDER_BASE_H
 #define UQ_SURROGATE_BUILDER_BASE_H
 
+// C++
+#include <vector>
+
 namespace QUESO
 {
   class GslVector;
@@ -41,7 +44,7 @@ namespace QUESO
 
     virtual ~SurrogateBuilderBase(){};
 
-    virtual double evaluate_model( const V & domainVector ) const =0;
+    virtual void evaluate_model( const V & domainVector, std::vector<double>& values ) =0;
 
   };
 

--- a/src/surrogates/src/InterpolationSurrogateBuilder.C
+++ b/src/surrogates/src/InterpolationSurrogateBuilder.C
@@ -42,30 +42,7 @@ namespace QUESO
     m_data(data),
     m_njobs(this->get_default_data().get_paramDomain().env().numSubEnvironments(), 0)
   {
-    this->check_process_config();
-
     this->partition_work();
-  }
-
-  template<class V, class M>
-  void InterpolationSurrogateBuilder<V,M>::check_process_config()
-  {
-    /* If fullComm() > 1 and n_subenvironments == 1 this is strange and means
-       the user is doing redundant work. So, let's make that an error.
-       This could happen if, for example the user forgets to change the number
-       of subenvironments to > 1 and runs with multiple MPI processes. */
-    unsigned int full_comm_size = this->get_default_data().get_paramDomain().env().fullComm().NumProc();
-    unsigned int n_subenvs = this->get_default_data().get_paramDomain().env().numSubEnvironments();
-
-    if( (full_comm_size > 1) &&  (n_subenvs == 1) )
-      {
-        std::string error = "ERROR: fullComm() size is greater than 1 and the number\n";
-        error += "       of subenvrionments = 1. InterpolationSurrogateBuilder\n";
-        error += "       is not compatible with this configuration.\n";
-        error += "       Did you forget to change the number of subenvironments?\n";
-
-        queso_error_msg(error);
-      }
   }
 
   template<class V, class M>

--- a/src/surrogates/src/InterpolationSurrogateBuilder.C
+++ b/src/surrogates/src/InterpolationSurrogateBuilder.C
@@ -37,10 +37,10 @@
 namespace QUESO
 {
   template<class V, class M>
-  InterpolationSurrogateBuilder<V,M>::InterpolationSurrogateBuilder( InterpolationSurrogateData<V,M>& data )
+  InterpolationSurrogateBuilder<V,M>::InterpolationSurrogateBuilder( InterpolationSurrogateDataSet<V,M>& data )
     : SurrogateBuilderBase<V>(),
     m_data(data),
-    m_njobs(data.get_paramDomain().env().numSubEnvironments(), 0)
+    m_njobs(this->get_default_data().get_paramDomain().env().numSubEnvironments(), 0)
   {
     this->check_process_config();
 
@@ -54,8 +54,8 @@ namespace QUESO
        the user is doing redundant work. So, let's make that an error.
        This could happen if, for example the user forgets to change the number
        of subenvironments to > 1 and runs with multiple MPI processes. */
-    unsigned int full_comm_size = this->m_data.get_paramDomain().env().fullComm().NumProc();
-    unsigned int n_subenvs = this->m_data.get_paramDomain().env().numSubEnvironments();
+    unsigned int full_comm_size = this->get_default_data().get_paramDomain().env().fullComm().NumProc();
+    unsigned int n_subenvs = this->get_default_data().get_paramDomain().env().numSubEnvironments();
 
     if( (full_comm_size > 1) &&  (n_subenvs == 1) )
       {
@@ -72,11 +72,11 @@ namespace QUESO
   void InterpolationSurrogateBuilder<V,M>::partition_work()
   {
     // Convenience
-    unsigned int n_values = this->m_data.n_values();
-    unsigned int n_workers = this->m_data.get_paramDomain().env().numSubEnvironments();
+    unsigned int n_values = this->get_default_data().n_values();
+    unsigned int n_workers = this->get_default_data().get_paramDomain().env().numSubEnvironments();
 
     unsigned int n_jobs = n_values/n_workers;
-    unsigned int n_leftover = this->m_data.n_values() % n_workers;
+    unsigned int n_leftover = this->get_default_data().n_values() % n_workers;
 
     /* If the number of values is evenly divisible over all workers,
        then everyone gets the same amount work */
@@ -109,32 +109,46 @@ namespace QUESO
 
     // Cache each processors work, then we only need to do 1 Allgather
     std::vector<unsigned int> local_n(n_end-n_begin);
-    std::vector<double> local_values(n_end-n_begin);
+
+    // We need to cache (n_end-n_begin) values for each dataset,
+    std::vector<std::vector<double> > local_values(this->m_data.size());
+    for( std::vector<std::vector<double> >::iterator it = local_values.begin();
+         it != local_values.end(); ++it )
+      it->resize(n_end-n_begin);
+
     unsigned int count = 0;
 
     // vector to store current domain value
-    V domain_vector(this->m_data.get_paramDomain().vectorSpace().zeroVector());
+    V domain_vector(this->get_default_data().get_paramDomain().vectorSpace().zeroVector());
+
+    // vector to store values evaluated at the current domain_vector
+    std::vector<double> values(this->m_data.size());
 
     for( unsigned int n = n_begin; n < n_end; n++ )
       {
         this->set_domain_vector( n, domain_vector );
 
-        double value = this->evaluate_model( domain_vector );
+        this->evaluate_model( domain_vector, values );
 
         local_n[count] = n;
-        local_values[count] = value;
+
+        for( unsigned int s = 0; s < this->m_data.size(); s++ )
+          local_values[s][count] = values[s];
+
         count += 1;
       }
 
     /* Sync all the locally computed values between the subenvironments
-       so all processes have all the computed values. */
-    this->sync_data( local_n, local_values );
+       so all processes have all the computed values. We need to sync
+       values for every data set. */
+    for( unsigned int s = 0; s < this->m_data.size(); s++ )
+      this->sync_data( local_n, local_values[s], this->m_data.get_dataset(s) );
   }
 
   template<class V, class M>
   void InterpolationSurrogateBuilder<V,M>::set_work_bounds( unsigned int& n_begin, unsigned int& n_end ) const
   {
-    unsigned int my_subid = this->m_data.get_paramDomain().env().subId();
+    unsigned int my_subid = this->get_default_data().get_paramDomain().env().subId();
 
     /* Starting index will be the sum of the all the previous num jobs */
     n_begin = 0;
@@ -146,21 +160,22 @@ namespace QUESO
 
   template<class V, class M>
   void InterpolationSurrogateBuilder<V,M>::sync_data( std::vector<unsigned int>& local_n,
-                                                      std::vector<double>& local_values  )
+                                                      std::vector<double>& local_values,
+                                                      InterpolationSurrogateData<V,M>& data )
   {
     // Only members of the inter0comm will do the communication of the local values
-    unsigned int my_subrank = this->m_data.get_paramDomain().env().subRank();
+    unsigned int my_subrank = data.get_paramDomain().env().subRank();
 
     if( my_subrank == 0 )
       {
-        std::vector<double> all_values(this->m_data.n_values());
+        std::vector<double> all_values(data.n_values());
 
-        std::vector<unsigned int> all_indices(this->m_data.n_values());
+        std::vector<unsigned int> all_indices(data.n_values());
 
         std::vector<int> strides;
         this->compute_strides( strides );
 
-        const MpiComm& inter0comm = this->m_data.get_paramDomain().env().inter0Comm();
+        const MpiComm& inter0comm = data.get_paramDomain().env().inter0Comm();
 
         /*! \todo Would be more efficient to pack local_n and local_values
             togethers and do Gatherv only once. */
@@ -181,35 +196,35 @@ namespace QUESO
            I'm not sure we can assume the same continuity of the inter0 ranks, i.e.
            I'm not sure how QUESO ordered the inter0 ranks. So, we go ahead and
            manually set the values. */
-        if( this->m_data.get_paramDomain().env().subRank() == 0 )
+        if( data.get_paramDomain().env().subRank() == 0 )
           {
-            for( unsigned int n = 0; n < this->m_data.n_values(); n++ )
-              this->m_data.set_value( all_indices[n], all_values[n] );
+            for( unsigned int n = 0; n < data.n_values(); n++ )
+              data.set_value( all_indices[n], all_values[n] );
           }
       }
 
     // Now broadcast the values data to all other processes
-    this->m_data.sync_values( 0 /*root*/);
+    data.sync_values( 0 /*root*/);
   }
 
   template<class V, class M>
   void InterpolationSurrogateBuilder<V,M>::set_domain_vector( unsigned int n, V& domain_vector ) const
   {
     // Convert global index n to local coordinates in each dimension
-    std::vector<unsigned int> indices(this->m_data.dim());
-    InterpolationSurrogateHelper::globalToCoord( n, this->m_data.get_n_points(), indices );
+    std::vector<unsigned int> indices(this->get_default_data().dim());
+    InterpolationSurrogateHelper::globalToCoord( n, this->get_default_data().get_n_points(), indices );
 
     // Use indices to get x coordinates and populate domain_vector
-    for( unsigned int d = 0; d < this->m_data.dim(); d++ )
+    for( unsigned int d = 0; d < this->get_default_data().dim(); d++ )
       {
-        domain_vector[d] = this->m_data.get_x( d, indices[d] );
+        domain_vector[d] = this->get_default_data().get_x( d, indices[d] );
       }
   }
 
   template<class V, class M>
   void InterpolationSurrogateBuilder<V,M>::compute_strides( std::vector<int>& strides ) const
   {
-    unsigned int n_subenvs = this->m_data.get_paramDomain().env().numSubEnvironments();
+    unsigned int n_subenvs = this->get_default_data().get_paramDomain().env().numSubEnvironments();
 
     strides.resize(n_subenvs);
 

--- a/src/surrogates/src/InterpolationSurrogateDataSet.C
+++ b/src/surrogates/src/InterpolationSurrogateDataSet.C
@@ -1,0 +1,55 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+// This class
+#include <queso/InterpolationSurrogateDataSet.h>
+
+// QUESO
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+
+namespace QUESO
+{
+  template<class V, class M>
+  InterpolationSurrogateDataSet<V,M>::InterpolationSurrogateDataSet(const BoxSubset<V,M> & domain,
+                                                                    const std::vector<unsigned int>& n_points,
+                                                                    unsigned int n_datasets )
+    : m_datasets(n_datasets,NULL)
+  {
+    for( unsigned int s = 0; s < n_datasets; s++ )
+      m_datasets[s] = new InterpolationSurrogateData<V,M>( domain, n_points );
+  }
+
+  template<class V, class M>
+  InterpolationSurrogateDataSet<V,M>::~InterpolationSurrogateDataSet()
+  {
+    for( typename std::vector<InterpolationSurrogateData<V,M>*>::iterator it = m_datasets.begin();
+         it != m_datasets.end(); ++it )
+      delete *it;
+  }
+
+} // end namespace QUESO
+
+// Instantiate
+template class QUESO::InterpolationSurrogateDataSet<QUESO::GslVector,QUESO::GslMatrix>;

--- a/src/surrogates/src/InterpolationSurrogateIOASCII.C
+++ b/src/surrogates/src/InterpolationSurrogateIOASCII.C
@@ -181,10 +181,11 @@ namespace QUESO
 
   template<class V, class M>
   void InterpolationSurrogateIOASCII<V,M>::write( const std::string& filename,
-                                                  const InterpolationSurrogateData<V,M>& data ) const
+                                                  const InterpolationSurrogateData<V,M>& data,
+                                                  int writing_rank ) const
   {
     // Make sure there are values in the data. If not the user didn't populate the data
-    if( !data.n_values() > 0 )
+    if( !(data.n_values() > 0) )
       {
         std::string error = "ERROR: No values found in InterpolationSurrogateData.\n";
         error += "Cannot write data without values.\n";

--- a/src/surrogates/src/InterpolationSurrogateIOASCII.C
+++ b/src/surrogates/src/InterpolationSurrogateIOASCII.C
@@ -44,10 +44,11 @@ namespace QUESO
   template<class V, class M>
   void InterpolationSurrogateIOASCII<V,M>::read( const std::string& filename,
                                                  const FullEnvironment& env,
-                                                 const std::string& vector_space_prefix )
+                                                 const std::string& vector_space_prefix,
+                                                 int reading_rank )
   {
     // Root processor
-    unsigned int root = 0;
+    int root = reading_rank;
 
     MpiComm full_comm = env.fullComm();
 
@@ -198,7 +199,7 @@ namespace QUESO
     std::ofstream output;
 
     // Only processor 0 does the writing
-    if( data.get_paramDomain().env().fullRank() == 0 )
+    if( data.get_paramDomain().env().fullRank() == writing_rank )
       {
         output.open( filename.c_str() );
 
@@ -244,7 +245,7 @@ namespace QUESO
         // All done
         output.close();
 
-      } // data.get_paramDomain().env().fullRank() == 0
+      } // data.get_paramDomain().env().fullRank() == writing_rank
   }
 
 } // end namespace QUESO

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -248,7 +248,8 @@ EXTRA_DIST += test_SequenceOfVectors/test_unifiedPositionsOfMaximum.sh.in
 CLEANFILES =
 CLEANFILES += test_Environment/debug_output_sub0.txt
 CLEANFILES += gslvector_out_sub0.m
-CLEANFILES += test_write_InterpolationSurrogateBuilder.dat
+CLEANFILES += test_write_InterpolationSurrogateBuilder_1.dat
+CLEANFILES += test_write_InterpolationSurrogateBuilder_2.dat
 
 clean-local:
 	rm -rf $(top_builddir)/test/chain0

--- a/test/test_InterpolationSurrogate/test_build_InterpolationSurrogateBuilder.C
+++ b/test/test_InterpolationSurrogate/test_build_InterpolationSurrogateBuilder.C
@@ -30,7 +30,10 @@
 #include <queso/InterpolationSurrogateDataSet.h>
 #include <queso/InterpolationSurrogateIOASCII.h>
 
-double four_d_fn( double x, double y, double z, double a );
+double four_d_fn_1( double x, double y, double z, double a );
+double four_d_fn_2( double x, double y, double z, double a );
+
+int test_val(double test_val, double exact_val, double tol, const std::string& test_name);
 
 template<class V, class M>
 class MyInterpolationBuilder : public QUESO::InterpolationSurrogateBuilder<V,M>
@@ -44,8 +47,9 @@ public:
 
   virtual void evaluate_model( const V & domainVector, std::vector<double>& values )
   { queso_assert_equal_to( domainVector.sizeGlobal(), 4);
-    queso_assert_equal_to( values.size(), 1 );
-    values [0] = four_d_fn(domainVector[0],domainVector[1],domainVector[2],domainVector[3]);
+    queso_assert_equal_to( values.size(), 2 );
+    values[0] = four_d_fn_1(domainVector[0],domainVector[1],domainVector[2],domainVector[3]);
+    values[1] = four_d_fn_2(domainVector[0],domainVector[1],domainVector[2],domainVector[3]);
   };
 };
 
@@ -59,7 +63,8 @@ int main(int argc, char ** argv)
   std::string vs_prefix = "param_";
 
   // Filename for writing/reading surrogate data
-  std::string filename = "test_write_InterpolationSurrogateBuilder.dat";
+  std::string filename1 = "test_write_InterpolationSurrogateBuilder_1.dat";
+  std::string filename2 = "test_write_InterpolationSurrogateBuilder_2.dat";
 
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>
       paramSpace(env,vs_prefix.c_str(), 4, NULL);
@@ -71,7 +76,8 @@ int main(int argc, char ** argv)
   domainVector[2] = 1.5;
   domainVector[3] = 1.65;
 
-  double exact_val = four_d_fn(domainVector[0],domainVector[1],domainVector[2],domainVector[3]);
+  double exact_val_1 = four_d_fn_1(domainVector[0],domainVector[1],domainVector[2],domainVector[3]);
+  double exact_val_2 = four_d_fn_2(domainVector[0],domainVector[1],domainVector[2],domainVector[3]);
 
   double tol = 2.0*std::numeric_limits<double>::epsilon();
 
@@ -98,8 +104,11 @@ int main(int argc, char ** argv)
     n_points[2] = 31;
     n_points[3] = 41;
 
+    // One dataset for each of the two functions
+    const unsigned int n_datasets = 2;
+
     QUESO::InterpolationSurrogateDataSet<QUESO::GslVector, QUESO::GslMatrix>
-      data(paramDomain,n_points,1);
+      data(paramDomain,n_points,n_datasets);
 
     MyInterpolationBuilder<QUESO::GslVector,QUESO::GslMatrix>
       builder( data );
@@ -107,66 +116,86 @@ int main(int argc, char ** argv)
     builder.build_values();
 
     QUESO::LinearLagrangeInterpolationSurrogate<QUESO::GslVector,QUESO::GslMatrix>
-      four_d_surrogate( data.get_dataset(0) );
+      four_d_surrogate_1( data.get_dataset(0) );
 
-    double test_val = four_d_surrogate.evaluate(domainVector);
+    QUESO::LinearLagrangeInterpolationSurrogate<QUESO::GslVector,QUESO::GslMatrix>
+      four_d_surrogate_2( data.get_dataset(1) );
 
-    double rel_error = (test_val - exact_val)/exact_val;
+    double test_val_1 = four_d_surrogate_1.evaluate(domainVector);
+    double test_val_2 = four_d_surrogate_2.evaluate(domainVector);
 
-    if( std::fabs(rel_error) > tol )
-      {
-        std::cerr << "ERROR: Tolerance exceeded for 4D Lagrange interpolation test."
-                  << std::endl
-                  << " test_val  = " << test_val << std::endl
-                  << " exact_val = " << exact_val << std::endl
-                  << " rel_error = " << rel_error << std::endl
-                  << " tol       = " << tol << std::endl;
-
-        return_flag = 1;
-      }
+    return_flag  = return_flag ||
+      test_val( test_val_1, exact_val_1, tol, "test_build_1" ) ||
+      test_val( test_val_2, exact_val_2, tol, "test_build_2" );
 
     // Write the output to test reading next
     QUESO::InterpolationSurrogateIOASCII<QUESO::GslVector,QUESO::GslMatrix>
       data_writer;
 
-    data_writer.write( filename, data.get_dataset(0) );
+    data_writer.write( filename1, data.get_dataset(0) );
+    data_writer.write( filename2, data.get_dataset(1) );
   }
 
   // Now read the data and test
   {
     QUESO::InterpolationSurrogateIOASCII<QUESO::GslVector,QUESO::GslMatrix>
-      data_reader;
+      data_reader_1, data_reader_2;
 
-    data_reader.read( filename, env, vs_prefix.c_str() );
+    data_reader_1.read( filename1, env, vs_prefix.c_str() );
+    data_reader_2.read( filename2, env, vs_prefix.c_str() );
+
 
     // Build a new surrogate
     QUESO::LinearLagrangeInterpolationSurrogate<QUESO::GslVector,QUESO::GslMatrix>
-      four_d_surrogate( data_reader.data() );
+      four_d_surrogate_1( data_reader_1.data() );
 
-    double test_val = four_d_surrogate.evaluate(domainVector);
+    QUESO::LinearLagrangeInterpolationSurrogate<QUESO::GslVector,QUESO::GslMatrix>
+      four_d_surrogate_2( data_reader_2.data() );
 
-    double rel_error = (test_val - exact_val)/exact_val;
+    double test_val_1 = four_d_surrogate_1.evaluate(domainVector);
+    double test_val_2 = four_d_surrogate_2.evaluate(domainVector);
 
-    if( std::fabs(rel_error) > tol )
-      {
-        std::cerr << "ERROR: Tolerance exceeded for read/write interpolation test."
-                  << std::endl
-                  << " test_val  = " << test_val << std::endl
-                  << " exact_val = " << exact_val << std::endl
-                  << " rel_error = " << rel_error << std::endl
-                  << " tol       = " << tol << std::endl;
-
-        return_flag = 1;
-      }
+    return_flag  = return_flag ||
+      test_val( test_val_1, exact_val_1, tol, "test_read_1" ) ||
+      test_val( test_val_2, exact_val_2, tol, "test_read_2" );
   }
 
   return return_flag;
 }
 
-double four_d_fn( double x, double y, double z, double a )
+int test_val( double test_val, double exact_val, double tol, const std::string& test_name )
+{
+  int return_flag = 0;
+
+  double rel_error = (test_val - exact_val)/exact_val;
+
+  if( std::fabs(rel_error) > tol )
+    {
+      std::cerr << "ERROR: Tolerance exceeded for "+test_name
+                << std::endl
+                << " test_val  = " << test_val << std::endl
+                << " exact_val = " << exact_val << std::endl
+                << " rel_error = " << rel_error << std::endl
+                << " tol       = " << tol << std::endl;
+
+      return_flag = 1;
+    }
+
+  return return_flag;
+}
+
+double four_d_fn_1( double x, double y, double z, double a )
 {
   return 3.0 + 2.5*x - 3.1*y + 2.71*z + 3.14*a
     + 0.1*x*y + 1.2*x*z + 0.5*y*z + 0.1*x*a + 1.1*y*a + 2.1*z*a
     + 0.3*x*y*a + 0.5*x*z*a + 1.2*y*z*a + 0.9*x*y*z
     + 2.5*x*y*z*a;
+}
+
+double four_d_fn_2( double x, double y, double z, double a )
+{
+  return 2.0 + 1.5*x - 2.1*y + 1.71*z + 2.14*a
+    + 0.01*x*y + 0.2*x*z + 0.05*y*z + 0.01*x*a + 2.1*y*a + 3.1*z*a
+    + 1.3*x*y*a + 1.5*x*z*a + 2.2*y*z*a + 1.9*x*y*z
+    + 3.5*x*y*z*a;
 }


### PR DESCRIPTION
If the user is, say, solving a PDE and extracting multiple quantities from that PDE solution from which they will build multiple surrogates, it would be nice if the surrogate building infrastructure allowed that. So, I redid the API on the SurrogateBuilders to support this. Namely, I introduced a simple container object `InterpolationSurrogateDataSet` that creates consistent `InterpolationSurrogateData` objects. The SurrogateBuilder objects now take the DataSet object. Futhermore, the `evaluate_model` function got changed to a `void` function and now also takes an `std::vector` which the user populates; these are the values for each of the different functions the user is trying to interpolate. Everything else is unchanged. Once the builder is done, we can write/read each surrogate model individually, as before, and the user can use those as they please. Also updated the I/O to allow the user to supply the rank for reading/writing so that, if there's multiple processes available, the user can read/write each dataset on a different rank.

Tests and examples updated and passing. In particular, I manually tested the example on multiple MPI ranks and it is behaving as expected.