### PR TITLE
Disable HDF5-dependent examples if HDF5 is not configured

### DIFF
--- a/examples/infinite_dim/inverse_problem.C
+++ b/examples/infinite_dim/inverse_problem.C
@@ -70,6 +70,12 @@ int main(int argc, char **argv) {
 
   QUESO::FullEnvironment env(MPI_COMM_WORLD, argv[1], "", NULL);
 
+#ifndef QUESO_HAVE_HDF5
+  std::cerr << "Cannot run infinite dimensional inverse problems\n" <<
+               "without HDF5 enabled." << std::endl;
+  return 0;
+#else
+
   libMesh::LibMeshInit init(argc, argv);
 
   // Generate the mesh on which the samples live.
@@ -126,6 +132,8 @@ int main(int argc, char **argv) {
       std::cout << "l2 norm is: " << s.llhd_val() << std::endl;
     }
   }
+
+#endif // QUESO_HAVE_HDF5
 
   return 0;
 }

--- a/examples/infinite_dim/parallel_inverse_problem.C
+++ b/examples/infinite_dim/parallel_inverse_problem.C
@@ -74,6 +74,12 @@ int main(int argc, char **argv) {
 
   QUESO::FullEnvironment env(MPI_COMM_WORLD, argv[1], "", NULL);
 
+#ifndef QUESO_HAVE_HDF5
+  std::cerr << "Cannot run infinite dimensional inverse problems\n" <<
+               "without HDF5 enabled." << std::endl;
+  return 0;
+#else
+
   // When the number of processes passed to `mpirun` is different from the
   // number of subenvironments asked for in the input file, QUESO creates a
   // subcommunicator that 'does the right thing'.
@@ -143,6 +149,8 @@ int main(int argc, char **argv) {
     }
   }
 }
+
+#endif // QUESO_HAVE_HDF5
 
   MPI_Finalize();
 

--- a/test/test_infinite/test_inf_options.C
+++ b/test/test_infinite/test_inf_options.C
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
 
 // Need an artificial block here because libmesh needs to
 // call PetscFinalize before we call MPI_Finalize
-#ifdef LIBMESH_HAVE_SLEPC
+#if defined(LIBMESH_HAVE_SLEPC) && defined(QUESO_HAVE_HDF5)
 {
   libMesh::LibMeshInit init(argc, argv);
 


### PR DESCRIPTION
Long term, I need to upgrade our hdf5.m4 so that libMesh and QUESO (and anyone else) can use the Ubuntu 15.04 install.

Short term, this at least gets us compiling without errors again.