### PR TITLE
GslVector optimizations

### DIFF
--- a/examples/infinite_dim/inverse_problem.C
+++ b/examples/infinite_dim/inverse_problem.C
@@ -2,10 +2,6 @@
 #include <cmath>
 #include <string>
 
-// GSL includes
-#include <gsl/gsl_rng.h>
-#include <gsl/gsl_randist.h>
-
 // Boost includes
 #include <boost/math/constants/constants.hpp>
 
@@ -20,6 +16,7 @@
 #include <libmesh/explicit_system.h>
 
 // QUESO includes
+#include <queso/Defines.h>
 #include <queso/FunctionOperatorBuilder.h>
 #include <queso/LibMeshFunction.h>
 #include <queso/LibMeshNegativeLaplacianOperator.h>
@@ -27,6 +24,10 @@
 #include <queso/InfiniteDimensionalLikelihoodBase.h>
 #include <queso/InfiniteDimensionalMCMCSamplerOptions.h>
 #include <queso/InfiniteDimensionalMCMCSampler.h>
+
+// GSL includes
+#include <gsl/gsl_rng.h>
+#include <gsl/gsl_randist.h>
 
 // The likelihood object subclass
 class Likelihood : public QUESO::InfiniteDimensionalLikelihoodBase

--- a/examples/infinite_dim/parallel_inverse_problem.C
+++ b/examples/infinite_dim/parallel_inverse_problem.C
@@ -3,10 +3,6 @@
 #include <string>
 #include <sstream>
 
-// GSL includes
-#include <gsl/gsl_rng.h>
-#include <gsl/gsl_randist.h>
-
 // Boost includes
 #include <boost/math/constants/constants.hpp>
 
@@ -23,6 +19,7 @@
 #include <libmesh/explicit_system.h>
 
 // QUESO includes
+#include <queso/Defines.h>
 #include <queso/FunctionOperatorBuilder.h>
 #include <queso/LibMeshFunction.h>
 #include <queso/LibMeshNegativeLaplacianOperator.h>
@@ -30,6 +27,10 @@
 #include <queso/InfiniteDimensionalLikelihoodBase.h>
 #include <queso/InfiniteDimensionalMCMCSamplerOptions.h>
 #include <queso/InfiniteDimensionalMCMCSampler.h>
+
+// GSL includes
+#include <gsl/gsl_rng.h>
+#include <gsl/gsl_randist.h>
 
 // The likelihood object subclass
 class Likelihood : public QUESO::InfiniteDimensionalLikelihoodBase

--- a/src/core/inc/Defines.h
+++ b/src/core/inc/Defines.h
@@ -50,6 +50,14 @@
 //! This define is deprecated.  Remove any #ifdef statements in user code.
 #define QUESO_EXPECTS_LN_LIKELIHOOD_INSTEAD_OF_MINUS_2_LN
 
+// Use GSL inline functions
+#define HAVE_INLINE
+
+// And only do GSL range-checking if we're really debugging
+#ifndef DEBUG
+#define GSL_RANGE_CHECK_OFF
+#endif
+
 #include <iostream>
 #include <stdlib.h> // For exit()
 #include <set>

--- a/src/core/inc/GslMatrix.h
+++ b/src/core/inc/GslMatrix.h
@@ -29,10 +29,12 @@
     \brief QUESO matrix class using GSL.
 */
 
+#include <queso/Defines.h>
+#include <queso/GslVector.h>
 #include <queso/Matrix.h>
+
 #include <gsl/gsl_matrix.h>
 #include <gsl/gsl_permutation.h>
-#include <queso/GslVector.h>
 
 namespace QUESO {
 

--- a/src/core/inc/GslVector.h
+++ b/src/core/inc/GslVector.h
@@ -32,6 +32,7 @@
 
 #include <queso/Defines.h>
 #include <queso/Vector.h>
+
 #include <gsl/gsl_vector.h>
 
 namespace QUESO {

--- a/src/core/inc/GslVector.h
+++ b/src/core/inc/GslVector.h
@@ -257,6 +257,23 @@ GslVector operator-    (const GslVector& x,   const GslVector& y  );
 bool             operator==   (const GslVector& lhs, const GslVector& rhs);
 std::ostream&    operator<<   (std::ostream& os,            const GslVector& obj);
 
+
+inline
+double&
+GslVector::operator[](unsigned int i)
+{
+  return *gsl_vector_ptr(m_vec,i);
+}
+
+
+inline
+const double&
+GslVector::operator[](unsigned int i) const
+{
+  return *gsl_vector_const_ptr(m_vec,i);
+}
+
+
 }  // End namespace QUESO
 
 #endif // UQ_GSL_VECTOR_H

--- a/src/core/inc/RngGsl.h
+++ b/src/core/inc/RngGsl.h
@@ -26,6 +26,8 @@
 #define UQ_RNG_GSL_H
 
 #include <queso/RngBase.h>
+
+#include <queso/Defines.h>
 #include <gsl/gsl_rng.h>
 
 

--- a/src/core/src/BasicPdfsGsl.C
+++ b/src/core/src/BasicPdfsGsl.C
@@ -23,6 +23,7 @@
 //-----------------------------------------------------------------------el-
 
 #include <queso/BasicPdfsGsl.h>
+#include <queso/Defines.h>
 #include <gsl/gsl_randist.h>
 #include <mpi.h>
 #include <math.h>

--- a/src/core/src/GslOptimizer.C
+++ b/src/core/src/GslOptimizer.C
@@ -24,13 +24,15 @@
 
 #include <iostream>
 
-#include <gsl/gsl_multimin.h>
-#include <gsl/gsl_blas.h>
+#include <queso/Defines.h>
 #include <queso/GslVector.h>
 #include <queso/VectorSpace.h>
 #include <queso/ScalarFunction.h>
 #include <queso/GslOptimizer.h>
 #include <queso/OptimizerMonitor.h>
+
+#include <gsl/gsl_multimin.h>
+#include <gsl/gsl_blas.h>
 
 namespace QUESO {
 

--- a/src/core/src/GslVector.C
+++ b/src/core/src/GslVector.C
@@ -226,18 +226,6 @@ GslVector::operator-=(const GslVector& rhs)
   return *this;
 }
 
-double&
-GslVector::operator[](unsigned int i)
-{
-  return *gsl_vector_ptr(m_vec,i);
-}
-
-const double&
-GslVector::operator[](unsigned int i) const
-{
-  return *gsl_vector_const_ptr(m_vec,i);
-}
-
 void
 GslVector::copy(const GslVector& src)
 {

--- a/src/core/src/RngGsl.C
+++ b/src/core/src/RngGsl.C
@@ -22,6 +22,7 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/Defines.h>
 #include <queso/RngGsl.h>
 #include <gsl/gsl_randist.h>
 #include <mpi.h>

--- a/src/stats/inc/BetaVectorRV.h
+++ b/src/stats/inc/BetaVectorRV.h
@@ -33,7 +33,6 @@
 #include <queso/VectorMdf.h>
 #include <queso/SequenceOfVectors.h>
 #include <queso/InfoTheory.h>
-#include <gsl/gsl_sf_psi.h> // todo: take specificity of gsl_, i.e., make it general (gsl or boost or etc)
 
 namespace QUESO {
 

--- a/src/stats/inc/ConcatenatedVectorRV.h
+++ b/src/stats/inc/ConcatenatedVectorRV.h
@@ -33,7 +33,6 @@
 #include <queso/VectorMdf.h>
 #include <queso/SequenceOfVectors.h>
 #include <queso/InfoTheory.h>
-#include <gsl/gsl_sf_psi.h> // todo: take specificity of gsl_, i.e., make it general (gsl or boost or etc)
 
 namespace QUESO {
 

--- a/src/stats/inc/GammaVectorRV.h
+++ b/src/stats/inc/GammaVectorRV.h
@@ -33,7 +33,6 @@
 #include <queso/VectorMdf.h>
 #include <queso/SequenceOfVectors.h>
 #include <queso/InfoTheory.h>
-#include <gsl/gsl_sf_psi.h> // todo: take specificity of gsl_, i.e., make it general (gsl or boost or etc)
 
 namespace QUESO {
 

--- a/src/stats/inc/GaussianVectorRV.h
+++ b/src/stats/inc/GaussianVectorRV.h
@@ -33,7 +33,6 @@
 #include <queso/VectorMdf.h>
 #include <queso/SequenceOfVectors.h>
 #include <queso/InfoTheory.h>
-#include <gsl/gsl_sf_psi.h> // todo: take specificity of gsl_, i.e., make it general (gsl or boost or etc)
 
 namespace QUESO {
 

--- a/src/stats/inc/GenericVectorRV.h
+++ b/src/stats/inc/GenericVectorRV.h
@@ -33,7 +33,6 @@
 #include <queso/VectorMdf.h>
 #include <queso/SequenceOfVectors.h>
 #include <queso/InfoTheory.h>
-#include <gsl/gsl_sf_psi.h> // todo: take specificity of gsl_, i.e., make it general (gsl or boost or etc)
 
 namespace QUESO {
 

--- a/src/stats/inc/InfoTheory.h
+++ b/src/stats/inc/InfoTheory.h
@@ -30,7 +30,6 @@
 
 #include <ANN/ANN.h>
 #include <ANN/ANNx.h>
-#include <gsl/gsl_sf_psi.h>
 
 // TODO: create InfoTheoryOptions
 #define UQ_INFTH_ANN_NO_SMP        10000

--- a/src/stats/inc/InverseGammaVectorRV.h
+++ b/src/stats/inc/InverseGammaVectorRV.h
@@ -33,7 +33,6 @@
 #include <queso/VectorMdf.h>
 #include <queso/SequenceOfVectors.h>
 #include <queso/InfoTheory.h>
-#include <gsl/gsl_sf_psi.h> // todo: take specificity of gsl_, i.e., make it general (gsl or boost or etc)
 
 namespace QUESO {
 

--- a/src/stats/inc/JeffreysVectorRV.h
+++ b/src/stats/inc/JeffreysVectorRV.h
@@ -31,7 +31,6 @@
 #include <queso/VectorCdf.h>
 #include <queso/VectorMdf.h>
 #include <queso/SequenceOfVectors.h>
-#include <gsl/gsl_sf_psi.h> // todo: take specificity of gsl_, i.e., make it general (gsl or boost or etc)
 
 namespace QUESO {
 

--- a/src/stats/inc/LogNormalVectorRV.h
+++ b/src/stats/inc/LogNormalVectorRV.h
@@ -33,7 +33,6 @@
 #include <queso/VectorMdf.h>
 #include <queso/SequenceOfVectors.h>
 #include <queso/InfoTheory.h>
-#include <gsl/gsl_sf_psi.h> // todo: take specificity of gsl_, i.e., make it general (gsl or boost or etc)
 
 namespace QUESO {
 

--- a/src/stats/inc/UniformVectorRV.h
+++ b/src/stats/inc/UniformVectorRV.h
@@ -33,7 +33,6 @@
 #include <queso/VectorMdf.h>
 #include <queso/SequenceOfVectors.h>
 #include <queso/InfoTheory.h>
-#include <gsl/gsl_sf_psi.h> // todo: take specificity of gsl_, i.e., make it general (gsl or boost or etc)
 
 namespace QUESO {
 

--- a/src/stats/inc/WignerVectorRV.h
+++ b/src/stats/inc/WignerVectorRV.h
@@ -33,7 +33,6 @@
 #include <queso/VectorMdf.h>
 #include <queso/SequenceOfVectors.h>
 #include <queso/InfoTheory.h>
-#include <gsl/gsl_sf_psi.h> // todo: take specificity of gsl_, i.e., make it general (gsl or boost or etc)
 
 namespace QUESO {
 

--- a/src/stats/src/InfoTheory.C
+++ b/src/stats/src/InfoTheory.C
@@ -24,6 +24,9 @@
 
 #include <queso/InfoTheory.h>
 
+#include <queso/Defines.h>
+#include <gsl/gsl_sf_psi.h> // todo: take specificity of gsl_, i.e., make it general (gsl or boost or etc)
+
 #ifdef QUESO_HAS_ANN
 
 namespace QUESO {

--- a/src/stats/src/VectorRV.C
+++ b/src/stats/src/VectorRV.C
@@ -26,6 +26,9 @@
 #include <queso/GslVector.h>
 #include <queso/GslMatrix.h>
 
+#include <queso/Defines.h>
+#include <gsl/gsl_sf_psi.h> // todo: take specificity of gsl_, i.e., make it general (gsl or boost or etc)
+
 namespace QUESO {
 
 // Default constructor -----------------------------


### PR DESCRIPTION
This turns on GSL's accessor inlining, inlines our operator[] shim, and turns off (except when DEBUG is defined) GSL's range checking.  Speeds up my GPMSA runs by ~20%.