### PR TITLE
Document all input file options for DRAM

### DIFF
--- a/src/stats/inc/MetropolisHastingsSGOptions.h
+++ b/src/stats/inc/MetropolisHastingsSGOptions.h
@@ -562,68 +562,118 @@ public:
 private:
   BoostInputOptionsParser * m_parser;
 
+  //! Option name for MhOptionsValues::m_help.  Option name is m_prefix + "mh_help"
   std::string                   m_option_help;
 
+  //! Option name for MhOptionsValues::m_dataOutputFileName.  Option name is m_prefix + "mh_dataOutputFileName"
   std::string                   m_option_dataOutputFileName;
+  //! Option name for MhOptionsValues::m_dataOutputAllowAll.  Option name is m_prefix + "mh_dataOutputAllowAll"
   std::string                   m_option_dataOutputAllowAll;
+  //! Option name for MhOptionsValues::m_dataOutputAllowedSet.  Option name is m_prefix + "mh_dataOutputAllowedSet"
   std::string                   m_option_dataOutputAllowedSet;
 
+  //! Option name for MhOptionsValues::m_totallyMute.  Option name is m_prefix + "mh_totallyMute"
   std::string                   m_option_totallyMute;
+  //! Option name for MhOptionsValues::m_initialPositionDataInputFileName.  Option name is m_prefix + "mh_initialPosition_dataInputFileName"
   std::string                   m_option_initialPosition_dataInputFileName;
+  //! Option name for MhOptionsValues::m_initialPositionDataInputFileType.  Option name is m_prefix + "mh_initialPosition_dataInputFileType"
   std::string                   m_option_initialPosition_dataInputFileType;
+  //! Option name for MhOptionsValues::m_initialProposalCovMatrixDataInputFileName.  Option name is m_prefix + "mh_initialProposalCovMatrix_dataInputFileName"
   std::string                   m_option_initialProposalCovMatrix_dataInputFileName;
+  //! Option name for MhOptionsValues::m_initialProposalCovMatrixDataInputFileType.  Option name is m_prefix + "mh_initialProposalCovMatrix_dataInputFileType"
   std::string                   m_option_initialProposalCovMatrix_dataInputFileType;
+  //! Option name for MhOptionsValues::m_parameterDisabledSet.  Option name is m_prefix + "mh_listOfDisabledParameters"
   std::string                   m_option_listOfDisabledParameters;  // gpmsa2
+  //! Option name for MhOptionsValues::m_rawChainDataInputFileName.  Option name is m_prefix + "mh_rawChain_dataInputFileName"
   std::string                   m_option_rawChain_dataInputFileName;
+  //! Option name for MhOptionsValues::m_rawChainDataInputFileType.  Option name is m_prefix + "mh_rawChain_dataInputFileType"
   std::string                   m_option_rawChain_dataInputFileType;
+  //! Option name for MhOptionsValues::m_rawChainSize.  Option name is m_prefix + "mh_rawChain_size"
   std::string                   m_option_rawChain_size;
+  //! Option name for MhOptionsValues::m_rawChainGenerateExtra.  Option name is m_prefix + "mh_rawChain_generateExtra"
   std::string                   m_option_rawChain_generateExtra;
+  //! Option name for MhOptionsValues::m_rawChainDisplayPeriod.  Option name is m_prefix + "mh_rawChain_displayPeriod"
   std::string                   m_option_rawChain_displayPeriod;
+  //! Option name for MhOptionsValues::m_rawChainMeasureRunTimes.  Option name is m_prefix + "mh_rawChain_measureRunTimes"
   std::string                   m_option_rawChain_measureRunTimes;
+  //! Option name for MhOptionsValues::m_rawChainDataOutputPeriod.  Option name is m_prefix + "mh_rawChain_dataOutputPeriod"
   std::string                   m_option_rawChain_dataOutputPeriod;
+  //! Option name for MhOptionsValues::m_rawChainDataOutputFileName.  Option name is m_prefix + "mh_rawChain_dataOutputFileName"
   std::string                   m_option_rawChain_dataOutputFileName;
+  //! Option name for MhOptionsValues::m_rawChainDataOutputFileType.  Option name is m_prefix + "mh_rawChain_dataOutputFileType"
   std::string                   m_option_rawChain_dataOutputFileType;
+  //! Option name for MhOptionsValues::m_rawChainDataOutputAllowAll.  Option name is m_prefix + "mh_rawChain_dataOutputAllowAll"
   std::string                   m_option_rawChain_dataOutputAllowAll;
+  //! Option name for MhOptionsValues::m_rawChainDataOutputAllowedSet.  Option name is m_prefix + "mh_rawChain_dataOutputAllowedSet"
   std::string                   m_option_rawChain_dataOutputAllowedSet;
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  //! Option name for MhOptionsValues::m_rawChainComputeStats.  Option name is m_prefix + "mh_rawChain_computeStats"
   std::string                   m_option_rawChain_computeStats;
 #endif
+  //! Option name for MhOptionsValues::m_filteredChainGenerate.  Option name is m_prefix + "mh_filteredChain_generate"
   std::string                   m_option_filteredChain_generate;
+  //! Option name for MhOptionsValues::m_filteredChainDiscardedPortion.  Option name is m_prefix + "mh_filteredChain_discardedPortion"
   std::string                   m_option_filteredChain_discardedPortion;
+  //! Option name for MhOptionsValues::m_filteredChainLag.  Option name is m_prefix + "mh_filteredChain_lag"
   std::string                   m_option_filteredChain_lag;
+  //! Option name for MhOptionsValues::m_filteredChainDataOutputFileName.  Option name is m_prefix + "mh_filteredChain_dataOutputFileName"
   std::string                   m_option_filteredChain_dataOutputFileName;
+  //! Option name for MhOptionsValues::m_filteredChainDataOutputFileType.  Option name is m_prefix + "mh_filteredChain_dataOutputFileType"
   std::string                   m_option_filteredChain_dataOutputFileType;
+  //! Option name for MhOptionsValues::m_filteredChainDataOutputAllowAll.  Option name is m_prefix + "mh_filteredChain_dataOutputAllowAll"
   std::string                   m_option_filteredChain_dataOutputAllowAll;
+  //! Option name for MhOptionsValues::m_filteredChainDataOutputAllowedSet.  Option name is m_prefix + "mh_filteredChain_dataOutputAllowedSet"
   std::string                   m_option_filteredChain_dataOutputAllowedSet;
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  //! Option name for MhOptionsValues::m_filteredChainComputeStats.  Option name is m_prefix + "mh_filteredChain_computeStats"
   std::string                   m_option_filteredChain_computeStats;
 #endif
+  //! Option name for MhOptionsValues::m_displayCandidates.  Option name is m_prefix + "mh_displayCandidates"
   std::string                   m_option_displayCandidates;
+  //! Option name for MhOptionsValues::m_putOutOfBoundsInChain.  Option name is m_prefix + "mh_putOutOfBoundsInChain"
   std::string                   m_option_putOutOfBoundsInChain;
+  //! Option name for MhOptionsValues::m_tkUseLocalHessian.  Option name is m_prefix + "mh_tk_useLocalHessian"
   std::string                   m_option_tk_useLocalHessian;
+  //! Option name for MhOptionsValues::m_tkUseNewtonComponent.  Option name is m_prefix + "mh_tk_useNewtonComponent"
   std::string                   m_option_tk_useNewtonComponent;
+  //! Option name for MhOptionsValues::m_drMaxNumExtraStages.  Option name is m_prefix + "mh_dr_maxNumExtraStages"
   std::string                   m_option_dr_maxNumExtraStages;
+  //! Option name for MhOptionsValues::m_drScalesForExtraStages.  Option name is m_prefix + "mh_dr_listOfScalesForExtraStages"
   std::string                   m_option_dr_listOfScalesForExtraStages;
+  //! Option name for MhOptionsValues::m_drDuringAmNonAdaptiveInt.  Option name is m_prefix + "mh_dr_duringAmNonAdaptiveInt"
   std::string                   m_option_dr_duringAmNonAdaptiveInt;
+  //! Option name for MhOptionsValues::m_amKeepInitialMatrix.  Option name is m_prefix + "mh_am_keepInitialMatrix"
   std::string                   m_option_am_keepInitialMatrix;
+  //! Option name for MhOptionsValues::m_amInitialNonAdaptInterval.  Option name is m_prefix + "mh_am_initialNonAdaptInterval"
   std::string                   m_option_am_initialNonAdaptInterval;
+  //! Option name for MhOptionsValues::m_amAdaptInterval.  Option name is m_prefix + "mh_am_adaptInterval"
   std::string                   m_option_am_adaptInterval;
+  //! Option name for MhOptionsValues::m_amAdaptedMatricesDataOutputPeriod.  Option name is m_prefix + "mh_am_adaptedMatrices_dataOutputPeriod"
   std::string                   m_option_am_adaptedMatrices_dataOutputPeriod;
+  //! Option name for MhOptionsValues::m_amAdaptedMatricesDataOutputFileName.  Option name is m_prefix + "mh_am_adaptedMatrices_dataOutputFileName"
   std::string                   m_option_am_adaptedMatrices_dataOutputFileName;
+  //! Option name for MhOptionsValues::m_amAdaptedMatricesDataOutputFileType.  Option name is m_prefix + "mh_am_adaptedMatrices_dataOutputFileType"
   std::string                   m_option_am_adaptedMatrices_dataOutputFileType;
+  //! Option name for MhOptionsValues::m_amAdaptedMatricesDataOutputAllowAll.  Option name is m_prefix + "mh_am_adaptedMatrices_dataOutputAllowAll"
   std::string                   m_option_am_adaptedMatrices_dataOutputAllowAll;
+  //! Option name for MhOptionsValues::m_amAdaptedMatricesDataOutputAllowedSet.  Option name is m_prefix + "mh_am_adaptedMatrices_dataOutputAllowedSet"
   std::string                   m_option_am_adaptedMatrices_dataOutputAllowedSet;
 
-  //! See MhOptionsValues::m_amEta
+  //! Option name for MhOptionsValues::m_amEta.  Option name is m_prefix + "mh_am_eta"
   std::string                   m_option_am_eta;
-  //! See MhOptionsValues::m_amEpsilon
+  //! Option name for MhOptionsValues::m_amEpsilon.  Option name is m_prefix + "mh_am_epsilon"
   std::string                   m_option_am_epsilon;
 
+  //! Option name for MhOptionsValues::m_enableBrooksGelmanConvMonitor.  Option name is m_prefix + "mh_enableBrooksGelmanConvMonitor"
   std::string                   m_option_enableBrooksGelmanConvMonitor;
+  //! Option name for MhOptionsValues::m_BrooksGelmanLag.  Option name is m_prefix + "mh_BrooksGelmanLag"
   std::string                   m_option_BrooksGelmanLag;
 
+  //! Option name for MhOptionsValues::m_outputLogLikelihood.  Option name is m_prefix + "mh_outputLogLikelihood"
   std::string                   m_option_outputLogLikelihood;
+  //! Option name for MhOptionsValues::m_outputLogTarget.  Option name is m_prefix + "mh_outputLogTarget"
   std::string                   m_option_outputLogTarget;
+  //! Option name for MhOptionsValues::m_doLogitTransform.  Option name is m_prefix + "mh_doLogitTransform"
   std::string                   m_option_doLogitTransform;
 
   //! Copies the option values from \c src to \c this.

--- a/src/stats/inc/MetropolisHastingsSGOptions.h
+++ b/src/stats/inc/MetropolisHastingsSGOptions.h
@@ -154,6 +154,7 @@ public:
   MhOptionsValues& operator= (const MhOptionsValues& rhs);
   //@}
 
+  //! Prefix for input file option names.  Prepends all options for this class.
   std::string                        m_prefix;
 
   //! If non-empty string, print options and values to the output file
@@ -162,8 +163,7 @@ public:
    */
   std::string m_help;
 
-  //! The base name of output files where the chain (and related information)
-  //! will be written.
+  //! The base name of output files where the chain (and related information) will be written.
   /*!
    * For multiple environments, the respective chains will append "_subN"
    * where N is the environment number.
@@ -193,16 +193,13 @@ public:
   //! If true, zero output is written to files.  Default is false.
   bool                               m_totallyMute;
 
-  //! If not ".", reads the contents of the file and uses that to start the
-  //! MCMC.  Default is "."
+  //! If not ".", reads the contents of the file and uses that to start the MCMC.  Default is "."
   std::string                        m_initialPositionDataInputFileName;
 
-  //! The filetype of m_initialPositionDataInputFileName.  Only "m" (matlab) is
-  //! currently supported.  Default is "m"
+  //! The filetype of m_initialPositionDataInputFileName.  Only "m" (matlab) is currently supported.  Default is "m"
   std::string                        m_initialPositionDataInputFileType;
 
-  //! If not ".", reads the contents of the file as the initial proposal
-  //! covariance matrix.
+  //! If not ".", reads the contents of the file as the initial proposal covariance matrix.
   /*!
    * To use this, m_tkUseLocalHessian must be false
    *
@@ -210,8 +207,7 @@ public:
    */
   std::string                        m_initialProposalCovMatrixDataInputFileName;
 
-  //! The filetype of m_initialProposalCovMatrixDataInputFileName.  Only "m"
-  //! (matlab) is currently supported.  Default is "m"
+  //! The filetype of m_initialProposalCovMatrixDataInputFileName.  Only "m" (matlab) is currently supported.  Default is "m"
   std::string                        m_initialProposalCovMatrixDataInputFileType;
 
   //! \todo DOCUMENT ME
@@ -231,12 +227,10 @@ public:
    */
   std::string                        m_rawChainDataInputFileName;
 
-  //! The filetype of m_rawChainDataInputFileName.  Only "m" (matlab) is
-  //! currently supported.  Default is "m"
+  //! The filetype of m_rawChainDataInputFileName.  Only "m" (matlab) is currently supported.  Default is "m"
   std::string                        m_rawChainDataInputFileType;
 
-  //! The size of the chain (number of posterior samples) to generate.  Default
-  //! is 100
+  //! The size of the chain (number of posterior samples) to generate.  Default is 100
   unsigned int                       m_rawChainSize;
 
   //! If true, extra chain information is computed/stored
@@ -256,8 +250,7 @@ public:
    */
   unsigned int                       m_rawChainDisplayPeriod;
 
-  //! If true, measures timings spent in various chain computions and writes
-  //! them to the output file
+  //! If true, measures timings spent in various chain computions and writes them to the output file
   /*!
    * The measurements are:
    *
@@ -285,12 +278,10 @@ public:
    */
   std::string                        m_rawChainDataOutputFileName;
 
-  //! The filetype of m_rawChainDataOutputFileName.  Only "m" (matlab) is
-  //! currently supported.  Default is "m"
+  //! The filetype of m_rawChainDataOutputFileName.  Only "m" (matlab) is currently supported.  Default is "m"
   std::string                        m_rawChainDataOutputFileType;
 
-  //! Toggle for whether or not to allow all processes to write Markov chain
-  //! output to a file
+  //! Toggle for whether or not to allow all processes to write Markov chain output to a file
   /*!
    * If true, all processes write Markov chain output and
    * m_rawChainDataOutputAllowedSet is ignored.
@@ -302,12 +293,10 @@ public:
    */
   bool                               m_rawChainDataOutputAllowAll;
 
-  //! The set of MPI ranks that will write Markov chain output to a file.  See
-  //! also m_rawChainDataOutputAllowAll.  Default is empty set.
+  //! The set of MPI ranks that will write Markov chain output to a file.  See also m_rawChainDataOutputAllowAll.  Default is empty set.
   std::set<unsigned int>             m_rawChainDataOutputAllowedSet;
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-  //! Flag to tell QUESO whether or not to compute chain statistics.  Default
-  //! is false.
+  //! Flag to tell QUESO whether or not to compute chain statistics.  Default is false.
   bool                               m_rawChainComputeStats;
 #endif
 
@@ -339,12 +328,10 @@ public:
   //! If not ".", file name to save the filtered chain to.  Default is ".".
   std::string                        m_filteredChainDataOutputFileName;
 
-  //! The filetype of m_filteredChainDataOutputFileName.  Only "m" (matlab) is
-  //! currently supported.  Default is "m"
+  //! The filetype of m_filteredChainDataOutputFileName.  Only "m" (matlab) is currently supported.  Default is "m"
   std::string                        m_filteredChainDataOutputFileType;
 
-  //! Toggle for whether or not to allow all processes to write *filetered*
-  //! Markov chain output to a file
+  //! Toggle for whether or not to allow all processes to write *filetered* Markov chain output to a file
   /*!
    * If true, all processes write filtered Markov chain output and
    * m_filteredChainDataOutputAllowedSet is ignored.
@@ -356,21 +343,17 @@ public:
    */
   bool                               m_filteredChainDataOutputAllowAll;
 
-  //! The set of MPI ranks that will write filtered Markov chain output to a
-  //! file.  See also m_filteredChainDataOutputAllowAll.  Default is empty set.
+  //! The set of MPI ranks that will write filtered Markov chain output to a file.  See also m_filteredChainDataOutputAllowAll.  Default is empty set.
   std::set<unsigned int>             m_filteredChainDataOutputAllowedSet;
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-  //! Toggle to tell QUESO whether or not to compute statistics on the filtered
-  //! chain.  Default is false
+  //! Toggle to tell QUESO whether or not to compute statistics on the filtered chain.  Default is false
   bool                               m_filteredChainComputeStats;
 #endif
 
-  //! Toggle to tell QUESO whether or not to write proposal (candidate) state
-  //! to output file.  Default is false
+  //! Toggle to tell QUESO whether or not to write proposal (candidate) state to output file.  Default is false
   bool                               m_displayCandidates;
 
-  //! Flag to tell QUESO how chains should be upon generating a proposal that
-  //! is out of the problem domain.
+  //! Flag to tell QUESO how chains should be upon generating a proposal that is out of the problem domain.
   /*!
    * If true, the chain will reject any proposal states outside of the
    * problem domain and the chain will *advance* to the next iteration, staying
@@ -385,8 +368,7 @@ public:
    */
   bool                               m_putOutOfBoundsInChain;
 
-  //! Flag to tell QUESO whether or not to use Hessian information for the
-  //! proposal covariance matrix
+  //! Flag to tell QUESO whether or not to use Hessian information for the proposal covariance matrix
   /*!
    * The interaction with delayed rejection:
    *
@@ -425,8 +407,7 @@ public:
    */
   unsigned int                       m_drMaxNumExtraStages;
 
-  //! The vector of scale factors for the proposal covariance matrix to use for
-  //! delayed rejection.
+  //! The vector of scale factors for the proposal covariance matrix to use for delayed rejection.
   /*!
    * Example:
    *
@@ -470,8 +451,7 @@ public:
   //! This option is a no-op.  The default is false.
   bool                               m_amKeepInitialMatrix;
 
-  //! The number of initial samples to do without adapting the proposal
-  //! covariance matrix
+  //! The number of initial samples to do without adapting the proposal covariance matrix
   /*!
    * If positive and the current sampler iteration is <=
    * m_amInitialNonAdaptInterval, then no delayed rejection is done if
@@ -492,8 +472,7 @@ public:
    */
   unsigned int                       m_amAdaptInterval;
 
-  //! The frequency (after m_amInitialNonAdaptInterval samples are done) of
-  //! printing the last adapted proposal covariance matrix.
+  //! The frequency (after m_amInitialNonAdaptInterval samples are done) of printing the last adapted proposal covariance matrix.
   /*!
    * Provided m_amAdaptedMatricesDataOutputFileName is not ".", the last
    * adapted proposal covariance matrix will be written regardless of the value
@@ -508,12 +487,10 @@ public:
    */
   unsigned int                       m_amAdaptedMatricesDataOutputPeriod;
 
-  //! If not ".", this is the file to write adapted proposal covariance
-  //! matrices to.  Default is "."
+  //! If not ".", this is the file to write adapted proposal covariance matrices to.  Default is "."
   std::string                        m_amAdaptedMatricesDataOutputFileName;
 
-  //! The filetype of m_amAdaptedMatricesDataOutputFileName.  Only "m" (matlab)
-  //is currently supported.  Default is "m"
+  //! The filetype of m_amAdaptedMatricesDataOutputFileName.  Only "m" (matlab) is currently supported.  Default is "m"
   std::string                        m_amAdaptedMatricesDataOutputFileType;
 
   //! This option is a no-op.  The default is false.
@@ -547,8 +524,7 @@ public:
    */
   double                             m_amEpsilon;
 
-  //! The frequency with which to compute the Brooks-Gelman convergence
-  //! statistic.
+  //! The frequency with which to compute the Brooks-Gelman convergence statistic.
   /*!
    * If zero, it is not computed.
    *
@@ -574,16 +550,13 @@ public:
    */
   unsigned int                       m_BrooksGelmanLag;
 
-  //! Flag for deciding whether or not to dump log likelihood values in output.
-  //! Default is true.
+  //! Flag for deciding whether or not to dump log likelihood values in output.  Default is true.
   bool m_outputLogLikelihood;
 
-  //! Flag for deciding whether or not to dump log target values in output
-  //! Default is true.
+  //! Flag for deciding whether or not to dump log target values in output Default is true.
   bool m_outputLogTarget;
 
-  //! Flag for deciding whether or not to do logit transform of bounded domains
-  //! Default is true.
+  //! Flag for deciding whether or not to do logit transform of bounded domains Default is true.
   bool m_doLogitTransform;
 
 private:

--- a/src/stats/inc/MetropolisHastingsSGOptions.h
+++ b/src/stats/inc/MetropolisHastingsSGOptions.h
@@ -204,7 +204,9 @@ public:
 
   //! If not ".", reads the contents of the file as the initial proposal covariance matrix.
   /*!
-   * To use this, m_tkUseLocalHessian must be false
+   * To use this, m_tkUseLocalHessian must be false.  If it is true, and this
+   * option is ".", no input file is read and the user-provided initial
+   * proposal covariance matrix is used.
    *
    * If this option is ".", no input file is read.
    *
@@ -215,13 +217,13 @@ public:
   //! The filetype of m_initialProposalCovMatrixDataInputFileName.  Only "m" (matlab) is currently supported.  Default is "m"
   std::string                        m_initialProposalCovMatrixDataInputFileType;
 
-  //! \todo DOCUMENT ME
+  //! Set of parameters that don't get sampled
   /*!
    * Default is empty set
    */
   std::set<unsigned int>             m_parameterDisabledSet;  // gpmsa2
 
-  //! Filename for reading and already-produced Markov chain
+  //! Filename for reading an already-produced Markov chain
   /*!
    * If ".", generates the Markov chain without reading anything.
    * If not ".", this is the name of the file to read a Markov chain from
@@ -249,7 +251,9 @@ public:
 
   //! The frequency with which to output diagnostic information
   /*!
-   * Diagnostics are current sample iteration and current rejection percentage
+   * Diagnostics are current sample iteration and current rejection percentage.
+   *
+   * Must be an integer.
    *
    * Default is 500
    */
@@ -345,7 +349,7 @@ public:
   //! The filetype of m_filteredChainDataOutputFileName.  Only "m" (matlab) is currently supported.  Default is "m"
   std::string                        m_filteredChainDataOutputFileType;
 
-  //! Toggle for whether or not to allow all processes to write *filetered* Markov chain output to a file
+  //! Toggle for whether or not to allow all processes to write *filtered* Markov chain output to a file
   /*!
    * If true, all processes write filtered Markov chain output and
    * m_filteredChainDataOutputAllowedSet is ignored.
@@ -496,6 +500,8 @@ public:
    * Beyond m_amInitialNonAdaptInterval, the last adapted proposal covariance
    * matrix will be printed to the output file every
    * m_amAdaptedMatricesDataOutputPeriod samples.
+   *
+   * If zero, no output is written.
    *
    * The default is 0
    */

--- a/src/stats/inc/MetropolisHastingsSGOptions.h
+++ b/src/stats/inc/MetropolisHastingsSGOptions.h
@@ -157,44 +157,175 @@ public:
   std::string                        m_prefix;
 
   //! If non-empty string, print options and values to the output file
+  /*!
+   * Default is empty string
+   */
   std::string m_help;
 
+  //! The base name of output files where the chain (and related information)
+  //! will be written.
+  /*!
+   * For multiple environments, the respective chains will append "_subN"
+   * where N is the environment number.
+   *
+   * For log likelihood, log target, and log prior, a further "_loglikelihood",
+   * "_logtarget" and "_logprior" is appended respectively
+   *
+   * Default value is "."
+   */
   std::string                        m_dataOutputFileName;
+
+  //! If true, all processes write output and m_dataOutputAllowedSet is ignored
+  /*!
+   * If false, m_dataOutputAllowedSet determines the set of MPI ranks that
+   * can write output
+   *
+   * Default is false
+   */
   bool                               m_dataOutputAllowAll;
+
+  //! The set of MPI ranks that can write output.  See m_dataOutputAllowAll
+  /*!
+   * Default value is the empty set
+   */
   std::set<unsigned int>             m_dataOutputAllowedSet;
 
+  //! If true, zero output is written to files.  Default is false.
   bool                               m_totallyMute;
+
+  //! If not ".", reads the contents of the file and uses that to start the
+  //! MCMC.  Default is "."
   std::string                        m_initialPositionDataInputFileName;
+
+  //! The filetype of m_initialPositionDataInputFileName.  Only "m" (matlab) is
+  //! currently supported.  Default is "m"
   std::string                        m_initialPositionDataInputFileType;
+
+  //! If not ".", reads the contents of the file as the initial proposal
+  //! covariance matrix.
+  /*!
+   * To use this, m_tkUseLocalHessian must be false
+   *
+   * Default is "."
+   */
   std::string                        m_initialProposalCovMatrixDataInputFileName;
+
+  //! The filetype of m_initialProposalCovMatrixDataInputFileName.  Only "m"
+  //! (matlab) is currently supported.  Default is "m"
   std::string                        m_initialProposalCovMatrixDataInputFileType;
+
+  //! \todo DOCUMENT ME
+  /*!
+   * Default is empty set
+   */
   std::set<unsigned int>             m_parameterDisabledSet;  // gpmsa2
+
+  //! Filename for reading and already-produced Markov chain
+  /*!
+   * If ".", generates the Markov chain without reading anything.
+   * If not ".", this is the name of the file to read a Markov chain from
+   * instead of generating a chain.  Filtering and MLE/MAP computations are
+   * still done.
+   *
+   * Default is "."
+   */
   std::string                        m_rawChainDataInputFileName;
+
+  //! The filetype of m_rawChainDataInputFileName.  Only "m" (matlab) is
+  //! currently supported.  Default is "m"
   std::string                        m_rawChainDataInputFileType;
+
+  //! The size of the chain (number of posterior samples) to generate.  Default
+  //! is 100
   unsigned int                       m_rawChainSize;
+
+  //! If true, extra chain information is computed/stored
+  /*!
+   * The extra information written is: log target, acceptance ratio, number
+   * of rejected samples.
+   *
+   * Default is false
+   */
   bool                               m_rawChainGenerateExtra;
+
+  //! The frequency with which to output diagnostic information
+  /*!
+   * Diagnostics are current sample iteration and current rejection percentage
+   *
+   * Default is 500
+   */
   unsigned int                       m_rawChainDisplayPeriod;
+
+  //! If true, measures timings spent in various chain computions and writes
+  //! them to the output file
+  /*!
+   * The measurements are:
+   *
+   * time spent computing proposal
+   * time spent computing target
+   * time spent computing metropolis
+   * time spent computing hastings acceptance ratio
+   * time spent computing delayed rejection
+   * average time spent computing target
+   * total delayed rejection run time
+   * total adaptive metropolis run time
+   *
+   * Default is true
+   */
   bool                               m_rawChainMeasureRunTimes;
+
+  //! The frequency with which to write chain output.  Defaults to 0.
   unsigned int                       m_rawChainDataOutputPeriod;
+
+  //! If not ".", filename to write the Markov chain to
+  /*!
+   * m_totallyMute must be false
+   *
+   * Default is "."
+   */
   std::string                        m_rawChainDataOutputFileName;
+
+  //! The filetype of m_rawChainDataOutputFileName.  Only "m" (matlab) is
+  //! currently supported.  Default is "m"
   std::string                        m_rawChainDataOutputFileType;
+
+  //! Toggle for whether or not to allow all processes to write Markov chain
+  //! output to a file
+  /*!
+   * If true, all processes write Markov chain output and
+   * m_rawChainDataOutputAllowedSet is ignored.
+   *
+   * If false, m_rawChainDataOutputAllowedSet determines the set of
+   * processor ranks that will write Markov chain output to a file
+   *
+   * Default is false
+   */
   bool                               m_rawChainDataOutputAllowAll;
+
+  //! The set of MPI ranks that will write Markov chain output to a file.  See
+  //! also m_rawChainDataOutputAllowAll.  Default is empty set.
   std::set<unsigned int>             m_rawChainDataOutputAllowedSet;
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  //! Flag to tell QUESO whether or not to compute chain statistics.  Default
+  //! is false.
   bool                               m_rawChainComputeStats;
 #endif
 
-  //! Toggle the option to save a filtered chain.  Default is 0 (off).
+  //! Toggle the option to save a filtered chain.
   /*!
    * A filtered chain is one where only every k-th sample is saved.  Here k
    * is called the 'lag' and can be set through m_filteredChainLag.
+   *
+   * Default is false
    */
   bool                               m_filteredChainGenerate;
 
-  //! What initial fraction of the filtered chain is discarded.  Default is 0.
+  //! What initial fraction of the filtered chain is discarded.
   /*!
    * For example, if set to 0.2 then the first 20% of the filtered chain is
    * discarded.  Useful for discarding 'burn-in'.
+   *
+   * Default is 0.0
    */
   double                             m_filteredChainDiscardedPortion; // input or set during run time
 
@@ -205,29 +336,190 @@ public:
    */
   unsigned int                       m_filteredChainLag;              // input or set during run time
 
-  //! File name to save the filtered chain to.  Default is ".".
+  //! If not ".", file name to save the filtered chain to.  Default is ".".
   std::string                        m_filteredChainDataOutputFileName;
+
+  //! The filetype of m_filteredChainDataOutputFileName.  Only "m" (matlab) is
+  //! currently supported.  Default is "m"
   std::string                        m_filteredChainDataOutputFileType;
+
+  //! Toggle for whether or not to allow all processes to write *filetered*
+  //! Markov chain output to a file
+  /*!
+   * If true, all processes write filtered Markov chain output and
+   * m_filteredChainDataOutputAllowedSet is ignored.
+   *
+   * If false, m_filteredChainDataOutputAllowedSet determines the set of
+   * processor ranks that will write filtered Markov chain output to a file
+   *
+   * Default is false
+   */
   bool                               m_filteredChainDataOutputAllowAll;
+
+  //! The set of MPI ranks that will write filtered Markov chain output to a
+  //! file.  See also m_filteredChainDataOutputAllowAll.  Default is empty set.
   std::set<unsigned int>             m_filteredChainDataOutputAllowedSet;
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  //! Toggle to tell QUESO whether or not to compute statistics on the filtered
+  //! chain.  Default is false
   bool                               m_filteredChainComputeStats;
 #endif
 
+  //! Toggle to tell QUESO whether or not to write proposal (candidate) state
+  //! to output file.  Default is false
   bool                               m_displayCandidates;
+
+  //! Flag to tell QUESO how chains should be upon generating a proposal that
+  //! is out of the problem domain.
+  /*!
+   * If true, the chain will reject any proposal states outside of the
+   * problem domain and the chain will *advance* to the next iteration, staying
+   * where it is.
+   *
+   * If false, the chain will not do an accept-reject on a proposed state that
+   * is out of bounds.  Instead, QUESO will regenerate proposal until it is in
+   * the domain.  Only when a proposal is in the problem domain does QUESO do
+   * an accept-reject step.
+   *
+   * The default is true
+   */
   bool                               m_putOutOfBoundsInChain;
+
+  //! Flag to tell QUESO whether or not to use Hessian information for the
+  //! proposal covariance matrix
+  /*!
+   * The interaction with delayed rejection:
+   *
+   * If m_drDuringAmNonAdaptiveInt is false and m_tkUseLocalHessian is false
+   * and m_amInitialNonAdaptInterval > 0 and m_amAdaptInterval is > 0 and
+   * the current sampler iteration is <= m_amInitialNonAdaptInterval, then
+   * no delayed rejection is done.
+   *
+   * The above is hard to parse, it essentially means that, unless you ask for
+   * it, no delayed rejection is dont in the initial phase of sampling when no
+   * adaptive Metropolis is happening.
+   *
+   * The interaction with adaptive Metropolis:
+   *
+   * If m_tkUseLocalHessian is true, no adaptive Metropolis is done.  If it's
+   * false, then we also need that m_amInitialNonAdaptInterval > 0 and
+   * m_amAdaptInterval > 0 otherwise no adaptive Metropolis is done.
+   *
+   * The default is false.
+   *
+   * DM: I think m_tkUseLocalHessian == true is not supported, since we have no
+   * algorithms that leverage Hessian information right now.
+   */
   bool                               m_tkUseLocalHessian;
+
+  //! This option is a no-op.  Default is true.
   bool                               m_tkUseNewtonComponent;
+
+  //! The number of delayed rejection stages to do.  Default is 0
+  /*!
+   * Delayed rejection happens when a proposal is about to be rejected.
+   *
+   * If m_drMaxNumExtraStages is zero, no delayed rejection is done.
+   *
+   * Default is 0
+   */
   unsigned int                       m_drMaxNumExtraStages;
+
+  //! The vector of scale factors for the proposal covariance matrix to use for
+  //! delayed rejection.
+  /*!
+   * Example:
+   *
+   * Assume the user provides "2.0 3.0 5.0" as their list of scales.  This
+   * means QUESO will multiply the proposal covariance matrix for delayed
+   * rejection stage 1 by 1.0 / (2.0 * 2.0).  For delayed rejection stage 2
+   * the proposal covariance matrix will be multiplied by 1.0 / (3.0 * 3.0).
+   * And for stage 3 it will be multiplied by 1.0 / (5.0 * 5.0).
+   *
+   * Generally, the user-provided list of scales should be *increasing*, but
+   * this is not checked for.
+   *
+   * QUESO will prepend a scale of 1.0 to the user-provided list.
+   *
+   * The default is the empty list.
+   */
   std::vector<double>                m_drScalesForExtraStages;
+
+  //! Do delayed rejection during the initial non-adaptive part of sampling?
+  /*!
+   * This option interacts with the following other options:
+   *
+   * m_tkUseLocalHessian
+   * m_amInitialNonAdaptInterval
+   * m_amAdaptInterval
+   *
+   *
+   * The interaction is as follows.  If this option is false, then as long as
+   * m_tkUseLocalHessian is false, m_amInitialNonAdaptInterval is > 0,
+   * m_amAdaptInterval is > 0, and the current sampler iteration is <=
+   * m_amInitialNonAdaptInterval *NO* delayed rejection is done.
+   *
+   * If this option is true (regardless of the other above conditions) then
+   * delayed rejection is done (including the initial non-adaptive part of
+   * sampling).
+   *
+   * The default is true.
+   */
   bool                               m_drDuringAmNonAdaptiveInt;
+
+  //! This option is a no-op.  The default is false.
   bool                               m_amKeepInitialMatrix;
+
+  //! The number of initial samples to do without adapting the proposal
+  //! covariance matrix
+  /*!
+   * If positive and the current sampler iteration is <=
+   * m_amInitialNonAdaptInterval, then no delayed rejection is done if
+   * m_drDuringAmNonAdaptiveInt is false and m_tkUseLocalHessian is false
+   * and m_amAdaptInterval is > 0.
+   *
+   * The default is 0.
+   */
   unsigned int                       m_amInitialNonAdaptInterval;
+
+  //! The frequency at which to adapt the proposal covariance matrix.
+  /*!
+   * If zero, no adaptive metropolis is done.  If positive, the proposal
+   * covariance matrix will be adapted every m_amAdaptInterval samples
+   * after m_amInitialNonAdaptInterval have been done.
+   *
+   * The default is 0
+   */
   unsigned int                       m_amAdaptInterval;
+
+  //! The frequency (after m_amInitialNonAdaptInterval samples are done) of
+  //! printing the last adapted proposal covariance matrix.
+  /*!
+   * Provided m_amAdaptedMatricesDataOutputFileName is not ".", the last
+   * adapted proposal covariance matrix will be written regardless of the value
+   * of this option if the current sampler iteration is exactly
+   * m_amInitialNonAdaptInterval.
+   *
+   * Beyond m_amInitialNonAdaptInterval, the last adapted proposal covariance
+   * matrix will be printed to the output file every
+   * m_amAdaptedMatricesDataOutputPeriod samples.
+   *
+   * The default is 0
+   */
   unsigned int                       m_amAdaptedMatricesDataOutputPeriod;
+
+  //! If not ".", this is the file to write adapted proposal covariance
+  //! matrices to.  Default is "."
   std::string                        m_amAdaptedMatricesDataOutputFileName;
+
+  //! The filetype of m_amAdaptedMatricesDataOutputFileName.  Only "m" (matlab)
+  //is currently supported.  Default is "m"
   std::string                        m_amAdaptedMatricesDataOutputFileType;
+
+  //! This option is a no-op.  The default is false.
   bool                               m_amAdaptedMatricesDataOutputAllowAll;
+
+  //! This option is a no-op.  The default is the empty set.
   std::set<unsigned int>             m_amAdaptedMatricesDataOutputAllowedSet;
 
   /*! \brief Proposal covariance scaling factor, usually 2.4 * 2.4 / d
@@ -238,6 +530,8 @@ public:
    * The parameter defines how much the proposal covariance matrix is to be
    * scaled by, and should usually be set to 2.4 * 2.4 / d, where d is the
    * dimension of the state space being sampled.
+   *
+   * The default is 1.0.
    */
   double                             m_amEta;
 
@@ -248,19 +542,48 @@ public:
    *
    * The parameter defines how much the diagonal of the proposal covariance
    * matrix is perturbed.  Usually this is small, of order 1e-5.
+   *
+   * The default is 1.e-5
    */
   double                             m_amEpsilon;
 
+  //! The frequency with which to compute the Brooks-Gelman convergence
+  //! statistic.
+  /*!
+   * If zero, it is not computed.
+   *
+   * If positive, the Brooks-Gelman convergence statistic is computed every
+   * m_enableBrooksGelmanConvMonitor samples as long as the current sampler
+   * iteration is larger than m_BrooksGelmanLag + 1.  The "+ 1" is to ensure
+   * there are at least two samples with which to compute the convergence
+   * statistic.
+   *
+   * Needs at least 2 chains (sub environments) to be computed.
+   *
+   * The default is 0
+   */
   unsigned int                       m_enableBrooksGelmanConvMonitor;
+
+  //! The lag with which to compute the Brooks-Gelman convergence statistic
+  /*!
+   * The convergence statistic will be computed from sampler iteration
+   * m_BrooksGelmanLag to sampler iteration
+   * (current_sampler_iteration - m_BrooksGelmanLag).
+   *
+   * The default is 100.
+   */
   unsigned int                       m_BrooksGelmanLag;
 
-  //! Flag for deciding whether or not to dump log likelihood values in output
+  //! Flag for deciding whether or not to dump log likelihood values in output.
+  //! Default is true.
   bool m_outputLogLikelihood;
 
   //! Flag for deciding whether or not to dump log target values in output
+  //! Default is true.
   bool m_outputLogTarget;
 
   //! Flag for deciding whether or not to do logit transform of bounded domains
+  //! Default is true.
   bool m_doLogitTransform;
 
 private:

--- a/src/stats/inc/MetropolisHastingsSGOptions.h
+++ b/src/stats/inc/MetropolisHastingsSGOptions.h
@@ -194,6 +194,9 @@ public:
   bool                               m_totallyMute;
 
   //! If not ".", reads the contents of the file and uses that to start the MCMC.  Default is "."
+  /*!
+   * If ".", the input file is not read.
+   */
   std::string                        m_initialPositionDataInputFileName;
 
   //! The filetype of m_initialPositionDataInputFileName.  Only "m" (matlab) is currently supported.  Default is "m"
@@ -202,6 +205,8 @@ public:
   //! If not ".", reads the contents of the file as the initial proposal covariance matrix.
   /*!
    * To use this, m_tkUseLocalHessian must be false
+   *
+   * If this option is ".", no input file is read.
    *
    * Default is "."
    */
@@ -272,7 +277,10 @@ public:
 
   //! If not ".", filename to write the Markov chain to
   /*!
-   * m_totallyMute must be false
+   * If ".", the chain is not written to a file.
+   *
+   * If m_totallyMute is true, the chain is not written regardless of the value
+   * of this option.
    *
    * Default is "."
    */
@@ -326,6 +334,12 @@ public:
   unsigned int                       m_filteredChainLag;              // input or set during run time
 
   //! If not ".", file name to save the filtered chain to.  Default is ".".
+  /*!
+   * If ".", the filtered chain is not written to a file.
+   *
+   * If m_totallyMute is true, then the chain is not written to a file
+   * regardless of the value of this option.
+   */
   std::string                        m_filteredChainDataOutputFileName;
 
   //! The filetype of m_filteredChainDataOutputFileName.  Only "m" (matlab) is currently supported.  Default is "m"
@@ -488,6 +502,9 @@ public:
   unsigned int                       m_amAdaptedMatricesDataOutputPeriod;
 
   //! If not ".", this is the file to write adapted proposal covariance matrices to.  Default is "."
+  /*!
+   * If ".", the adapted proposal covariance matrices are not written to a file
+   */
   std::string                        m_amAdaptedMatricesDataOutputFileName;
 
   //! The filetype of m_amAdaptedMatricesDataOutputFileName.  Only "m" (matlab) is currently supported.  Default is "m"


### PR DESCRIPTION
This pull request has been a long time coming.  It documents all the input file options for DRAM; each option's default value; and any possible interaction with other input options where the interaction is not immediately obvious.

Doing this was painful as it required looking how each option played a role in the ~800 line `for` loop that is our DRAM algorithm, but this should help our users greatly.  Any feedback is graciously welcome.

This work branches from the refactor in #376.  PR #376 must be merged before this one.