### PR TITLE
Fix double `delete` seg fault for various options objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,5 @@ test/test_BoostInputOptionsParser
 test/test_InputOptionsParser/test_options_good.txt
 test/test_InputOptionsParser/test_options_bad.txt
 test/test_InputOptionsParser/test_options_default.txt
+test/test_NoInputFile
+test/test_outputNoInputFile

--- a/src/stats/inc/MetropolisHastingsSG.h
+++ b/src/stats/inc/MetropolisHastingsSG.h
@@ -306,6 +306,8 @@ private:
 
   void transformInitialCovMatrixToGaussianSpace(const BoxSubset<P_V, P_M> &
       boxSubset);
+
+  bool m_userDidNotProvideOptions;
 };
 
 }  // End namespace QUESO

--- a/src/stats/inc/MonteCarloSG.h
+++ b/src/stats/inc/MonteCarloSG.h
@@ -131,6 +131,8 @@ private:
   unsigned int                                              m_numQsNotSubWritten;
 
   const McOptionsValues *                            m_optionsObj;
+
+  bool m_userDidNotProvideOptions;
 };
 
 }  // End namespace QUESO

--- a/src/stats/inc/StatisticalForwardProblem.h
+++ b/src/stats/inc/StatisticalForwardProblem.h
@@ -183,6 +183,8 @@ private:
         ArrayOfOneDTables <Q_V,Q_M>*         m_unifiedCdfValues;
         BaseVectorCdf     <Q_V,Q_M>*         m_unifiedSolutionCdf;
 #endif
+
+  bool m_userDidNotProvideOptions;
 };
 
 }  // End namespace QUESO

--- a/src/stats/inc/StatisticalInverseProblem.h
+++ b/src/stats/inc/StatisticalInverseProblem.h
@@ -239,6 +239,8 @@ private:
         ArrayOfOneDGrids    <P_V,P_M>*   m_subMdfGrids;
         ArrayOfOneDTables   <P_V,P_M>*   m_subMdfValues;
 #endif
+
+  bool m_userDidNotProvideOptions;
 };
 
 }  // End namespace QUESO

--- a/src/stats/src/MonteCarloSG.C
+++ b/src/stats/src/MonteCarloSG.C
@@ -44,7 +44,8 @@ MonteCarloSG<P_V,P_M,Q_V,Q_M>::MonteCarloSG(
   m_qoiFunctionSynchronizer (new VectorFunctionSynchronizer<P_V,P_M,Q_V,Q_M>(m_qoiFunction,m_paramRv.imageSet().vectorSpace().zeroVector(),m_qoiFunction.imageSet().vectorSpace().zeroVector())),
   m_numPsNotSubWritten      (0),
   m_numQsNotSubWritten      (0),
-  m_optionsObj              (alternativeOptionsValues)
+  m_optionsObj              (alternativeOptionsValues),
+  m_userDidNotProvideOptions(false)
 {
   if (m_env.subDisplayFile()) {
     *m_env.subDisplayFile() << "Entering MonteCarloSG<P_V,P_M,Q_V,Q_M>::constructor()"
@@ -61,6 +62,9 @@ MonteCarloSG<P_V,P_M,Q_V,Q_M>::MonteCarloSG(
     // We did this dance because scanOptionsValues is not a const method, but
     // m_optionsObj is a pointer to const
     m_optionsObj = tempOptions;
+
+    // We do this so we don't delete the user's object in the dtor
+    m_userDidNotProvideOptions = true;
   }
 
   if (m_optionsObj->m_help != "") {
@@ -80,7 +84,10 @@ MonteCarloSG<P_V,P_M,Q_V,Q_M>::MonteCarloSG(
 template <class P_V,class P_M,class Q_V,class Q_M>
 MonteCarloSG<P_V,P_M,Q_V,Q_M>::~MonteCarloSG()
 {
-  if (m_optionsObj             ) delete m_optionsObj;
+  if (m_optionsObj && m_userDidNotProvideOptions) {
+    delete m_optionsObj;
+  }
+
   if (m_qoiFunctionSynchronizer) delete m_qoiFunctionSynchronizer;
 }
 // Statistical methods ------------------------------

--- a/src/stats/src/StatisticalForwardProblem.C
+++ b/src/stats/src/StatisticalForwardProblem.C
@@ -60,7 +60,8 @@ StatisticalForwardProblem<P_V,P_M,Q_V,Q_M>::StatisticalForwardProblem(
   m_unifiedSolutionCdf      (NULL),
 #endif
   m_solutionPdf             (NULL),
-  m_optionsObj              (alternativeOptionsValues)
+  m_optionsObj              (alternativeOptionsValues),
+  m_userDidNotProvideOptions(false)
 {
   if (m_env.subDisplayFile()) {
     *m_env.subDisplayFile() << "Entering StatisticalForwardProblem<P_V,P_M,Q_V,Q_M>::constructor()"
@@ -77,6 +78,9 @@ StatisticalForwardProblem<P_V,P_M,Q_V,Q_M>::StatisticalForwardProblem(
     // We did this dance because scanOptionsValues is not a const method, but
     // m_optionsObj is a pointer to const
     m_optionsObj = tempOptions;
+
+    // We do this so we don't delete the user's object in the dtor
+    m_userDidNotProvideOptions = true;
   }
 
   if (m_optionsObj->m_help != "") {

--- a/src/stats/src/StatisticalInverseProblem.C
+++ b/src/stats/src/StatisticalInverseProblem.C
@@ -54,7 +54,8 @@ StatisticalInverseProblem<P_V,P_M>::StatisticalInverseProblem(
   m_logLikelihoodValues     (NULL),
   m_logTargetValues         (NULL),
   m_optionsObj              (alternativeOptionsValues),
-  m_seedWithMAPEstimator    (false)
+  m_seedWithMAPEstimator    (false),
+  m_userDidNotProvideOptions(false)
 {
 #ifdef QUESO_MEMORY_DEBUGGING
   std::cout << "Entering Sip" << std::endl;
@@ -74,6 +75,10 @@ StatisticalInverseProblem<P_V,P_M>::StatisticalInverseProblem(
     // We did this dance because scanOptionsValues is not a const method, but
     // m_optionsObj is a pointer to const
     m_optionsObj = tempOptions;
+
+    // We set this flag so we don't delete the user-created object when it
+    // comes time to deconstruct
+    m_userDidNotProvideOptions = true;
   }
 
   if (m_optionsObj->m_help != "") {
@@ -121,7 +126,8 @@ StatisticalInverseProblem<P_V,P_M>::StatisticalInverseProblem(
   m_logLikelihoodValues     (NULL),
   m_logTargetValues         (NULL),
   m_optionsObj              (alternativeOptionsValues),
-  m_seedWithMAPEstimator    (false)
+  m_seedWithMAPEstimator    (false),
+  m_userDidNotProvideOptions(false)
 {
   if (m_env.subDisplayFile()) {
     *m_env.subDisplayFile() << "Entering StatisticalInverseProblem<P_V,P_M>::constructor()"
@@ -138,6 +144,8 @@ StatisticalInverseProblem<P_V,P_M>::StatisticalInverseProblem(
     // We did this dance because scanOptionsValues is not a const method, but
     // m_optionsObj is a pointer to const
     m_optionsObj = tempOptions;
+
+    m_userDidNotProvideOptions = true;
   }
 
   if (m_optionsObj->m_help != "") {
@@ -182,7 +190,10 @@ StatisticalInverseProblem<P_V,P_M>::~StatisticalInverseProblem()
   if (m_subSolutionMdf  ) delete m_subSolutionMdf;
   if (m_solutionPdf     ) delete m_solutionPdf;
   if (m_solutionDomain  ) delete m_solutionDomain;
-  if (m_optionsObj      ) delete m_optionsObj;
+
+  if (m_optionsObj && m_userDidNotProvideOptions) {
+    delete m_optionsObj;
+  }
 }
 // Statistical methods -----------------------------
 template <class P_V,class P_M>

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -50,6 +50,7 @@ check_PROGRAMS += test_4D_LinearLagrangeInterpolationSurrogate
 check_PROGRAMS += test_InterpolationSurrogateHelper
 check_PROGRAMS += test_build_InterpolationSurrogateBuilder
 check_PROGRAMS += test_BoostInputOptionsParser
+check_PROGRAMS += test_NoInputFile
 
 LDADD       = $(top_builddir)/src/libqueso.la
 
@@ -125,6 +126,7 @@ test_4D_LinearLagrangeInterpolationSurrogate_SOURCES = test_InterpolationSurroga
 test_InterpolationSurrogateHelper_SOURCES = test_InterpolationSurrogate/test_InterpolationSurrogateHelper.C
 test_build_InterpolationSurrogateBuilder_SOURCES = test_InterpolationSurrogate/test_build_InterpolationSurrogateBuilder.C
 test_BoostInputOptionsParser_SOURCES = test_InputOptionsParser/test_BoostInputOptionsParser.C
+test_NoInputFile_SOURCES = test_StatisticalInverseProblem/test_NoInputFile.C
 
 # Files to freedom stamp
 srcstamp =
@@ -172,6 +174,7 @@ srcstamp += $(test_4D_LinearLagrangeInterpolationSurrogate_SOURCES)
 srcstamp += $(test_InterpolationSurrogateHelper_SOURCES)
 srcstamp += $(test_build_InterpolationSurrogateBuilder_SOURCES)
 srcstamp += $(test_BoostInputOptionsParser_SOURCES)
+srcstamp += $(test_NoInputFile_SOURCES)
 
 TESTS =
 TESTS += $(top_builddir)/test/test_uqEnvironmentNonFatal
@@ -219,6 +222,7 @@ TESTS += $(top_builddir)/test/test_4D_LinearLagrangeInterpolationSurrogate
 TESTS += $(top_builddir)/test/test_InterpolationSurrogateHelper
 TESTS += $(top_builddir)/test/test_build_InterpolationSurrogateBuilder
 TESTS += $(top_builddir)/test/test_BoostInputOptionsParser
+TESTS += $(top_builddir)/test/test_NoInputFile
 
 XFAIL_TESTS = $(top_builddir)/test/test_SequenceOfVectorsErase
 
@@ -259,6 +263,7 @@ clean-local:
 	rm -rf $(top_builddir)/test/test_output_gaussian_likelihoods
 	rm -rf $(top_builddir)/test/test_gpmsa_cobra_output
 	rm -rf $(top_builddir)/test/test_adaptedcov_output
+	rm -rf $(top_builddir)/test/test_outputNoInputFile
 
 if CODE_COVERAGE_ENABLED
   CLEANFILES += *.gcda *.gcno

--- a/test/test_StatisticalInverseProblem/test_NoInputFile.C
+++ b/test/test_StatisticalInverseProblem/test_NoInputFile.C
@@ -1,0 +1,123 @@
+#include <queso/Environment.h>
+#include <queso/EnvironmentOptions.h>
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/UniformVectorRV.h>
+#include <queso/MetropolisHastingsSGOptions.h>
+#include <queso/StatisticalInverseProblem.h>
+#include <queso/StatisticalInverseProblemOptions.h>
+#include <queso/ScalarFunction.h>
+#include <queso/VectorSet.h>
+
+template <class V = QUESO::GslVector, class M = QUESO::GslMatrix>
+class Likelihood : public QUESO::BaseScalarFunction<V, M>
+{
+public:
+
+  Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domain)
+    : QUESO::BaseScalarFunction<V, M>(prefix, domain)
+  {
+  }
+
+  virtual ~Likelihood()
+  {
+  }
+
+  virtual double lnValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const
+  {
+    double x1 = domainVector[0];
+    double x2 = domainVector[1];
+
+    return -0.5 * (x1 * x1 + x2 * x2);
+  }
+
+  virtual double actualValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const
+  {
+    return std::exp(this->lnValue(domainVector, domainDirection, gradVector,
+          hessianMatrix, hessianEffect));
+  }
+};
+
+int main(int argc, char ** argv) {
+  MPI_Init(&argc, &argv);
+
+  QUESO::EnvOptionsValues envOptions;
+  envOptions.m_numSubEnvironments = 1;
+  envOptions.m_subDisplayFileName = "test_outputNoInputFile/display";
+  envOptions.m_subDisplayAllowAll = 1;
+  envOptions.m_displayVerbosity = 2;
+  envOptions.m_syncVerbosity = 0;
+  envOptions.m_seed = 0;
+
+  QUESO::FullEnvironment env(MPI_COMM_WORLD, "", "", &envOptions);
+
+  unsigned int dim = 2;
+  QUESO::VectorSpace<> paramSpace(env, "param_", dim, NULL);
+
+  QUESO::GslVector paramMins(paramSpace.zeroVector());
+  QUESO::GslVector paramMaxs(paramSpace.zeroVector());
+
+  double min_val = -10.0;
+  double max_val = 10.0;
+  paramMins.cwSet(min_val);
+  paramMaxs.cwSet(max_val);
+
+  QUESO::BoxSubset<> paramDomain("param_", paramSpace, paramMins, paramMaxs);
+
+  QUESO::UniformVectorRV<> priorRv("prior_", paramDomain);
+
+  Likelihood<> lhood("llhd_", paramDomain);
+
+  QUESO::GenericVectorRV<> postRv("post_", paramSpace);
+
+  QUESO::SipOptionsValues sipOptions;
+  sipOptions.m_computeSolution = 1;
+  sipOptions.m_dataOutputFileName = "test_outputNoInputFile/sipOutput";
+  sipOptions.m_dataOutputAllowedSet.clear();
+  sipOptions.m_dataOutputAllowedSet.insert(0);
+
+  QUESO::StatisticalInverseProblem<> ip("", NULL, priorRv, lhood, postRv);
+
+  QUESO::GslVector paramInitials(paramSpace.zeroVector());
+  paramInitials[0] = 0.0;
+  paramInitials[1] = 0.0;
+
+  QUESO::GslMatrix proposalCovMatrix(paramSpace.zeroVector());
+
+  proposalCovMatrix(0, 0) = 1.0;
+  proposalCovMatrix(0, 1) = 0.0;
+  proposalCovMatrix(1, 0) = 0.0;
+  proposalCovMatrix(1, 1) = 1.0;
+
+  QUESO::MhOptionsValues mhOptions;
+  mhOptions.m_dataOutputFileName = "test_outputNoInputFile/sipOutput";
+  mhOptions.m_dataOutputAllowAll = 1;
+  mhOptions.m_rawChainGenerateExtra = 0;
+  mhOptions.m_rawChainDisplayPeriod = 50000;
+  mhOptions.m_rawChainMeasureRunTimes = 1;
+  mhOptions.m_rawChainDataOutputFileName = "test_outputNoInputFile/ip_raw_chain";
+  mhOptions.m_rawChainDataOutputAllowAll = 1;
+  mhOptions.m_displayCandidates = 0;
+  mhOptions.m_tkUseLocalHessian = 0;
+  mhOptions.m_tkUseNewtonComponent = 1;
+  mhOptions.m_filteredChainGenerate = 0;
+  mhOptions.m_rawChainSize = 1000;
+  mhOptions.m_putOutOfBoundsInChain = false;
+  mhOptions.m_drMaxNumExtraStages = 1;
+  mhOptions.m_drScalesForExtraStages.resize(1);
+  mhOptions.m_drScalesForExtraStages[0] = 5.0;
+  mhOptions.m_amInitialNonAdaptInterval = 100;
+  mhOptions.m_amAdaptInterval = 100;
+  mhOptions.m_amEta = (double) 2.4 * 2.4 / dim;  // From Gelman 95
+  mhOptions.m_amEpsilon = 1.e-8;
+  mhOptions.m_doLogitTransform = false;
+
+  ip.solveWithBayesMetropolisHastings(&mhOptions, paramInitials,
+      &proposalCovMatrix);
+
+  MPI_Finalize();
+
+  return 0;
+}

--- a/test/test_StatisticalInverseProblem/test_NoInputFile.C
+++ b/test/test_StatisticalInverseProblem/test_NoInputFile.C
@@ -78,7 +78,8 @@ int main(int argc, char ** argv) {
   sipOptions.m_dataOutputAllowedSet.clear();
   sipOptions.m_dataOutputAllowedSet.insert(0);
 
-  QUESO::StatisticalInverseProblem<> ip("", NULL, priorRv, lhood, postRv);
+  QUESO::StatisticalInverseProblem<> ip("", &sipOptions, priorRv, lhood,
+      postRv);
 
   QUESO::GslVector paramInitials(paramSpace.zeroVector());
   paramInitials[0] = 0.0;


### PR DESCRIPTION
For user-provided options objects, we were doing a `delete`.  If the user also `delete`s their options object outside then a segmentation fault will occur.  I've just added a flag to check for when the user doesn't pass in an options object and only do the delete if the flag is true.