### PR TITLE
Don't forget MPI_Finalize() if !QUESO_HAVE_HDF5

### DIFF
--- a/examples/infinite_dim/parallel_inverse_problem.C
+++ b/examples/infinite_dim/parallel_inverse_problem.C
@@ -77,6 +77,9 @@ int main(int argc, char **argv) {
 #ifndef QUESO_HAVE_HDF5
   std::cerr << "Cannot run infinite dimensional inverse problems\n" <<
                "without HDF5 enabled." << std::endl;
+
+  MPI_Finalize();
+
   return 0;
 #else
 


### PR DESCRIPTION
Otherwise MPI returns 1 and run_all.sh thinks we have an actual error
rather than just a disabled example.