### PR TITLE
Refactor adaptive Metropolis logic

### DIFF
--- a/src/stats/inc/MetropolisHastingsSG.h
+++ b/src/stats/inc/MetropolisHastingsSG.h
@@ -235,6 +235,7 @@ private:
                                    ScalarSequence<double>*      workingLogLikelihoodValues,
                                    ScalarSequence<double>*      workingLogTargetValues);
 
+  //! Adaptive Metropolis method that deals with adapting the proposal covariance matrix
   void adapt(unsigned int positionId,
       BaseVectorSequence<P_V, P_M> & workingChain);
 

--- a/src/stats/inc/MetropolisHastingsSG.h
+++ b/src/stats/inc/MetropolisHastingsSG.h
@@ -235,6 +235,9 @@ private:
                                    ScalarSequence<double>*      workingLogLikelihoodValues,
                                    ScalarSequence<double>*      workingLogTargetValues);
 
+  void adapt(unsigned int positionId,
+      BaseVectorSequence<P_V, P_M> & workingChain);
+
   //! This method reads the chain contents.
   void   readFullChain            (const std::string&                  inputFileName,
                                    const std::string&                  inputFileType,

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -2072,6 +2072,10 @@ MetropolisHastingsSG<P_V,P_M>::generateFullChain(
       }
     }
 
+    //****************************************************
+    // Point 5/6 of logic for new position
+    // Adaptive Metropolis calculation
+    //****************************************************
     this->adapt(positionId, workingChain);
 
     //****************************************************
@@ -2206,7 +2210,6 @@ MetropolisHastingsSG<P_V, P_M>::adapt(unsigned int positionId,
     iRC = gettimeofday(&timevalAM, NULL);
   }
 
-  // Now might be the moment to adapt
   unsigned int idOfFirstPositionInSubChain = 0;
   SequenceOfVectors<P_V,P_M> partialChain(m_vectorSpace,0,m_optionsObj->m_prefix+"partialChain");
 

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -2056,18 +2056,20 @@ MetropolisHastingsSG<P_V,P_M>::generateFullChain(
       m_logTargets[positionId] = currentPositionData.logTarget();
     }
 
-    if( m_optionsObj->m_enableBrooksGelmanConvMonitor > 0 ) {
-      if( positionId%m_optionsObj->m_enableBrooksGelmanConvMonitor == 0 &&
-    positionId > m_optionsObj->m_BrooksGelmanLag+1 ) { //+1 to help ensure there are at least 2 samples to use
+    if (m_optionsObj->m_enableBrooksGelmanConvMonitor > 0) {
+      if (positionId % m_optionsObj->m_enableBrooksGelmanConvMonitor == 0 &&
+          positionId > m_optionsObj->m_BrooksGelmanLag + 1) {  // +1 to help ensure there are at least 2 samples to use
 
-  double conv_est = workingChain.estimateConvBrooksGelman( m_optionsObj->m_BrooksGelmanLag,
-                 positionId - m_optionsObj->m_BrooksGelmanLag );
+        double conv_est = workingChain.estimateConvBrooksGelman(
+            m_optionsObj->m_BrooksGelmanLag,
+            positionId - m_optionsObj->m_BrooksGelmanLag);
 
-  if ( m_env.subDisplayFile() ) {
-      *m_env.subDisplayFile() << "positionId = " << positionId
-            << ", conv_est = " << conv_est << std::endl;
-      (*m_env.subDisplayFile()).flush();
-  }
+        if (m_env.subDisplayFile()) {
+          *m_env.subDisplayFile() << "positionId = " << positionId
+                                  << ", conv_est = " << conv_est
+                                  << std::endl;
+          (*m_env.subDisplayFile()).flush();
+        }
       }
     }
 

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -2194,118 +2194,176 @@ MetropolisHastingsSG<P_V, P_M>::adapt(unsigned int positionId,
   int iRC = UQ_OK_RC;
   struct timeval timevalAM;
 
-  //****************************************************
-  // Point 5/6 of logic for new position
-  // Loop: adaptive Metropolis (adaptation of covariance matrix)
-  //****************************************************
-  // sep2011
-  if ((m_optionsObj->m_tkUseLocalHessian ==    false) && // IMPORTANT
-      (m_optionsObj->m_amInitialNonAdaptInterval > 0) &&
-      (m_optionsObj->m_amAdaptInterval           > 0)) {
-    if (m_optionsObj->m_rawChainMeasureRunTimes) iRC = gettimeofday(&timevalAM, NULL);
+  // Bail early if we don't satisfy conditions needed to do adaptation
+  if ((m_optionsObj->m_tkUseLocalHessian         == true) || // IMPORTANT
+      (m_optionsObj->m_amInitialNonAdaptInterval == 0) ||
+      (m_optionsObj->m_amAdaptInterval           == 0)) {
+    return;
+  }
 
-    // Now might be the moment to adapt
-    unsigned int idOfFirstPositionInSubChain = 0;
-    SequenceOfVectors<P_V,P_M> partialChain(m_vectorSpace,0,m_optionsObj->m_prefix+"partialChain");
+  // Get timing info if we're measuring run times
+  if (m_optionsObj->m_rawChainMeasureRunTimes) {
+    iRC = gettimeofday(&timevalAM, NULL);
+  }
 
-    // Check if now is indeed the moment to adapt
-    bool printAdaptedMatrix = false;
-    if (positionId < m_optionsObj->m_amInitialNonAdaptInterval) {
-      // Do nothing
+  // Now might be the moment to adapt
+  unsigned int idOfFirstPositionInSubChain = 0;
+  SequenceOfVectors<P_V,P_M> partialChain(m_vectorSpace,0,m_optionsObj->m_prefix+"partialChain");
+
+  // Check if now is indeed the moment to adapt
+  bool printAdaptedMatrix = false;
+  if (positionId < m_optionsObj->m_amInitialNonAdaptInterval) {
+    // Do nothing
+  }
+  else if (positionId == m_optionsObj->m_amInitialNonAdaptInterval) {
+    idOfFirstPositionInSubChain = 0;
+    partialChain.resizeSequence(m_optionsObj->m_amInitialNonAdaptInterval+1);
+    m_lastMean             = m_vectorSpace.newVector();
+    m_lastAdaptedCovMatrix = m_vectorSpace.newMatrix();
+    printAdaptedMatrix = true;
+  }
+  else {
+    unsigned int interval = positionId - m_optionsObj->m_amInitialNonAdaptInterval;
+    if ((interval % m_optionsObj->m_amAdaptInterval) == 0) {
+      idOfFirstPositionInSubChain = positionId - m_optionsObj->m_amAdaptInterval;
+      partialChain.resizeSequence(m_optionsObj->m_amAdaptInterval);
+
+      if (m_optionsObj->m_amAdaptedMatricesDataOutputPeriod > 0) {
+        if ((interval % m_optionsObj->m_amAdaptedMatricesDataOutputPeriod) == 0) {
+          printAdaptedMatrix = true;
+        }
+      }
     }
-    else if (positionId == m_optionsObj->m_amInitialNonAdaptInterval) {
-      idOfFirstPositionInSubChain = 0;
-      partialChain.resizeSequence(m_optionsObj->m_amInitialNonAdaptInterval+1);
-      m_lastMean             = m_vectorSpace.newVector();
-      m_lastAdaptedCovMatrix = m_vectorSpace.newMatrix();
-      printAdaptedMatrix = true;
-    }
-    else {
-      unsigned int interval = positionId - m_optionsObj->m_amInitialNonAdaptInterval;
-      if ((interval % m_optionsObj->m_amAdaptInterval) == 0) {
-        idOfFirstPositionInSubChain = positionId - m_optionsObj->m_amAdaptInterval;
-        partialChain.resizeSequence(m_optionsObj->m_amAdaptInterval);
+  }
 
-        if (m_optionsObj->m_amAdaptedMatricesDataOutputPeriod > 0) {
-          if ((interval % m_optionsObj->m_amAdaptedMatricesDataOutputPeriod) == 0) {
-            printAdaptedMatrix = true;
+  // If now is indeed the moment to adapt, then do it!
+  if (partialChain.subSequenceSize() > 0) {
+    P_V transporterVec(m_vectorSpace.zeroVector());
+    for (unsigned int i = 0; i < partialChain.subSequenceSize(); ++i) {
+      workingChain.getPositionValues(idOfFirstPositionInSubChain+i,transporterVec);
+
+      // Transform to the space without boundaries.  This is the space
+      // where the proposal distribution is Gaussian
+      if (this->m_optionsObj->m_doLogitTransform == true) {
+        // Only do this when we don't use the Hessian (this may change in
+        // future, but transformToGaussianSpace() is only implemented in
+        // TransformedScaledCovMatrixTKGroup
+        P_V transformedTransporterVec(m_vectorSpace.zeroVector());
+        dynamic_cast<TransformedScaledCovMatrixTKGroup<P_V, P_M>* >(
+            m_tk)->transformToGaussianSpace(transporterVec,
+              transformedTransporterVec);
+        partialChain.setPositionValues(i, transformedTransporterVec);
+      }
+      else {
+        partialChain.setPositionValues(i, transporterVec);
+      }
+    }
+
+    updateAdaptedCovMatrix(partialChain,
+                           idOfFirstPositionInSubChain,
+                           m_lastChainSize,
+                           *m_lastMean,
+                           *m_lastAdaptedCovMatrix);
+
+    // Print adapted matrix info
+    if ((printAdaptedMatrix == true) &&
+        (m_optionsObj->m_amAdaptedMatricesDataOutputFileName != "." )) {
+      char varNamePrefix[64];
+      sprintf(varNamePrefix,"mat_am%d",positionId);
+
+      char tmpChar[64];
+      sprintf(tmpChar,"_am%d",positionId);
+
+      std::set<unsigned int> tmpSet;
+      tmpSet.insert(m_env.subId());
+
+      m_lastAdaptedCovMatrix->subWriteContents(varNamePrefix,
+                                               (m_optionsObj->m_amAdaptedMatricesDataOutputFileName+tmpChar),
+                                               m_optionsObj->m_amAdaptedMatricesDataOutputFileType,
+                                               tmpSet);
+      if ((m_env.subDisplayFile()                   ) &&
+          (m_optionsObj->m_totallyMute == false)) {
+        *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain()"
+                                << ": just wrote last adapted proposal cov matrix contents = " << *m_lastAdaptedCovMatrix
+                                << std::endl;
+      }
+    } // if (printAdaptedMatrix && ...)
+
+    bool tmpCholIsPositiveDefinite = false;
+    P_M tmpChol(*m_lastAdaptedCovMatrix);
+    P_M attemptedMatrix(tmpChol);
+    if ((m_env.subDisplayFile()        ) &&
+        (m_env.displayVerbosity() >= 10)) {
+//(m_optionsObj->m_totallyMute == false)) {
+      *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain()"
+                              << ", positionId = "  << positionId
+                              << ": 'am' calling first tmpChol.chol()"
+                              << std::endl;
+    }
+    iRC = tmpChol.chol();
+    if (iRC) {
+      std::cerr << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain(): first chol failed\n";
+    }
+    if ((m_env.subDisplayFile()        ) &&
+        (m_env.displayVerbosity() >= 10)) {
+//(m_optionsObj->m_totallyMute == false)) {
+      *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain()"
+                              << ", positionId = "  << positionId
+                              << ": 'am' got first tmpChol.chol() with iRC = " << iRC
+                              << std::endl;
+      if (iRC == 0) {
+        double diagMult = 1.;
+        for (unsigned int j = 0; j < tmpChol.numRowsLocal(); ++j) {
+          diagMult *= tmpChol(j,j);
+        }
+        *m_env.subDisplayFile() << "diagMult = " << diagMult
+                                << std::endl;
+      }
+    }
+#if 0 // tentative logic
+    if (iRC == 0) {
+      double diagMult = 1.;
+      for (unsigned int j = 0; j < tmpChol.numRowsLocal(); ++j) {
+        diagMult *= tmpChol(j,j);
+      }
+      if (diagMult < 1.e-40) {
+        iRC = UQ_MATRIX_IS_NOT_POS_DEFINITE_RC;
+      }
+    }
+#endif
+
+    if (iRC) {
+      queso_require_equal_to_msg(iRC, UQ_MATRIX_IS_NOT_POS_DEFINITE_RC, "invalid iRC returned from first chol()");
+      // Matrix is not positive definite
+      P_M* tmpDiag = m_vectorSpace.newDiagMatrix(m_optionsObj->m_amEpsilon);
+      if (m_numDisabledParameters > 0) { // gpmsa2
+        for (unsigned int paramId = 0; paramId < m_vectorSpace.dimLocal(); ++paramId) {
+          if (m_parameterEnabledStatus[paramId] == false) {
+            (*tmpDiag)(paramId,paramId) = 0.;
           }
         }
       }
-    }
-
-    // If now is indeed the moment to adapt, then do it!
-    if (partialChain.subSequenceSize() > 0) {
-      P_V transporterVec(m_vectorSpace.zeroVector());
-      for (unsigned int i = 0; i < partialChain.subSequenceSize(); ++i) {
-        workingChain.getPositionValues(idOfFirstPositionInSubChain+i,transporterVec);
-
-        // Transform to the space without boundaries.  This is the space
-        // where the proposal distribution is Gaussian
-        if (this->m_optionsObj->m_doLogitTransform == true) {
-          // Only do this when we don't use the Hessian (this may change in
-          // future, but transformToGaussianSpace() is only implemented in
-          // TransformedScaledCovMatrixTKGroup
-          P_V transformedTransporterVec(m_vectorSpace.zeroVector());
-          dynamic_cast<TransformedScaledCovMatrixTKGroup<P_V, P_M>* >(
-              m_tk)->transformToGaussianSpace(transporterVec,
-                transformedTransporterVec);
-          partialChain.setPositionValues(i, transformedTransporterVec);
-        }
-        else {
-          partialChain.setPositionValues(i, transporterVec);
-        }
-      }
-      updateAdaptedCovMatrix(partialChain,
-                             idOfFirstPositionInSubChain,
-                             m_lastChainSize,
-                             *m_lastMean,
-                             *m_lastAdaptedCovMatrix);
-
-      if ((printAdaptedMatrix                                       == true) &&
-          (m_optionsObj->m_amAdaptedMatricesDataOutputFileName != "." )) { // palms
-        char varNamePrefix[64];
-        sprintf(varNamePrefix,"mat_am%d",positionId);
-
-        char tmpChar[64];
-        sprintf(tmpChar,"_am%d",positionId);
-
-        std::set<unsigned int> tmpSet;
-        tmpSet.insert(m_env.subId());
-
-        m_lastAdaptedCovMatrix->subWriteContents(varNamePrefix,
-                                                 (m_optionsObj->m_amAdaptedMatricesDataOutputFileName+tmpChar),
-                                                 m_optionsObj->m_amAdaptedMatricesDataOutputFileType,
-                                                 tmpSet);
-        if ((m_env.subDisplayFile()                   ) &&
-            (m_optionsObj->m_totallyMute == false)) {
-          *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain()"
-                                  << ": just wrote last adapted proposal cov matrix contents = " << *m_lastAdaptedCovMatrix
-                                  << std::endl;
-        }
-      } // if (printAdaptedMatrix && ...)
-
-      bool tmpCholIsPositiveDefinite = false;
-      P_M tmpChol(*m_lastAdaptedCovMatrix);
-      P_M attemptedMatrix(tmpChol);
+      tmpChol = *m_lastAdaptedCovMatrix + *tmpDiag;
+      attemptedMatrix = tmpChol;
+      delete tmpDiag;
       if ((m_env.subDisplayFile()        ) &&
           (m_env.displayVerbosity() >= 10)) {
   //(m_optionsObj->m_totallyMute == false)) {
         *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain()"
                                 << ", positionId = "  << positionId
-                                << ": 'am' calling first tmpChol.chol()"
+                                << ": 'am' calling second tmpChol.chol()"
                                 << std::endl;
       }
       iRC = tmpChol.chol();
       if (iRC) {
-        std::cerr << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain(): first chol failed\n";
+        std::cerr << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain(): second chol failed\n";
       }
       if ((m_env.subDisplayFile()        ) &&
           (m_env.displayVerbosity() >= 10)) {
   //(m_optionsObj->m_totallyMute == false)) {
         *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain()"
-                                << ", positionId = "  << positionId
-                                << ": 'am' got first tmpChol.chol() with iRC = " << iRC
+                                << ", positionId = " << positionId
+                                << ": 'am' got second tmpChol.chol() with iRC = " << iRC
                                 << std::endl;
         if (iRC == 0) {
           double diagMult = 1.;
@@ -2315,114 +2373,61 @@ MetropolisHastingsSG<P_V, P_M>::adapt(unsigned int positionId,
           *m_env.subDisplayFile() << "diagMult = " << diagMult
                                   << std::endl;
         }
-      }
-#if 0 // tentative logic
-      if (iRC == 0) {
-        double diagMult = 1.;
-        for (unsigned int j = 0; j < tmpChol.numRowsLocal(); ++j) {
-          diagMult *= tmpChol(j,j);
-        }
-        if (diagMult < 1.e-40) {
-          iRC = UQ_MATRIX_IS_NOT_POS_DEFINITE_RC;
-        }
-      }
-#endif
-
-      if (iRC) {
-        queso_require_equal_to_msg(iRC, UQ_MATRIX_IS_NOT_POS_DEFINITE_RC, "invalid iRC returned from first chol()");
-        // Matrix is not positive definite
-        P_M* tmpDiag = m_vectorSpace.newDiagMatrix(m_optionsObj->m_amEpsilon);
-        if (m_numDisabledParameters > 0) { // gpmsa2
-          for (unsigned int paramId = 0; paramId < m_vectorSpace.dimLocal(); ++paramId) {
-            if (m_parameterEnabledStatus[paramId] == false) {
-              (*tmpDiag)(paramId,paramId) = 0.;
-            }
-          }
-        }
-        tmpChol = *m_lastAdaptedCovMatrix + *tmpDiag;
-        attemptedMatrix = tmpChol;
-        delete tmpDiag;
-        if ((m_env.subDisplayFile()        ) &&
-            (m_env.displayVerbosity() >= 10)) {
-    //(m_optionsObj->m_totallyMute == false)) {
-          *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain()"
-                                  << ", positionId = "  << positionId
-                                  << ": 'am' calling second tmpChol.chol()"
-                                  << std::endl;
-        }
-        iRC = tmpChol.chol();
-        if (iRC) {
-          std::cerr << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain(): second chol failed\n";
-        }
-        if ((m_env.subDisplayFile()        ) &&
-            (m_env.displayVerbosity() >= 10)) {
-    //(m_optionsObj->m_totallyMute == false)) {
-          *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain()"
-                                  << ", positionId = " << positionId
-                                  << ": 'am' got second tmpChol.chol() with iRC = " << iRC
-                                  << std::endl;
-          if (iRC == 0) {
-            double diagMult = 1.;
-            for (unsigned int j = 0; j < tmpChol.numRowsLocal(); ++j) {
-              diagMult *= tmpChol(j,j);
-            }
-            *m_env.subDisplayFile() << "diagMult = " << diagMult
-                                    << std::endl;
-          }
-          else {
-            *m_env.subDisplayFile() << "attemptedMatrix = " << attemptedMatrix // FIX ME: might demand parallelism
-                                    << std::endl;
-          }
-        }
-        if (iRC) {
-          queso_require_equal_to_msg(iRC, UQ_MATRIX_IS_NOT_POS_DEFINITE_RC, "invalid iRC returned from second chol()");
-          // Do nothing
-        }
         else {
-          tmpCholIsPositiveDefinite = true;
+          *m_env.subDisplayFile() << "attemptedMatrix = " << attemptedMatrix // FIX ME: might demand parallelism
+                                  << std::endl;
         }
+      }
+      if (iRC) {
+        queso_require_equal_to_msg(iRC, UQ_MATRIX_IS_NOT_POS_DEFINITE_RC, "invalid iRC returned from second chol()");
+        // Do nothing
       }
       else {
         tmpCholIsPositiveDefinite = true;
       }
-      if (tmpCholIsPositiveDefinite) {
-        P_M tmpMatrix(m_optionsObj->m_amEta*attemptedMatrix);
-        if (m_numDisabledParameters > 0) { // gpmsa2
-          for (unsigned int paramId = 0; paramId < m_vectorSpace.dimLocal(); ++paramId) {
-            if (m_parameterEnabledStatus[paramId] == false) {
-              for (unsigned int i = 0; i < m_vectorSpace.dimLocal(); ++i) {
-                tmpMatrix(i,paramId) = 0.;
-              }
-              for (unsigned int j = 0; j < m_vectorSpace.dimLocal(); ++j) {
-                tmpMatrix(paramId,j) = 0.;
-              }
-              tmpMatrix(paramId,paramId) = 1.;
+    }
+    else {
+      tmpCholIsPositiveDefinite = true;
+    }
+    if (tmpCholIsPositiveDefinite) {
+      P_M tmpMatrix(m_optionsObj->m_amEta*attemptedMatrix);
+      if (m_numDisabledParameters > 0) { // gpmsa2
+        for (unsigned int paramId = 0; paramId < m_vectorSpace.dimLocal(); ++paramId) {
+          if (m_parameterEnabledStatus[paramId] == false) {
+            for (unsigned int i = 0; i < m_vectorSpace.dimLocal(); ++i) {
+              tmpMatrix(i,paramId) = 0.;
             }
+            for (unsigned int j = 0; j < m_vectorSpace.dimLocal(); ++j) {
+              tmpMatrix(paramId,j) = 0.;
+            }
+            tmpMatrix(paramId,paramId) = 1.;
           }
         }
-        if (this->m_optionsObj->m_doLogitTransform) {
-          (dynamic_cast<TransformedScaledCovMatrixTKGroup<P_V,P_M>* >(m_tk))
-            ->updateLawCovMatrix(tmpMatrix);
-        }
-        else{
-          (dynamic_cast<ScaledCovMatrixTKGroup<P_V,P_M>* >(m_tk))
-            ->updateLawCovMatrix(tmpMatrix);
-        }
-
-#ifdef UQ_DRAM_MCG_REQUIRES_INVERTED_COV_MATRICES
-        queso_require_msg(!(UQ_INCOMPLETE_IMPLEMENTATION_RC), "need to code the update of m_upperCholProposalPrecMatrices");
-#endif
+      }
+      if (this->m_optionsObj->m_doLogitTransform) {
+        (dynamic_cast<TransformedScaledCovMatrixTKGroup<P_V,P_M>* >(m_tk))
+          ->updateLawCovMatrix(tmpMatrix);
+      }
+      else{
+        (dynamic_cast<ScaledCovMatrixTKGroup<P_V,P_M>* >(m_tk))
+          ->updateLawCovMatrix(tmpMatrix);
       }
 
-      //for (unsigned int i = 0; i < partialChain.subSequenceSize(); ++i) {
-      //  if (partialChain[i]) delete partialChain[i];
-      //}
-    } // if (partialChain.subSequenceSize() > 0)
+#ifdef UQ_DRAM_MCG_REQUIRES_INVERTED_COV_MATRICES
+      queso_require_msg(!(UQ_INCOMPLETE_IMPLEMENTATION_RC), "need to code the update of m_upperCholProposalPrecMatrices");
+#endif
+    }
 
-    if (m_optionsObj->m_rawChainMeasureRunTimes) m_rawChainInfo.amRunTime += MiscGetEllapsedSeconds(&timevalAM);
-  } // End of 'adaptive Metropolis' logic
+    //for (unsigned int i = 0; i < partialChain.subSequenceSize(); ++i) {
+    //  if (partialChain[i]) delete partialChain[i];
+    //}
+  } // if (partialChain.subSequenceSize() > 0)
+
+      //
+  if (m_optionsObj->m_rawChainMeasureRunTimes) {
+    m_rawChainInfo.amRunTime += MiscGetEllapsedSeconds(&timevalAM);
+  }
 }
-
 
 //--------------------------------------------------
 template <class P_V,class P_M>

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -2312,7 +2312,11 @@ MetropolisHastingsSG<P_V, P_M>::adapt(unsigned int positionId,
   }
   iRC = tmpChol.chol();
   if (iRC) {
-    std::cerr << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain(): first chol failed\n";
+    std::string err1 = "In MetropolisHastingsSG<P_V,P_M>::adapt(): first ";
+    err1 += "Cholesky factorisation of proposal covariance matrix ";
+    err1 += "failed.  QUESO will now attempt to regularise the ";
+    err1 += "matrix before proceeding.  This is not a fatal error.";
+    std::cerr << err1 << std::endl;
   }
 
   // Print some infor about the Cholesky factorisation
@@ -2373,7 +2377,12 @@ MetropolisHastingsSG<P_V, P_M>::adapt(unsigned int positionId,
     // Trying the second (regularised Cholesky factorisation)
     iRC = tmpChol.chol();
     if (iRC) {
-      std::cerr << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain(): second chol failed\n";
+      std::string err2 = "In MetropolisHastingsSG<P_V,P_M>::adapt(): second ";
+      err2 += "Cholesky factorisation of (regularised) proposal ";
+      err2 += "covariance matrix failed.  QUESO is falling back to ";
+      err2 += "the last factorisable proposal covariance matrix.  ";
+      err2 += "This is not a fatal error.";
+      std::cerr << err2 << std::endl;
     }
 
     // Print some diagnostic info

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -2236,80 +2236,143 @@ MetropolisHastingsSG<P_V, P_M>::adapt(unsigned int positionId,
     }
   }
 
-  // If now is indeed the moment to adapt, then do it!
-  if (partialChain.subSequenceSize() > 0) {
-    P_V transporterVec(m_vectorSpace.zeroVector());
-    for (unsigned int i = 0; i < partialChain.subSequenceSize(); ++i) {
-      workingChain.getPositionValues(idOfFirstPositionInSubChain+i,transporterVec);
-
-      // Transform to the space without boundaries.  This is the space
-      // where the proposal distribution is Gaussian
-      if (this->m_optionsObj->m_doLogitTransform == true) {
-        // Only do this when we don't use the Hessian (this may change in
-        // future, but transformToGaussianSpace() is only implemented in
-        // TransformedScaledCovMatrixTKGroup
-        P_V transformedTransporterVec(m_vectorSpace.zeroVector());
-        dynamic_cast<TransformedScaledCovMatrixTKGroup<P_V, P_M>* >(
-            m_tk)->transformToGaussianSpace(transporterVec,
-              transformedTransporterVec);
-        partialChain.setPositionValues(i, transformedTransporterVec);
-      }
-      else {
-        partialChain.setPositionValues(i, transporterVec);
-      }
+  // Bail out if we don't have the samples to adapt
+  if (partialChain.subSequenceSize() == 0) {
+    // Save timings and bail
+    if (m_optionsObj->m_rawChainMeasureRunTimes) {
+      m_rawChainInfo.amRunTime += MiscGetEllapsedSeconds(&timevalAM);
     }
 
-    updateAdaptedCovMatrix(partialChain,
-                           idOfFirstPositionInSubChain,
-                           m_lastChainSize,
-                           *m_lastMean,
-                           *m_lastAdaptedCovMatrix);
+    return;
+  }
 
-    // Print adapted matrix info
-    if ((printAdaptedMatrix == true) &&
-        (m_optionsObj->m_amAdaptedMatricesDataOutputFileName != "." )) {
-      char varNamePrefix[64];
-      sprintf(varNamePrefix,"mat_am%d",positionId);
+  // If now is indeed the moment to adapt, then do it!
+  P_V transporterVec(m_vectorSpace.zeroVector());
+  for (unsigned int i = 0; i < partialChain.subSequenceSize(); ++i) {
+    workingChain.getPositionValues(idOfFirstPositionInSubChain+i,transporterVec);
 
-      char tmpChar[64];
-      sprintf(tmpChar,"_am%d",positionId);
+    // Transform to the space without boundaries.  This is the space
+    // where the proposal distribution is Gaussian
+    if (this->m_optionsObj->m_doLogitTransform == true) {
+      // Only do this when we don't use the Hessian (this may change in
+      // future, but transformToGaussianSpace() is only implemented in
+      // TransformedScaledCovMatrixTKGroup
+      P_V transformedTransporterVec(m_vectorSpace.zeroVector());
+      dynamic_cast<TransformedScaledCovMatrixTKGroup<P_V, P_M>* >(
+          m_tk)->transformToGaussianSpace(transporterVec,
+            transformedTransporterVec);
+      partialChain.setPositionValues(i, transformedTransporterVec);
+    }
+    else {
+      partialChain.setPositionValues(i, transporterVec);
+    }
+  }
 
-      std::set<unsigned int> tmpSet;
-      tmpSet.insert(m_env.subId());
+  updateAdaptedCovMatrix(partialChain,
+                         idOfFirstPositionInSubChain,
+                         m_lastChainSize,
+                         *m_lastMean,
+                         *m_lastAdaptedCovMatrix);
 
-      m_lastAdaptedCovMatrix->subWriteContents(varNamePrefix,
-                                               (m_optionsObj->m_amAdaptedMatricesDataOutputFileName+tmpChar),
-                                               m_optionsObj->m_amAdaptedMatricesDataOutputFileType,
-                                               tmpSet);
-      if ((m_env.subDisplayFile()                   ) &&
-          (m_optionsObj->m_totallyMute == false)) {
-        *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain()"
-                                << ": just wrote last adapted proposal cov matrix contents = " << *m_lastAdaptedCovMatrix
-                                << std::endl;
+  // Print adapted matrix info
+  if ((printAdaptedMatrix == true) &&
+      (m_optionsObj->m_amAdaptedMatricesDataOutputFileName != "." )) {
+    char varNamePrefix[64];
+    sprintf(varNamePrefix,"mat_am%d",positionId);
+
+    char tmpChar[64];
+    sprintf(tmpChar,"_am%d",positionId);
+
+    std::set<unsigned int> tmpSet;
+    tmpSet.insert(m_env.subId());
+
+    m_lastAdaptedCovMatrix->subWriteContents(varNamePrefix,
+                                             (m_optionsObj->m_amAdaptedMatricesDataOutputFileName+tmpChar),
+                                             m_optionsObj->m_amAdaptedMatricesDataOutputFileType,
+                                             tmpSet);
+    if ((m_env.subDisplayFile()                   ) &&
+        (m_optionsObj->m_totallyMute == false)) {
+      *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain()"
+                              << ": just wrote last adapted proposal cov matrix contents = " << *m_lastAdaptedCovMatrix
+                              << std::endl;
+    }
+  }
+
+  bool tmpCholIsPositiveDefinite = false;
+  P_M tmpChol(*m_lastAdaptedCovMatrix);
+  P_M attemptedMatrix(tmpChol);
+  if ((m_env.subDisplayFile()        ) &&
+      (m_env.displayVerbosity() >= 10)) {
+//(m_optionsObj->m_totallyMute == false)) {
+    *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain()"
+                            << ", positionId = "  << positionId
+                            << ": 'am' calling first tmpChol.chol()"
+                            << std::endl;
+  }
+  iRC = tmpChol.chol();
+  if (iRC) {
+    std::cerr << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain(): first chol failed\n";
+  }
+  if ((m_env.subDisplayFile()        ) &&
+      (m_env.displayVerbosity() >= 10)) {
+//(m_optionsObj->m_totallyMute == false)) {
+    *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain()"
+                            << ", positionId = "  << positionId
+                            << ": 'am' got first tmpChol.chol() with iRC = " << iRC
+                            << std::endl;
+    if (iRC == 0) {
+      double diagMult = 1.;
+      for (unsigned int j = 0; j < tmpChol.numRowsLocal(); ++j) {
+        diagMult *= tmpChol(j,j);
       }
-    } // if (printAdaptedMatrix && ...)
+      *m_env.subDisplayFile() << "diagMult = " << diagMult
+                              << std::endl;
+    }
+  }
+#if 0 // tentative logic
+  if (iRC == 0) {
+    double diagMult = 1.;
+    for (unsigned int j = 0; j < tmpChol.numRowsLocal(); ++j) {
+      diagMult *= tmpChol(j,j);
+    }
+    if (diagMult < 1.e-40) {
+      iRC = UQ_MATRIX_IS_NOT_POS_DEFINITE_RC;
+    }
+  }
+#endif
 
-    bool tmpCholIsPositiveDefinite = false;
-    P_M tmpChol(*m_lastAdaptedCovMatrix);
-    P_M attemptedMatrix(tmpChol);
+  if (iRC) {
+    queso_require_equal_to_msg(iRC, UQ_MATRIX_IS_NOT_POS_DEFINITE_RC, "invalid iRC returned from first chol()");
+    // Matrix is not positive definite
+    P_M* tmpDiag = m_vectorSpace.newDiagMatrix(m_optionsObj->m_amEpsilon);
+    if (m_numDisabledParameters > 0) { // gpmsa2
+      for (unsigned int paramId = 0; paramId < m_vectorSpace.dimLocal(); ++paramId) {
+        if (m_parameterEnabledStatus[paramId] == false) {
+          (*tmpDiag)(paramId,paramId) = 0.;
+        }
+      }
+    }
+    tmpChol = *m_lastAdaptedCovMatrix + *tmpDiag;
+    attemptedMatrix = tmpChol;
+    delete tmpDiag;
     if ((m_env.subDisplayFile()        ) &&
         (m_env.displayVerbosity() >= 10)) {
 //(m_optionsObj->m_totallyMute == false)) {
       *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain()"
                               << ", positionId = "  << positionId
-                              << ": 'am' calling first tmpChol.chol()"
+                              << ": 'am' calling second tmpChol.chol()"
                               << std::endl;
     }
     iRC = tmpChol.chol();
     if (iRC) {
-      std::cerr << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain(): first chol failed\n";
+      std::cerr << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain(): second chol failed\n";
     }
     if ((m_env.subDisplayFile()        ) &&
         (m_env.displayVerbosity() >= 10)) {
 //(m_optionsObj->m_totallyMute == false)) {
       *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain()"
-                              << ", positionId = "  << positionId
-                              << ": 'am' got first tmpChol.chol() with iRC = " << iRC
+                              << ", positionId = " << positionId
+                              << ": 'am' got second tmpChol.chol() with iRC = " << iRC
                               << std::endl;
       if (iRC == 0) {
         double diagMult = 1.;
@@ -2319,111 +2382,56 @@ MetropolisHastingsSG<P_V, P_M>::adapt(unsigned int positionId,
         *m_env.subDisplayFile() << "diagMult = " << diagMult
                                 << std::endl;
       }
-    }
-#if 0 // tentative logic
-    if (iRC == 0) {
-      double diagMult = 1.;
-      for (unsigned int j = 0; j < tmpChol.numRowsLocal(); ++j) {
-        diagMult *= tmpChol(j,j);
-      }
-      if (diagMult < 1.e-40) {
-        iRC = UQ_MATRIX_IS_NOT_POS_DEFINITE_RC;
-      }
-    }
-#endif
-
-    if (iRC) {
-      queso_require_equal_to_msg(iRC, UQ_MATRIX_IS_NOT_POS_DEFINITE_RC, "invalid iRC returned from first chol()");
-      // Matrix is not positive definite
-      P_M* tmpDiag = m_vectorSpace.newDiagMatrix(m_optionsObj->m_amEpsilon);
-      if (m_numDisabledParameters > 0) { // gpmsa2
-        for (unsigned int paramId = 0; paramId < m_vectorSpace.dimLocal(); ++paramId) {
-          if (m_parameterEnabledStatus[paramId] == false) {
-            (*tmpDiag)(paramId,paramId) = 0.;
-          }
-        }
-      }
-      tmpChol = *m_lastAdaptedCovMatrix + *tmpDiag;
-      attemptedMatrix = tmpChol;
-      delete tmpDiag;
-      if ((m_env.subDisplayFile()        ) &&
-          (m_env.displayVerbosity() >= 10)) {
-  //(m_optionsObj->m_totallyMute == false)) {
-        *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain()"
-                                << ", positionId = "  << positionId
-                                << ": 'am' calling second tmpChol.chol()"
-                                << std::endl;
-      }
-      iRC = tmpChol.chol();
-      if (iRC) {
-        std::cerr << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain(): second chol failed\n";
-      }
-      if ((m_env.subDisplayFile()        ) &&
-          (m_env.displayVerbosity() >= 10)) {
-  //(m_optionsObj->m_totallyMute == false)) {
-        *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::generateFullChain()"
-                                << ", positionId = " << positionId
-                                << ": 'am' got second tmpChol.chol() with iRC = " << iRC
-                                << std::endl;
-        if (iRC == 0) {
-          double diagMult = 1.;
-          for (unsigned int j = 0; j < tmpChol.numRowsLocal(); ++j) {
-            diagMult *= tmpChol(j,j);
-          }
-          *m_env.subDisplayFile() << "diagMult = " << diagMult
-                                  << std::endl;
-        }
-        else {
-          *m_env.subDisplayFile() << "attemptedMatrix = " << attemptedMatrix // FIX ME: might demand parallelism
-                                  << std::endl;
-        }
-      }
-      if (iRC) {
-        queso_require_equal_to_msg(iRC, UQ_MATRIX_IS_NOT_POS_DEFINITE_RC, "invalid iRC returned from second chol()");
-        // Do nothing
-      }
       else {
-        tmpCholIsPositiveDefinite = true;
+        *m_env.subDisplayFile() << "attemptedMatrix = " << attemptedMatrix // FIX ME: might demand parallelism
+                                << std::endl;
       }
+    }
+    if (iRC) {
+      queso_require_equal_to_msg(iRC, UQ_MATRIX_IS_NOT_POS_DEFINITE_RC, "invalid iRC returned from second chol()");
+      // Do nothing
     }
     else {
       tmpCholIsPositiveDefinite = true;
     }
-    if (tmpCholIsPositiveDefinite) {
-      P_M tmpMatrix(m_optionsObj->m_amEta*attemptedMatrix);
-      if (m_numDisabledParameters > 0) { // gpmsa2
-        for (unsigned int paramId = 0; paramId < m_vectorSpace.dimLocal(); ++paramId) {
-          if (m_parameterEnabledStatus[paramId] == false) {
-            for (unsigned int i = 0; i < m_vectorSpace.dimLocal(); ++i) {
-              tmpMatrix(i,paramId) = 0.;
-            }
-            for (unsigned int j = 0; j < m_vectorSpace.dimLocal(); ++j) {
-              tmpMatrix(paramId,j) = 0.;
-            }
-            tmpMatrix(paramId,paramId) = 1.;
+  }
+  else {
+    tmpCholIsPositiveDefinite = true;
+  }
+
+  if (tmpCholIsPositiveDefinite) {
+    P_M tmpMatrix(m_optionsObj->m_amEta*attemptedMatrix);
+    if (m_numDisabledParameters > 0) { // gpmsa2
+      for (unsigned int paramId = 0; paramId < m_vectorSpace.dimLocal(); ++paramId) {
+        if (m_parameterEnabledStatus[paramId] == false) {
+          for (unsigned int i = 0; i < m_vectorSpace.dimLocal(); ++i) {
+            tmpMatrix(i,paramId) = 0.;
           }
+          for (unsigned int j = 0; j < m_vectorSpace.dimLocal(); ++j) {
+            tmpMatrix(paramId,j) = 0.;
+          }
+          tmpMatrix(paramId,paramId) = 1.;
         }
       }
-      if (this->m_optionsObj->m_doLogitTransform) {
-        (dynamic_cast<TransformedScaledCovMatrixTKGroup<P_V,P_M>* >(m_tk))
-          ->updateLawCovMatrix(tmpMatrix);
-      }
-      else{
-        (dynamic_cast<ScaledCovMatrixTKGroup<P_V,P_M>* >(m_tk))
-          ->updateLawCovMatrix(tmpMatrix);
-      }
-
-#ifdef UQ_DRAM_MCG_REQUIRES_INVERTED_COV_MATRICES
-      queso_require_msg(!(UQ_INCOMPLETE_IMPLEMENTATION_RC), "need to code the update of m_upperCholProposalPrecMatrices");
-#endif
+    }
+    if (this->m_optionsObj->m_doLogitTransform) {
+      (dynamic_cast<TransformedScaledCovMatrixTKGroup<P_V,P_M>* >(m_tk))
+        ->updateLawCovMatrix(tmpMatrix);
+    }
+    else{
+      (dynamic_cast<ScaledCovMatrixTKGroup<P_V,P_M>* >(m_tk))
+        ->updateLawCovMatrix(tmpMatrix);
     }
 
-    //for (unsigned int i = 0; i < partialChain.subSequenceSize(); ++i) {
-    //  if (partialChain[i]) delete partialChain[i];
-    //}
-  } // if (partialChain.subSequenceSize() > 0)
+#ifdef UQ_DRAM_MCG_REQUIRES_INVERTED_COV_MATRICES
+    queso_require_msg(!(UQ_INCOMPLETE_IMPLEMENTATION_RC), "need to code the update of m_upperCholProposalPrecMatrices");
+#endif
+  }
 
-      //
+  //for (unsigned int i = 0; i < partialChain.subSequenceSize(); ++i) {
+  //  if (partialChain[i]) delete partialChain[i];
+  //}
+
   if (m_optionsObj->m_rawChainMeasureRunTimes) {
     m_rawChainInfo.amRunTime += MiscGetEllapsedSeconds(&timevalAM);
   }
@@ -2459,7 +2467,6 @@ MetropolisHastingsSG<P_V,P_M>::updateAdaptedCovMatrix(
   }
   else {
     queso_require_greater_equal_msg(partialChain.subSequenceSize(), 1, "'partialChain.subSequenceSize()' should be >= 1");
-
     queso_require_greater_equal_msg(idOfFirstPositionInSubChain, 1, "'idOfFirstPositionInSubChain' should be >= 1");
 
     P_V tmpVec (m_vectorSpace.zeroVector());


### PR DESCRIPTION
The main point of this pull request is to refactor the adaptive Metropolis code.

1. The adaptive Metropolis logic sat buried in an ~800 line `for` loop.  It is now in a separate function.
2.  The conditions required before executing the adaptation were tested and most of the adaptation code (300 lines) was nested in this `if` statement.  Where possible, I have negated this conditions so they become **exit** conditions, and de-dented the rest of the code.  This makes it a little easier to read.
3.  I have improved some of the printed warning messages that were raised in #203 to explain a little more what QUESO is doing.

All tests pass.  Feedback welcome.