### PR TITLE
Make MPI optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,6 @@ test/output_test_optimizer_options
 test/test_optimizer/input_test_optimizer_options
 test/test_optimizer_options
 test/test_SharedPtr
+test/output_test_serialEnv
+test/test_Environment/input_test_serialEnv
+test/test_serialEnv

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,9 @@ before_script:
   - sudo apt-get install -q build-essential
   - sudo apt-get install -q libgsl0-dev
   - sudo apt-get install -q openmpi-bin openmpi-dev
-  - sudo apt-get install -q libboost-all-dev
-script: ./bootstrap && CC="mpicc" CXX="mpicxx" ./configure && make -j2 && make check
+  - sudo apt-get install -q libboost-dev libboost-math-dev libboost-program-options-dev
+script:
+  - ./bootstrap
+  - ./configure CC="mpicc" CXX="mpicxx"
+  - make -j4
+  - make check -j4

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,9 @@ QUESO: Quantification of Uncertainty for Estimation,
 Simulation, and Optimization.
 -----------------------------------------------------
 
+Version 0.54.0
+  * Make MPI an optional dependency
+
 Version 0.53.0
   * Add linear interpolation surrogates
   * Refactor input options processing

--- a/configure.ac
+++ b/configure.ac
@@ -92,15 +92,20 @@ AC_PROG_CXX
 AC_PROG_FC
 AC_LANG([C])
 
+HAVE_MPI=0
 if test "x$enable_mpi" = "xyes"; then
     ACX_MPI(CC="$MPICC", [AC_MSG_ERROR([Could not find MPI.])])
+    HAVE_MPI=1
 fi
 
 AC_LANG([C++])
 
 if test "x$enable_mpi" = "xyes"; then
     ACX_MPI(CXX="$MPICXX", [AC_MSG_ERROR([Could not find MPI.])])
+    HAVE_MPI=1
 fi
+AC_SUBST(HAVE_MPI)
+AM_CONDITIONAL(MPI_ENABLED, test x$HAVE_MPI = x1)
 
 #-------------------------
 # External Library Checks

--- a/configure.ac
+++ b/configure.ac
@@ -235,6 +235,7 @@ AC_CONFIG_FILES([
   test/test_InputOptionsParser/test_options_bad.txt
   test/test_InputOptionsParser/test_options_default.txt
   test/test_optimizer/input_test_optimizer_options
+  test/test_Environment/input_test_serialEnv
 ])
 
 AC_CONFIG_FILES([test/test_Regression/test_cobra_samples_diff.sh

--- a/configure.ac
+++ b/configure.ac
@@ -75,17 +75,32 @@ else
    AC_MSG_RESULT(no)
 fi
 
+#############################################
+# Check if the user explicitly disabled mpi #
+#############################################
+AC_ARG_ENABLE(mpi,
+              AS_HELP_STRING([--disable-mpi],
+                             [build without message passing support]),
+              [enable_mpi=no],
+              [enable_mpi=yes])
+
 #-------------------
 # Compilers and MPI
 #-------------------
-
 AC_PROG_CC
 AC_PROG_CXX
 AC_PROG_FC
 AC_LANG([C])
-ACX_MPI([CC="$MPICC"], [AC_MSG_ERROR([Could not find MPI.])])
+
+if test "x$enable_mpi" = "xyes"; then
+    ACX_MPI(CC="$MPICC", [AC_MSG_ERROR([Could not find MPI.])])
+fi
+
 AC_LANG([C++])
-ACX_MPI([CXX="$MPICXX"], [AC_MSG_ERROR([Could not find MPI.])])
+
+if test "x$enable_mpi" = "xyes"; then
+    ACX_MPI(CXX="$MPICXX", [AC_MSG_ERROR([Could not find MPI.])])
+fi
 
 #-------------------------
 # External Library Checks

--- a/examples/bimodal/src/bimodal_main.C
+++ b/examples/bimodal/src/bimodal_main.C
@@ -27,14 +27,20 @@
 int main(int argc, char* argv[])
 {
   // Initialize environment
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc,&argv);
   QUESO::FullEnvironment* env = new QUESO::FullEnvironment(MPI_COMM_WORLD,argv[1],"",NULL);
+#else
+  QUESO::FullEnvironment* env = new QUESO::FullEnvironment(argv[1],"",NULL);
+#endif
 
   // Compute
   compute(*env);
 
   // Finalize environment
   delete env;
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
   return 0;
 }

--- a/examples/gaussian_likelihoods/blockDiagonalCovariance.C
+++ b/examples/gaussian_likelihoods/blockDiagonalCovariance.C
@@ -60,9 +60,12 @@ public:
 };
 
 int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
-
   QUESO::FullEnvironment env(MPI_COMM_WORLD, argv[1], "", NULL);
+#else
+  QUESO::FullEnvironment env(argv[1], "", NULL);
+#endif
 
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
       "param_", 1, NULL);
@@ -121,7 +124,9 @@ int main(int argc, char ** argv) {
 
   ip.solveWithBayesMetropolisHastings(NULL, paramInitials, &proposalCovMatrix);
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/examples/gaussian_likelihoods/blockDiagonalCovarianceRandomCoefficients.C
+++ b/examples/gaussian_likelihoods/blockDiagonalCovarianceRandomCoefficients.C
@@ -60,9 +60,12 @@ public:
 };
 
 int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
-
   QUESO::FullEnvironment env(MPI_COMM_WORLD, argv[1], "", NULL);
+#else
+  QUESO::FullEnvironment env(argv[1], "", NULL);
+#endif
 
   // Need 3 dims because two are for the hyperparameters
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
@@ -127,7 +130,9 @@ int main(int argc, char ** argv) {
 
   ip.solveWithBayesMetropolisHastings(NULL, paramInitials, &proposalCovMatrix);
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/examples/gaussian_likelihoods/diagonalCovariance.C
+++ b/examples/gaussian_likelihoods/diagonalCovariance.C
@@ -59,9 +59,12 @@ public:
 };
 
 int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
-
   QUESO::FullEnvironment env(MPI_COMM_WORLD, argv[1], "", NULL);
+#else
+  QUESO::FullEnvironment env(argv[1], "", NULL);
+#endif
 
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
       "param_", 1, NULL);
@@ -116,7 +119,9 @@ int main(int argc, char ** argv) {
 
   ip.solveWithBayesMetropolisHastings(NULL, paramInitials, &proposalCovMatrix);
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/examples/gaussian_likelihoods/fullCovariance.C
+++ b/examples/gaussian_likelihoods/fullCovariance.C
@@ -59,9 +59,12 @@ public:
 };
 
 int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
-
   QUESO::FullEnvironment env(MPI_COMM_WORLD, argv[1], "", NULL);
+#else
+  QUESO::FullEnvironment env(argv[1], "", NULL);
+#endif
 
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
       "param_", 1, NULL);
@@ -118,7 +121,9 @@ int main(int argc, char ** argv) {
 
   ip.solveWithBayesMetropolisHastings(NULL, paramInitials, &proposalCovMatrix);
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/examples/gaussian_likelihoods/fullCovarianceRandomCoefficient.C
+++ b/examples/gaussian_likelihoods/fullCovarianceRandomCoefficient.C
@@ -65,9 +65,12 @@ public:
 };
 
 int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
-
   QUESO::FullEnvironment env(MPI_COMM_WORLD, argv[1], "", NULL);
+#else
+  QUESO::FullEnvironment env(argv[1], "", NULL);
+#endif
 
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
       "param_", 2, NULL);
@@ -128,7 +131,9 @@ int main(int argc, char ** argv) {
 
   ip.solveWithBayesMetropolisHastings(NULL, paramInitials, &proposalCovMatrix);
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/examples/gaussian_likelihoods/scalarCovariance.C
+++ b/examples/gaussian_likelihoods/scalarCovariance.C
@@ -59,9 +59,12 @@ public:
 };
 
 int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
-
   QUESO::FullEnvironment env(MPI_COMM_WORLD, argv[1], "", NULL);
+#else
+  QUESO::FullEnvironment env(argv[1], "", NULL);
+#endif
 
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
       "param_", 1, NULL);
@@ -111,7 +114,9 @@ int main(int argc, char ** argv) {
 
   ip.solveWithBayesMetropolisHastings(NULL, paramInitials, &proposalCovMatrix);
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/examples/gp/scalar/gpmsa_scalar.C
+++ b/examples/gp/scalar/gpmsa_scalar.C
@@ -98,10 +98,14 @@ int main(int argc, char ** argv) {
   unsigned int numEta = 1;  // Number of responses the model is returning
   unsigned int experimentSize = 1;  // Size of each experiment
 
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
 
   // Step 1: Set up QUESO environment
   QUESO::FullEnvironment env(MPI_COMM_WORLD, argv[1], "", NULL);
+#else
+  QUESO::FullEnvironment env(argv[1], "", NULL);
+#endif
 
   // Step 2: Set up prior for calibration parameters
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
@@ -283,7 +287,9 @@ int main(int argc, char ** argv) {
 
   ip.solveWithBayesMetropolisHastings(NULL, paramInitials, &proposalCovMatrix);
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/examples/gravity/src/gravity_main.C
+++ b/examples/gravity/src/gravity_main.C
@@ -49,16 +49,23 @@
 int main(int argc, char* argv[])
 {
   // Initialize QUESO environment
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc,&argv);
   QUESO::FullEnvironment* env =
     new QUESO::FullEnvironment(MPI_COMM_WORLD,argv[1],"",NULL);
+#else
+  QUESO::FullEnvironment* env =
+    new QUESO::FullEnvironment(argv[1],"",NULL);
+#endif
 
   // Call application
   computeGravityAndTraveledDistance(*env);
 
   // Finalize QUESO environment
   delete env;
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/examples/hysteretic/src/example_main.C
+++ b/examples/hysteretic/src/example_main.C
@@ -35,9 +35,14 @@
 int main(int argc, char* argv[])
 {
   // Initialize environment
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc,&argv);
   QUESO::FullEnvironment* env =
     new QUESO::FullEnvironment(MPI_COMM_WORLD,argv[1],"",NULL);
+#else
+  QUESO::FullEnvironment* env =
+    new QUESO::FullEnvironment(argv[1],"",NULL);
+#endif
 
   // Compute
 #if 1
@@ -48,7 +53,9 @@ int main(int argc, char* argv[])
 
   // Finalize environment
   delete env;
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/examples/interpolation_surrogate/4d_interp.C
+++ b/examples/interpolation_surrogate/4d_interp.C
@@ -24,6 +24,7 @@
 
 #include <queso/GslVector.h>
 #include <queso/GslMatrix.h>
+#include <queso/MpiComm.h>
 #include <queso/BoxSubset.h>
 #include <queso/LinearLagrangeInterpolationSurrogate.h>
 #include <queso/InterpolationSurrogateBuilder.h>
@@ -62,8 +63,12 @@ int main(int argc, char ** argv)
     }
   std::string filename = argv[1];
 
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
   QUESO::FullEnvironment env(MPI_COMM_WORLD, filename.c_str(), "", NULL);
+#else
+  QUESO::FullEnvironment env(filename.c_str(), "", NULL);
+#endif
 
   // Define the parameter space. It's 4-dimensional in this example.
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>
@@ -166,10 +171,12 @@ int main(int argc, char ** argv)
                     << "======================================" << std::endl;
         }
 
-      MPI_Barrier(MPI_COMM_WORLD);
+      env.fullComm().Barrier();
     }
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/examples/interpolation_surrogate/4d_interp_read.C
+++ b/examples/interpolation_surrogate/4d_interp_read.C
@@ -24,6 +24,7 @@
 
 #include <queso/GslVector.h>
 #include <queso/GslMatrix.h>
+#include <queso/MpiComm.h>
 #include <queso/InterpolationSurrogateIOASCII.h>
 #include <queso/LinearLagrangeInterpolationSurrogate.h>
 
@@ -38,8 +39,12 @@ int main(int argc, char ** argv)
     }
   std::string filename = argv[1];
 
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
   QUESO::FullEnvironment env(MPI_COMM_WORLD, filename.c_str(), "", NULL);
+#else
+  QUESO::FullEnvironment env(filename.c_str(), "", NULL);
+#endif
 
   // We will read in the previously computed interpolation data
   QUESO::InterpolationSurrogateIOASCII<QUESO::GslVector, QUESO::GslMatrix>
@@ -82,10 +87,12 @@ int main(int argc, char ** argv)
                     << "======================================" << std::endl;
         }
 
-      MPI_Barrier(MPI_COMM_WORLD);
+      env.fullComm().Barrier();
     }
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/examples/simpleStatisticalForwardProblem/src/simple_sfp_example_main.C
+++ b/examples/simpleStatisticalForwardProblem/src/simple_sfp_example_main.C
@@ -27,19 +27,26 @@
 int main(int argc, char* argv[])
 {
   // Initialize environment
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc,&argv);
 
   UQ_FATAL_TEST_MACRO(argc != 2, QUESO::UQ_UNAVAILABLE_RANK, "main()",
                       "input file must be specified in command line as argv[1], just after executable argv[0]");
   QUESO::FullEnvironment* env =
     new QUESO::FullEnvironment(MPI_COMM_WORLD,argv[1],"",NULL);
+#else
+  QUESO::FullEnvironment* env =
+    new QUESO::FullEnvironment(argv[1],"",NULL);
+#endif
 
   // Compute
   compute(*env);
 
   // Finalize environment
   delete env;
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/examples/simpleStatisticalInverseProblem/src/example_main.C
+++ b/examples/simpleStatisticalInverseProblem/src/example_main.C
@@ -27,6 +27,7 @@
 int main(int argc, char* argv[])
 {
   // Initialize environment
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc,&argv);
 
   UQ_FATAL_TEST_MACRO(argc != 2,
@@ -35,13 +36,18 @@ int main(int argc, char* argv[])
                       "input file must be specified in command line as argv[1], just after executable argv[0]");
 
   QUESO::FullEnvironment* env =  new QUESO::FullEnvironment(MPI_COMM_WORLD,argv[1],"",NULL);
+#else
+  QUESO::FullEnvironment* env =  new QUESO::FullEnvironment(argv[1],"",NULL);
+#endif
 
   // Compute
   compute(*env);
 
   // Finalize environment
   delete env;
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/examples/validationCycle/src/exTgaValidationCycle_gsl.C
+++ b/examples/validationCycle/src/exTgaValidationCycle_gsl.C
@@ -62,7 +62,9 @@ int main(int argc, char* argv[])
   //************************************************
   // Initialize environment
   //************************************************
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc,&argv);
+#endif
 
   QUESO::EnvOptionsValues* envOptionsValues = NULL;
 #ifdef UQ_EXAMPLES_USES_QUESO_INPUT_FILE
@@ -70,7 +72,11 @@ int main(int argc, char* argv[])
                       QUESO::UQ_UNAVAILABLE_RANK,
                       "main()",
                       "input file must be specified in command line as argv[1], just after executable argv[0]");
+#ifdef QUESO_HAS_MPI
   QUESO::FullEnvironment* env = new QUESO::FullEnvironment(MPI_COMM_WORLD,argv[1],"",envOptionsValues);
+#else
+  QUESO::FullEnvironment* env = new QUESO::FullEnvironment(argv[1],"",envOptionsValues);
+#endif
 
 #else
   envOptionsValues = new QUESO::EnvOptionsValues();
@@ -80,7 +86,11 @@ int main(int argc, char* argv[])
   envOptionsValues->m_displayVerbosity     = 2;
   envOptionsValues->m_seed                 = 0;
 
+#ifdef QUESO_HAS_MPI
   QUESO::FullEnvironment* env = new QUESO::FullEnvironment(MPI_COMM_WORLD,"","",envOptionsValues);
+#else
+  QUESO::FullEnvironment* env = new QUESO::FullEnvironment("","",envOptionsValues);
+#endif
 #endif
 
   //************************************************
@@ -97,6 +107,8 @@ int main(int argc, char* argv[])
   //************************************************
   delete env;
   delete envOptionsValues;
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
   return 0;
 }

--- a/examples/validationCycle2/src/tga2_gsl.C
+++ b/examples/validationCycle2/src/tga2_gsl.C
@@ -31,6 +31,7 @@ int main(int argc, char* argv[])
   //************************************************
   // Initialize environment
   //************************************************
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc,&argv);
 
   UQ_FATAL_TEST_MACRO(argc != 2,
@@ -38,6 +39,9 @@ int main(int argc, char* argv[])
                       "main()",
                       "input file must be specified in command line as argv[1], just after executable argv[0]");
   QUESO::FullEnvironment* env = new QUESO::FullEnvironment(MPI_COMM_WORLD,argv[1],"",NULL);
+#else
+  QUESO::FullEnvironment* env = new QUESO::FullEnvironment(argv[1],"",NULL);
+#endif
 
   //************************************************
   // Run application
@@ -48,6 +52,8 @@ int main(int argc, char* argv[])
   // Finalize environment
   //************************************************
   delete env;
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
   return 0;
 }

--- a/m4/common/acx_mpi.m4
+++ b/m4/common/acx_mpi.m4
@@ -176,6 +176,7 @@ if test x = x"$MPILIBS"; then
         :
 else
         ifelse([$1],,[AC_DEFINE(HAVE_MPI,1,[Define if you have the MPI library.])],[$1])
+        AC_DEFINE(HAVE_MPI,1,[Define if you have the MPI library.])
         :
 fi
 ])dnl ACX_MPI

--- a/m4/config_summary.m4
+++ b/m4/config_summary.m4
@@ -43,10 +43,10 @@ echo Optional Features:
 
 # Optional Features Enabled?
 
-if test "$HAVE_MPI" = "0"; then
-  echo '   'Link with MPI.............. : no
-else
+if test "$HAVE_MPI" = "1"; then
   echo '   'Link with MPI.............. : yes
+else
+  echo '   'Link with MPI.............. : no
 fi
 
 if test "$HAVE_GRVY" = "0"; then

--- a/m4/config_summary.m4
+++ b/m4/config_summary.m4
@@ -43,6 +43,12 @@ echo Optional Features:
 
 # Optional Features Enabled?
 
+if test "$HAVE_MPI" = "0"; then
+  echo '   'Link with MPI.............. : no
+else
+  echo '   'Link with MPI.............. : yes
+fi
+
 if test "$HAVE_GRVY" = "0"; then
   echo '   'Link with GRVY............. : no
 else

--- a/src/basic/src/ScalarSequence.C
+++ b/src/basic/src/ScalarSequence.C
@@ -152,7 +152,7 @@ ScalarSequence<T>::unifiedSequenceSize(bool useOnlyInter0Comm) const
   if (useOnlyInter0Comm) {
     if (m_env.inter0Rank() >= 0) {
       unsigned int subNumSamples = this->subSequenceSize();
-      m_env.inter0Comm().Allreduce((void *) &subNumSamples, (void *) &unifiedNumSamples, (int) 1, RawValue_MPI_UNSIGNED, RawValue_MPI_SUM,
+      m_env.inter0Comm().template Allreduce<unsigned int>(&subNumSamples, &unifiedNumSamples, (int) 1, RawValue_MPI_SUM,
                                    "ScalarSequence<T>::unifiedSequenceSize()",
                                    "failed MPI.Allreduce() for unifiedSequenceSize()");
     }
@@ -252,7 +252,7 @@ ScalarSequence<T>::getUnifiedContentsAtProc0Only(
       // Use MPI_Gatherv for the case different nodes have different amount of data // KAUST4
       //******************************************************************
       std::vector<int> recvcnts(m_env.inter0Comm().NumProc(),0); // '0' is NOT the correct value for recvcnts[0]
-      m_env.inter0Comm().Gather((void *) &auxSubSize, 1, RawValue_MPI_INT, (void *) &recvcnts[0], (int) 1, RawValue_MPI_INT, 0,
+      m_env.inter0Comm().template Gather<int>(&auxSubSize, 1, &recvcnts[0], (int) 1, 0,
                                 "ScalarSequence<T>::getUnifiedContentsAtProc0Only()",
                                 "failed MPI.Gather()");
       if (m_env.inter0Rank() == 0) {
@@ -281,9 +281,11 @@ ScalarSequence<T>::getUnifiedContentsAtProc0Only(
         }
       }
 #endif
-      m_env.inter0Comm().Gatherv((void *) &m_seq[0], auxSubSize, RawValue_MPI_DOUBLE, (void *) &outputVec[0], (int *) &recvcnts[0], (int *) &displs[0], RawValue_MPI_DOUBLE, 0,
-                                 "ScalarSequence<T>::getUnifiedContentsAtProc0Only()",
-                                 "failed MPI.Gatherv()");
+
+      m_env.inter0Comm().template Gatherv<double>(&m_seq[0], auxSubSize,
+          &outputVec[0], (int *) &recvcnts[0], (int *) &displs[0], 0,
+          "ScalarSequence<T>::getUnifiedContentsAtProc0Only()",
+          "failed MPI.Gatherv()");
 
 #if 0 // for debug only
       if ((m_env.subDisplayFile()) && (m_env.displayVerbosity() >= 0)) {
@@ -908,7 +910,7 @@ ScalarSequence<T>::unifiedMeanExtra(
       //          << std::endl;
       //sleep(1);
       unsigned int unifiedNumPos = 0;
-      m_env.inter0Comm().Allreduce((void *) &numPos, (void *) &unifiedNumPos, (int) 1, RawValue_MPI_UNSIGNED, RawValue_MPI_SUM,
+      m_env.inter0Comm().template Allreduce<unsigned int>(&numPos, &unifiedNumPos, (int) 1, RawValue_MPI_SUM,
                                    "ScalarSequence<T>::unifiedMeanExtra()",
                                    "failed MPI.Allreduce() for numPos");
 
@@ -919,7 +921,7 @@ ScalarSequence<T>::unifiedMeanExtra(
                                 << std::endl;
       }
 
-      m_env.inter0Comm().Allreduce((void *) &localSum, (void *) &unifiedMeanValue, (int) 1, RawValue_MPI_DOUBLE, RawValue_MPI_SUM,
+      m_env.inter0Comm().template Allreduce<double>(&localSum, &unifiedMeanValue, (int) 1, RawValue_MPI_SUM,
                                    "ScalarSequence<T>::unifiedMeanExtra()",
                                    "failed MPI.Allreduce() for sum");
 
@@ -1097,11 +1099,11 @@ ScalarSequence<T>::unifiedSampleVarianceExtra(
       }
 
       unsigned int unifiedNumPos = 0;
-      m_env.inter0Comm().Allreduce((void *) &numPos, (void *) &unifiedNumPos, (int) 1, RawValue_MPI_UNSIGNED, RawValue_MPI_SUM,
+      m_env.inter0Comm().template Allreduce<unsigned int>(&numPos, &unifiedNumPos, (int) 1, RawValue_MPI_SUM,
                                    "ScalarSequence<T>::unifiedSampleVarianceExtra()",
                                    "failed MPI.Allreduce() for numPos");
 
-      m_env.inter0Comm().Allreduce((void *) &localSamValue, (void *) &unifiedSamValue, (int) 1, RawValue_MPI_DOUBLE, RawValue_MPI_SUM,
+      m_env.inter0Comm().template Allreduce<double>(&localSamValue, &unifiedSamValue, (int) 1, RawValue_MPI_SUM,
                                    "ScalarSequence<T>::unifiedSampleVarianceExtra()",
                                    "failed MPI.Allreduce() for samValue");
 
@@ -1184,11 +1186,11 @@ ScalarSequence<T>::unifiedSampleStd(
       }
 
       unsigned int unifiedNumPos = 0;
-      m_env.inter0Comm().Allreduce((void *) &numPos, (void *) &unifiedNumPos, (int) 1, RawValue_MPI_UNSIGNED, RawValue_MPI_SUM,
+      m_env.inter0Comm().template Allreduce<unsigned int>(&numPos, &unifiedNumPos, (int) 1, RawValue_MPI_SUM,
                                    "ScalarSequence<T>::unifiedSampleStd()",
                                    "failed MPI.Allreduce() for numPos");
 
-      m_env.inter0Comm().Allreduce((void *) &localStdValue, (void *) &unifiedStdValue, (int) 1, RawValue_MPI_DOUBLE, RawValue_MPI_SUM,
+      m_env.inter0Comm().template Allreduce<double>(&localStdValue, &unifiedStdValue, (int) 1, RawValue_MPI_SUM,
                                    "ScalarSequence<T>::unifiedSampleStd()",
                                    "failed MPI.Allreduce() for stdValue");
 
@@ -1271,11 +1273,11 @@ ScalarSequence<T>::unifiedPopulationVariance(
       }
 
       unsigned int unifiedNumPos = 0;
-      m_env.inter0Comm().Allreduce((void *) &numPos, (void *) &unifiedNumPos, (int) 1, RawValue_MPI_UNSIGNED, RawValue_MPI_SUM,
+      m_env.inter0Comm().template Allreduce<unsigned int>(&numPos, &unifiedNumPos, (int) 1, RawValue_MPI_SUM,
                                    "ScalarSequence<T>::unifiedPopulationVariance()",
                                    "failed MPI.Allreduce() for numPos");
 
-      m_env.inter0Comm().Allreduce((void *) &localPopValue, (void *) &unifiedPopValue, (int) 1, RawValue_MPI_DOUBLE, RawValue_MPI_SUM,
+      m_env.inter0Comm().template Allreduce<double>(&localPopValue, &unifiedPopValue, (int) 1, RawValue_MPI_SUM,
                                    "ScalarSequence<T>::unifiedPopulationVariance()",
                                    "failed MPI.Allreduce() for popValue");
 
@@ -1567,7 +1569,7 @@ ScalarSequence<T>::unifiedMinMaxExtra(
       for (unsigned int i = 0; i < sendBuf.size(); ++i) {
         sendBuf[i] = minValue;
       }
-      m_env.inter0Comm().Allreduce((void *) &sendBuf[0], (void *) &unifiedMinValue, (int) sendBuf.size(), RawValue_MPI_DOUBLE, RawValue_MPI_MIN,
+      m_env.inter0Comm().template Allreduce<double>(&sendBuf[0], &unifiedMinValue, (int) sendBuf.size(), RawValue_MPI_MIN,
                                    "ScalarSequence<T>::unifiedMinMaxExtra()",
                                    "failed MPI.Allreduce() for min");
 
@@ -1575,7 +1577,7 @@ ScalarSequence<T>::unifiedMinMaxExtra(
       for (unsigned int i = 0; i < sendBuf.size(); ++i) {
         sendBuf[i] = maxValue;
       }
-      m_env.inter0Comm().Allreduce((void *) &sendBuf[0], (void *) &unifiedMaxValue, (int) sendBuf.size(), RawValue_MPI_DOUBLE, RawValue_MPI_MAX,
+      m_env.inter0Comm().template Allreduce<double>(&sendBuf[0], &unifiedMaxValue, (int) sendBuf.size(), RawValue_MPI_MAX,
                                    "ScalarSequence<T>::unifiedMinMaxExtra()",
                                    "failed MPI.Allreduce() for max");
 
@@ -1708,7 +1710,7 @@ ScalarSequence<T>::unifiedHistogram(
         }
       }
 
-      m_env.inter0Comm().Allreduce((void *) &localBins[0], (void *) &unifiedBins[0], (int) localBins.size(), RawValue_MPI_UNSIGNED, RawValue_MPI_SUM,
+      m_env.inter0Comm().template Allreduce<unsigned int>(&localBins[0], &unifiedBins[0], (int) localBins.size(), RawValue_MPI_SUM,
                                    "ScalarSequence<T>::unifiedHistogram()",
                                    "failed MPI.Allreduce() for bins");
 
@@ -1964,7 +1966,7 @@ ScalarSequence<T>::unifiedSort(
                                "failed MPI.Bcast() for unified data size");
 
       unsigned int sumOfNumPos = 0;
-      m_env.inter0Comm().Allreduce((void *) &localNumPos, (void *) &sumOfNumPos, (int) 1, RawValue_MPI_UNSIGNED, RawValue_MPI_SUM,
+      m_env.inter0Comm().template Allreduce<unsigned int>(&localNumPos, &sumOfNumPos, (int) 1, RawValue_MPI_SUM,
                                    "ScalarSequence<T>::unifiedSort()",
                                    "failed MPI.Allreduce() for data size");
 
@@ -2138,7 +2140,7 @@ ScalarSequence<T>::unifiedInterQuantileRange(
 
       unsigned int localDataSize = this->subSequenceSize() - initialPos;
       unsigned int sumOfLocalSizes = 0;
-      m_env.inter0Comm().Allreduce((void *) &localDataSize, (void *) &sumOfLocalSizes, (int) 1, RawValue_MPI_UNSIGNED, RawValue_MPI_SUM,
+      m_env.inter0Comm().template Allreduce<unsigned int>(&localDataSize, &sumOfLocalSizes, (int) 1, RawValue_MPI_SUM,
                                    "ScalarSequence<T>::unifiedInterQuantileRange()",
                                    "failed MPI.Allreduce() for data size");
 
@@ -2277,7 +2279,7 @@ ScalarSequence<T>::unifiedScaleForKde(
                                                            unifiedMeanValue);
 
       unsigned int unifiedDataSize = 0;
-      m_env.inter0Comm().Allreduce((void *) &localDataSize, (void *) &unifiedDataSize, (int) 1, RawValue_MPI_UNSIGNED, RawValue_MPI_SUM,
+      m_env.inter0Comm().template Allreduce<unsigned int>(&localDataSize, &unifiedDataSize, (int) 1, RawValue_MPI_SUM,
                                    "ScalarSequence<T>::unifiedScaleForKde()",
                                    "failed MPI.Allreduce() for data size");
 
@@ -2371,7 +2373,7 @@ ScalarSequence<T>::unifiedGaussian1dKde(
 
       unsigned int localDataSize = this->subSequenceSize() - initialPos;
       unsigned int unifiedDataSize = 0;
-      m_env.inter0Comm().Allreduce((void *) &localDataSize, (void *) &unifiedDataSize, (int) 1, RawValue_MPI_UNSIGNED, RawValue_MPI_SUM,
+      m_env.inter0Comm().template Allreduce<unsigned int>(&localDataSize, &unifiedDataSize, (int) 1, RawValue_MPI_SUM,
                                    "ScalarSequence<T>::unifiedGaussian1dKde()",
                                    "failed MPI.Allreduce() for data size");
 
@@ -2392,7 +2394,7 @@ ScalarSequence<T>::unifiedGaussian1dKde(
       for (unsigned int j = 0; j < numEvals; ++j) {
         unifiedDensityValues[j] = 0.;
       }
-      m_env.inter0Comm().Allreduce((void *) &densityValues[0], (void *) &unifiedDensityValues[0], (int) numEvals, RawValue_MPI_DOUBLE, RawValue_MPI_SUM,
+      m_env.inter0Comm().template Allreduce<double>(&densityValues[0], &unifiedDensityValues[0], (int) numEvals, RawValue_MPI_SUM,
                                    "ScalarSequence<T>::unifiedGaussian1dKde()",
                                    "failed MPI.Allreduce() for density values");
 
@@ -3476,11 +3478,11 @@ ScalarSequence<T>::unifiedMeanCltStd(
       }
 
       unsigned int unifiedNumPos = 0;
-      m_env.inter0Comm().Allreduce((void *) &numPos, (void *) &unifiedNumPos, (int) 1, RawValue_MPI_UNSIGNED, RawValue_MPI_SUM,
+      m_env.inter0Comm().template Allreduce<unsigned int>(&numPos, &unifiedNumPos, (int) 1, RawValue_MPI_SUM,
                                    "ScalarSequence<T>::unifiedMeanCltStd()",
                                    "failed MPI.Allreduce() for numPos");
 
-      m_env.inter0Comm().Allreduce((void *) &localStdValue, (void *) &unifiedStdValue, (int) 1, RawValue_MPI_DOUBLE, RawValue_MPI_SUM,
+      m_env.inter0Comm().template Allreduce<double>(&localStdValue, &unifiedStdValue, (int) 1, RawValue_MPI_SUM,
                                    "ScalarSequence<T>::unifiedMeanCltStd()",
                                    "failed MPI.Allreduce() for stdValue");
 
@@ -4094,12 +4096,12 @@ ComputeCovCorrBetweenScalarSequences(
   // Compute unified covariance
   if (env.inter0Rank() >= 0) {
     unsigned int unifiedNumSamples = 0;
-    env.inter0Comm().Allreduce((void *) &subNumSamples, (void *) &unifiedNumSamples, (int) 1, RawValue_MPI_UNSIGNED, RawValue_MPI_SUM,
+    env.inter0Comm().template Allreduce<unsigned int>(&subNumSamples, &unifiedNumSamples, (int) 1, RawValue_MPI_SUM,
                                "ComputeCovCorrBetweenScalarSequences()",
                                "failed MPI.Allreduce() for subNumSamples");
 
     double aux = 0.;
-    env.inter0Comm().Allreduce((void *) &covValue, (void *) &aux, (int) 1, RawValue_MPI_DOUBLE, RawValue_MPI_SUM,
+    env.inter0Comm().template Allreduce<double>(&covValue, &aux, (int) 1, RawValue_MPI_SUM,
                                "ComputeCovCorrBetweenScalarSequences()",
                                "failed MPI.Allreduce() for a matrix position");
     covValue = aux/((double) (unifiedNumSamples-1)); // Yes, '-1' in order to compensate for the 'N-1' denominator factor in the calculations of sample variances above (whose square roots will be used below)

--- a/src/basic/src/VectorSequence.C
+++ b/src/basic/src/VectorSequence.C
@@ -76,7 +76,7 @@ BaseVectorSequence<V,M>::unifiedSequenceSize() const
   if (useOnlyInter0Comm) {
     if (m_env.inter0Rank() >= 0) {
       unsigned int subNumSamples = this->subSequenceSize();
-      m_env.inter0Comm().Allreduce((void *) &subNumSamples, (void *) &unifiedNumSamples, (int) 1, RawValue_MPI_UNSIGNED, RawValue_MPI_SUM,
+      m_env.inter0Comm().template Allreduce<unsigned int>(&subNumSamples, &unifiedNumSamples, (int) 1, RawValue_MPI_SUM,
                                    "BaseVectorSequence<V,M>::unifiedSequenceSize()",
                                    "failed MPI.Allreduce() for unifiedSequenceSize()");
     }
@@ -442,7 +442,7 @@ BaseVectorSequence<V,M>::unifiedPositionsOfMaximum( // rr0
   for (unsigned int i = 0; i < sendbufPos.size(); ++i) {
     sendbufPos[i] = subMaxValue;
   }
-  m_env.inter0Comm().Allreduce((void *) &sendbufPos[0], (void *) &unifiedMaxValue, (int) sendbufPos.size(), RawValue_MPI_DOUBLE, RawValue_MPI_MAX,
+  m_env.inter0Comm().template Allreduce<double>(&sendbufPos[0], &unifiedMaxValue, (int) sendbufPos.size(), RawValue_MPI_MAX,
                                "BaseVectorSequence<V,M>::unifiedPositionsOfMaximum()",
                                "failed MPI.Allreduce() for max");
 
@@ -474,7 +474,7 @@ BaseVectorSequence<V,M>::unifiedPositionsOfMaximum( // rr0
   std::vector<int> auxBuf(1,0);
   int unifiedNumPos = 0; // Yes, 'int', due to MPI to be used soon
   auxBuf[0] = subNumPos;
-  m_env.inter0Comm().Allreduce((void *) &auxBuf[0], (void *) &unifiedNumPos, (int) auxBuf.size(), RawValue_MPI_INT, RawValue_MPI_SUM,
+  m_env.inter0Comm().template Allreduce<int>(&auxBuf[0], &unifiedNumPos, (int) auxBuf.size(), RawValue_MPI_SUM,
                                "BaseVectorSequence<V,M>::unifiedPositionsOfMaximum()",
                                "failed MPI.Allreduce() for sum");
 
@@ -488,7 +488,7 @@ BaseVectorSequence<V,M>::unifiedPositionsOfMaximum( // rr0
   unsigned int Np = (unsigned int) m_env.inter0Comm().NumProc();
 
   std::vector<int> recvcntsPos(Np,0); // '0' is NOT the correct value for recvcntsPos[0]
-  m_env.inter0Comm().Gather((void *) &subNumPos, 1, RawValue_MPI_INT, (void *) &recvcntsPos[0], (int) 1, RawValue_MPI_INT, 0,
+  m_env.inter0Comm().template Gather<int>(&subNumPos, 1, &recvcntsPos[0], (int) 1, 0,
                             "BaseVectorSequence<V,M>::unifiedPositionsOfMaximum()",
                             "failed MPI.Gatherv()");
   if (m_env.inter0Rank() == 0) {
@@ -515,7 +515,7 @@ BaseVectorSequence<V,M>::unifiedPositionsOfMaximum( // rr0
   unsigned int dimSize = m_vectorSpace.dimLocal();
   int subNumDbs = subNumPos * dimSize; // Yes, 'int', due to MPI to be used soon
   std::vector<int> recvcntsDbs(Np,0); // '0' is NOT the correct value for recvcntsDbs[0]
-  m_env.inter0Comm().Gather((void *) &subNumDbs, 1, RawValue_MPI_INT, (void *) &recvcntsDbs[0], (int) 1, RawValue_MPI_INT, 0,
+  m_env.inter0Comm().template Gather<int>(&subNumDbs, 1, &recvcntsDbs[0], (int) 1, 0,
                             "BaseVectorSequence<V,M>::unifiedPositionsOfMaximum()",
                             "failed MPI.Gatherv()");
   if (m_env.inter0Rank() == 0) {
@@ -548,9 +548,10 @@ BaseVectorSequence<V,M>::unifiedPositionsOfMaximum( // rr0
   std::vector<double> recvbufDbs(unifiedNumPos * dimSize);
 
   // Gather up all states that attain maxima and store then in recvbufDbs
-  m_env.inter0Comm().Gatherv((void *) &sendbufDbs[0], (int) subNumDbs, RawValue_MPI_DOUBLE, (void *) &recvbufDbs[0], (int *) &recvcntsDbs[0], (int *) &displsDbs[0], RawValue_MPI_DOUBLE, 0,
-                             "BaseVectorSequence<V,M>::unifiedPositionsOfMaximum()",
-                             "failed MPI.Gatherv()");
+  m_env.inter0Comm().template Gatherv<double>(&sendbufDbs[0], (int) subNumDbs,
+      &recvbufDbs[0], (int *) &recvcntsDbs[0], (int *) &displsDbs[0], 0,
+      "BaseVectorSequence<V,M>::unifiedPositionsOfMaximum()",
+      "failed MPI.Gatherv()");
 
   //******************************************************************
   // Transfer data from 'recvbuf' to 'unifiedPositionsOfMaximum'
@@ -2854,14 +2855,14 @@ ComputeCovCorrMatricesBetweenVectorSequences(
   if (useOnlyInter0Comm) {
     if (env.inter0Rank() >= 0) {
       unsigned int unifiedNumSamples = 0;
-      env.inter0Comm().Allreduce((void *) &subNumSamples, (void *) &unifiedNumSamples, (int) 1, RawValue_MPI_UNSIGNED, RawValue_MPI_SUM,
+      env.inter0Comm().template Allreduce<unsigned int>(&subNumSamples, &unifiedNumSamples, (int) 1, RawValue_MPI_SUM,
                                  "ComputeCovCorrMatricesBetweenVectorSequences()",
                                  "failed MPI.Allreduce() for subNumSamples");
 
       for (unsigned i = 0; i < numRowsLocal; ++i) {
         for (unsigned j = 0; j < numCols; ++j) {
           double aux = 0.;
-          env.inter0Comm().Allreduce((void *) &pqCovMatrix(i,j), (void *) &aux, (int) 1, RawValue_MPI_DOUBLE, RawValue_MPI_SUM,
+          env.inter0Comm().template Allreduce<double>(&pqCovMatrix(i,j), &aux, (int) 1, RawValue_MPI_SUM,
                                      "ComputeCovCorrMatricesBetweenVectorSequences()",
                                      "failed MPI.Allreduce() for a matrix position");
           pqCovMatrix(i,j) = aux/((double) (unifiedNumSamples-1)); // Yes, '-1' in order to compensate for the 'N-1' denominator factor in the calculations of sample variances above (whose square roots will be used below)

--- a/src/core/inc/Defines.h
+++ b/src/core/inc/Defines.h
@@ -44,8 +44,9 @@
 #define QUESO_HAS_ANN
 #endif
 
-//! This define is deprecated.  Remove any #ifdef statements in user code.
+#ifdef QUESO_HAVE_MPI
 #define QUESO_HAS_MPI
+#endif
 
 //! This define is deprecated.  Remove any #ifdef statements in user code.
 #define QUESO_EXPECTS_LN_LIKELIHOOD_INSTEAD_OF_MINUS_2_LN
@@ -62,7 +63,11 @@
 #include <stdlib.h> // For exit()
 #include <set>
 #include <vector>
+
+#ifdef QUESO_HAS_MPI
 #include <mpi.h>
+#endif
+
 #include <queso/asserts.h> // for queso_error handler
 
 namespace QUESO {

--- a/src/core/inc/Environment.h
+++ b/src/core/inc/Environment.h
@@ -417,10 +417,22 @@ class FullEnvironment : public BaseEnvironment {
 public:
     //! @name Constructor/Destructor methods
   //@{
-  //! Default constructor.
-  /*! It initializes the full communicator, reads the options, deals with multiple sub-environments,
-   * e.g. dealing with sub/self/inter0-communicators, handles path for output files. */
+  //! Parallel constructor.
+  /*!
+   * Initializes the full communicator, reads the options, deals with multiple
+   * sub-environments, e.g. dealing with sub/self/inter0-communicators, handles
+   * path for output files.
+   */
+#ifdef QUESO_HAS_MPI
   FullEnvironment(RawType_MPI_Comm inputComm, const char* passedOptionsInputFileName, const char* prefix, EnvOptionsValues* alternativeOptionsValues);
+#endif
+
+  //! Serial constructor.
+  /*!
+   * No communicator is passed. Output path handling is exactly as in the
+   * parallel ctor.
+   */
+  FullEnvironment(const char* passedOptionsInputFileName, const char* prefix, EnvOptionsValues* alternativeOptionsValues);
 
   //! Destructor
  ~FullEnvironment();

--- a/src/core/inc/MpiComm.h
+++ b/src/core/inc/MpiComm.h
@@ -45,7 +45,6 @@ typedef MPI_Datatype data_type ;
 typedef MPI_Op       RawType_MPI_Op ;
 typedef MPI_Status   RawType_MPI_Status ;
 #define RawValue_MPI_COMM_SELF  MPI_COMM_SELF
-#define RawValue_MPI_IN_PLACE   MPI_IN_PLACE
 #define RawValue_MPI_ANY_SOURCE MPI_ANY_SOURCE
 #define RawValue_MPI_CHAR       MPI_CHAR
 #define RawValue_MPI_INT        MPI_INT
@@ -62,7 +61,6 @@ struct data_type { };
 typedef int RawType_MPI_Op;
 typedef int RawType_MPI_Status;
 #define RawValue_MPI_COMM_SELF   0
-#define RawValue_MPI_IN_PLACE    0
 #define RawValue_MPI_ANY_SOURCE -1
 #define RawValue_MPI_CHAR        0
 #define RawValue_MPI_INT         1

--- a/src/core/inc/exceptions.h
+++ b/src/core/inc/exceptions.h
@@ -29,7 +29,11 @@
 #include <stdexcept>
 #include <string>
 #include <exception>    // std::set_terminate
-#include <mpi.h>        // for MPI_ABORT in uncaught exceptions
+
+#ifdef QUESO_HAS_MPI
+#include <mpi.h>
+#endif
+
 #include <stdlib.h>     // exit(1)
 
 namespace QUESO

--- a/src/core/src/BasicPdfsBase.C
+++ b/src/core/src/BasicPdfsBase.C
@@ -23,7 +23,6 @@
 //-----------------------------------------------------------------------el-
 
 #include <queso/BasicPdfsBase.h>
-#include <mpi.h>
 
 namespace QUESO {
 

--- a/src/core/src/BasicPdfsBoost.C
+++ b/src/core/src/BasicPdfsBoost.C
@@ -23,7 +23,6 @@
 //-----------------------------------------------------------------------el-
 
 #include <queso/BasicPdfsBoost.h>
-#include <mpi.h>
 
 namespace QUESO {
 

--- a/src/core/src/BasicPdfsGsl.C
+++ b/src/core/src/BasicPdfsGsl.C
@@ -25,7 +25,6 @@
 #include <queso/BasicPdfsGsl.h>
 #include <queso/Defines.h>
 #include <gsl/gsl_randist.h>
-#include <mpi.h>
 #include <math.h>
 
 namespace QUESO {

--- a/src/core/src/Defines.C
+++ b/src/core/src/Defines.C
@@ -23,15 +23,20 @@
 //-----------------------------------------------------------------------el-
 
 #include <queso/Defines.h>
+
+#ifdef QUESO_HAS_MPI
 #include <mpi.h>
+#endif
 
 namespace QUESO {
 
 int MyWorldfullRank() {
   int result = 0;
+#ifdef QUESO_HAS_MPI
   int iRC;
   iRC = MPI_Comm_rank(MPI_COMM_WORLD,&result);
   if (iRC) {}; // just to remove compiler warning
+#endif
   return result;
 }
 

--- a/src/core/src/Environment.C
+++ b/src/core/src/Environment.C
@@ -1111,6 +1111,7 @@ EmptyEnvironment::print(std::ostream& os) const
 //*****************************************************
 // Full Environment
 //*****************************************************
+#ifdef QUESO_HAS_MPI
 FullEnvironment::FullEnvironment(
   RawType_MPI_Comm             inputComm,
   const char*                    passedOptionsInputFileName,
@@ -1130,6 +1131,7 @@ FullEnvironment::FullEnvironment(
   queso_require_equal_to_msg(mpiRC, MPI_SUCCESS, "failed to get world fullRank()");
 
   m_fullComm = new MpiComm(*this,inputComm);
+
   m_fullRank     = m_fullComm->MyPID();
   m_fullCommSize = m_fullComm->NumProc();
 
@@ -1370,6 +1372,236 @@ FullEnvironment::FullEnvironment(
 
   return;
 }
+#endif  // QUESO_HAS_MPI
+
+FullEnvironment::FullEnvironment(
+  const char*                    passedOptionsInputFileName,
+  const char*                    prefix,
+  EnvOptionsValues* alternativeOptionsValues)
+  :
+  BaseEnvironment(passedOptionsInputFileName,alternativeOptionsValues)
+{
+#ifdef QUESO_MEMORY_DEBUGGING
+  std::cout << "Entering FullEnv" << std::endl;
+#endif
+
+  m_worldRank = 0;
+
+  m_fullComm = new MpiComm(*this);
+  m_fullRank     = 0;
+  m_fullCommSize = 1;
+
+#ifndef QUESO_HAS_MPI
+  m_fullGroup = 0;
+#endif
+
+  // saving old uncaught exception handler, invoking queso_terminate
+  old_terminate_handler = std::set_terminate(queso_terminate_handler);
+
+#ifdef QUESO_MEMORY_DEBUGGING
+  std::cout << "In FullEnv, finished dealing with MPI initially" << std::endl;
+#endif
+
+  //////////////////////////////////////////////////
+  // Read options
+  //////////////////////////////////////////////////
+  // If NULL, we create one
+  if (m_optionsObj == NULL) {
+    EnvOptionsValues * tempOptions = new EnvOptionsValues(this, prefix);
+
+    // If there's an input file, we grab the options from there.  Otherwise the
+    // defaults are used
+    if (m_optionsInputFileName != "") {
+      m_allOptionsMap  = new boost::program_options::variables_map();
+      m_allOptionsDesc = new boost::program_options::options_description("Allowed options");
+
+      readOptionsInputFile();
+    }
+
+    // We did this dance because scanOptionsValues is not a const method, but
+    // m_optionsObj is a pointer to const
+    m_optionsObj = tempOptions;
+  }
+
+  // If help option was supplied, print info
+  if (m_optionsObj->m_help != "") {
+    // We write to std::cout because subDisplayFile() isn't ready yet?
+    std::cout << (*m_optionsObj) << std::endl;
+  }
+
+  queso_require_equal_to_msg(
+      fullComm().NumProc() % m_optionsObj->m_numSubEnvironments, 0,
+      "total number of processors in environment must be multiple of the specified number of subEnvironments");
+
+#ifdef QUESO_MEMORY_DEBUGGING
+  std::cout << "In FullEnv, finished scanning options" << std::endl;
+#endif
+
+  // Only display these messages if the user wants them
+  // NOTE: This got moved below the Read Options section
+  // because we need the options to be read to know what
+  // the verbosity level is.
+  if (this->displayVerbosity() > 0) {
+    //////////////////////////////////////////////////
+    // Display main initial messages
+    // 'std::cout' is for: main trace messages + synchronized trace messages + error messages prior to 'exit()' or 'abort()'
+    //////////////////////////////////////////////////
+    /*int iRC = 0;*/
+    /*iRC = */gettimeofday(&m_timevalBegin, NULL);
+
+    QUESO_version_print(std::cout);
+
+    std::cout << "Beginning run at " << ctime(&m_timevalBegin.tv_sec)
+              << std::endl;
+  }
+
+  m_subId = 0;
+  char tmpSubId[16];
+  sprintf(tmpSubId,"%u",m_subId);
+  m_subIdString = tmpSubId;
+
+  if (m_optionsObj->m_subDisplayAllowAll) {
+    m_optionsObj->m_subDisplayAllowedSet.insert((unsigned int) m_subId);
+  }
+
+  int fullRanksOfMySubEnvironment = 1;
+
+#ifndef QUESO_HAS_MPI
+  m_subGroup = 0;
+#endif
+
+  m_subComm = new MpiComm(*this);
+  m_subRank     = 0;
+  m_subCommSize = 1;
+
+  //////////////////////////////////////////////////
+  // Deal with multiple subEnvironments: create the self communicator
+  //////////////////////////////////////////////////
+  m_selfComm = new MpiComm(*this);
+
+  //////////////////////////////////////////////////
+  // Deal with multiple subEnvironments: create the inter0 communicator
+  //////////////////////////////////////////////////
+  int fullRanksOfInter0 = 0;
+#ifndef QUESO_HAS_MPI
+  m_inter0Group = 0;
+#endif
+  m_inter0Comm = new MpiComm(*this);
+  m_inter0Rank     = 0;
+  m_inter0CommSize = 1;
+
+  if (m_optionsObj->m_subDisplayAllowAll) {
+    // This situation has been already taken care of above
+  }
+  else if (m_optionsObj->m_subDisplayAllowInter0) {
+    if (m_inter0Rank >= 0) {
+      m_optionsObj->m_subDisplayAllowedSet.insert((unsigned int) m_subId);
+    }
+  }
+
+
+  //////////////////////////////////////////////////
+  // Open "screen" file
+  //////////////////////////////////////////////////
+  bool openFile = false;
+  if ((m_subRank                                               == 0                                              ) &&
+      (m_optionsObj->m_subDisplayFileName                 != UQ_ENV_FILENAME_FOR_NO_OUTPUT_FILE             ) &&
+      (m_optionsObj->m_subDisplayAllowedSet.find(m_subId) != m_optionsObj->m_subDisplayAllowedSet.end())) {
+    openFile = true;
+  }
+
+  if (openFile && m_worldRank == 0) {
+    //////////////////////////////////////////////////////////////////
+    // Verify parent directory exists (for cases when a user
+    // specifies a relative path for the desired output file).
+    //////////////////////////////////////////////////////////////////
+    int irtrn = CheckFilePath((m_optionsObj->m_subDisplayFileName+"_sub"+m_subIdString+".txt").c_str());
+    queso_require_greater_equal_msg(irtrn, 0, "unable to verify output path");
+  }
+
+  ////////////////////////////////////////////////////////////////////
+  // Ensure that rank 0 has created path, if necessary, before other tasks use it
+  ////////////////////////////////////////////////////////////////////
+  m_fullComm->Barrier();
+
+  if (openFile) {
+    //////////////////////////////////////////////////////////////////
+    // Always write over an eventual pre-existing file
+    //////////////////////////////////////////////////////////////////
+    m_subDisplayFile = new std::ofstream((m_optionsObj->m_subDisplayFileName+"_sub"+m_subIdString+".txt").c_str(),
+                                         std::ofstream::out | std::ofstream::trunc);
+    queso_require_msg((m_subDisplayFile && m_subDisplayFile->is_open()), "failed to open sub screen file");
+
+    QUESO_version_print(*m_subDisplayFile);
+
+    *m_subDisplayFile << "Beginning run at " << ctime(&m_timevalBegin.tv_sec)
+                      << std::endl;
+  }
+
+  //////////////////////////////////////////////////
+  // Debug message related to subEnvironments
+  //////////////////////////////////////////////////
+  if (this->displayVerbosity() >= 2) {
+    for (int i = 0; i < m_fullCommSize; ++i) {
+      if (i == m_fullRank) {
+        //std::cout << "In FullEnvironment::commonConstructor()"
+        std::cout << "MPI node of worldRank "             << m_worldRank
+                  << " has fullRank "                     << m_fullRank
+                  << ", belongs to subEnvironment of id " << m_subId
+                  << ", and has subRank "                 << m_subRank
+                  << std::endl;
+
+        std::cout << "MPI node of worldRank " << m_worldRank
+                  << " belongs to sub communicator with full ranks";
+          std::cout << " " << fullRanksOfMySubEnvironment;
+  std::cout << "\n";
+
+        if (m_inter0Comm) {
+          std::cout << "MPI node of worldRank " << m_worldRank
+                    << " also belongs to inter0 communicator with full ranks";
+            std::cout << " " << fullRanksOfInter0;
+          std::cout << ", and has inter0Rank " << m_inter0Rank;
+        }
+  std::cout << "\n";
+
+  std::cout << std::endl;
+      }
+      m_fullComm->Barrier();
+    }
+  }
+
+  //////////////////////////////////////////////////
+  // Deal with seed
+  //////////////////////////////////////////////////
+  if (m_optionsObj->m_rngType == "gsl") {
+    m_rngObject = new RngGsl(m_optionsObj->m_seed,m_worldRank);
+    m_basicPdfs = new BasicPdfsGsl(m_worldRank);
+  }
+  else if (m_optionsObj->m_rngType == "boost") {
+    m_rngObject = new RngBoost(m_optionsObj->m_seed,m_worldRank);
+    m_basicPdfs = new BasicPdfsBoost(m_worldRank);
+  }
+  else {
+    std::cerr << "In Environment::constructor()"
+              << ": rngType = " << m_optionsObj->m_rngType
+              << std::endl;
+    queso_error_msg("the requested 'rngType' is not supported yet");
+  }
+
+  //////////////////////////////////////////////////
+  // Leave commonConstructor()
+  //////////////////////////////////////////////////
+  m_fullComm->Barrier();
+  m_fullEnvIsReady = true;
+
+  if ((m_subDisplayFile) && (this->displayVerbosity() >= 5)) {
+    *m_subDisplayFile << "Done with initializations at FullEnvironment::commonConstructor()"
+                      << std::endl;
+  }
+
+  return;
+}
+
 //-------------------------------------------------------
 FullEnvironment::~FullEnvironment()
 {
@@ -1384,6 +1616,7 @@ FullEnvironment::print(std::ostream& os) const
 
 void queso_terminate_handler()
 {
+#ifdef QUESO_HAS_MPI
   int mpi_initialized;
   MPI_Initialized (&mpi_initialized);
 
@@ -1399,6 +1632,9 @@ void queso_terminate_handler()
       // their own terminate handler that we want to call.
       old_terminate_handler();
     }
+#else
+  old_terminate_handler();
+#endif
   exit(1);
 }
 

--- a/src/core/src/GslMatrix.C
+++ b/src/core/src/GslMatrix.C
@@ -1685,7 +1685,7 @@ GslMatrix::mpiSum( const MpiComm& comm, GslMatrix& M_global ) const
 	}
     }
 
-  comm.Allreduce((void*) &local[0], (void*) &global[0], size, RawValue_MPI_DOUBLE, RawValue_MPI_SUM,
+  comm.Allreduce<double>(&local[0], &global[0], size, RawValue_MPI_SUM,
                  "GslMatrix::mpiSum()",
                  "failed MPI.Allreduce()");
 

--- a/src/core/src/GslVector.C
+++ b/src/core/src/GslVector.C
@@ -643,7 +643,7 @@ GslVector::mpiBcast(int srcRank, const MpiComm& bcastComm)
   // Check number of participant nodes
   double localNumNodes = 1.;
   double totalNumNodes = 0.;
-  bcastComm.Allreduce((void *) &localNumNodes, (void *) &totalNumNodes, (int) 1, RawValue_MPI_DOUBLE, RawValue_MPI_SUM,
+  bcastComm.Allreduce<double>(&localNumNodes, &totalNumNodes, (int) 1, RawValue_MPI_SUM,
                       "GslVector::mpiBcast()",
                       "failed MPI.Allreduce() for numNodes");
   queso_require_equal_to_msg(((int) totalNumNodes), bcastComm.NumProc(), "inconsistent numNodes");
@@ -651,7 +651,7 @@ GslVector::mpiBcast(int srcRank, const MpiComm& bcastComm)
   // Check that all participant nodes have the same vector size
   double localVectorSize  = this->sizeLocal();
   double sumOfVectorSizes = 0.;
-  bcastComm.Allreduce((void *) &localVectorSize, (void *) &sumOfVectorSizes, (int) 1, RawValue_MPI_DOUBLE, RawValue_MPI_SUM,
+  bcastComm.Allreduce<double>(&localVectorSize, &sumOfVectorSizes, (int) 1, RawValue_MPI_SUM,
                       "GslVector::mpiBcast()",
                       "failed MPI.Allreduce() for vectorSize");
 
@@ -698,7 +698,7 @@ GslVector::mpiAllReduce(RawType_MPI_Op mpiOperation, const MpiComm& opComm, GslV
   for (unsigned int i = 0; i < size; ++i) {
     double srcValue = (*this)[i];
     double resultValue = 0.;
-    opComm.Allreduce((void *) &srcValue, (void *) &resultValue, (int) 1, RawValue_MPI_DOUBLE, mpiOperation,
+    opComm.Allreduce<double>(&srcValue, &resultValue, (int) 1, mpiOperation,
                      "GslVector::mpiAllReduce()",
                      "failed MPI.Allreduce()");
     resultVec[i] = resultValue;
@@ -721,7 +721,7 @@ GslVector::mpiAllQuantile(double probability, const MpiComm& opComm, GslVector& 
   for (unsigned int i = 0; i < size; ++i) {
     double auxDouble = (int) (*this)[i];
     std::vector<double> vecOfDoubles(opComm.NumProc(),0.);
-    opComm.Gather((void *) &auxDouble, 1, RawValue_MPI_DOUBLE, (void *) &vecOfDoubles[0], (int) 1, RawValue_MPI_DOUBLE, 0,
+    opComm.Gather<double>(&auxDouble, 1, &vecOfDoubles[0], (int) 1, 0,
                   "GslVector::mpiAllQuantile()",
                   "failed MPI.Gather()");
 

--- a/src/core/src/RngBase.C
+++ b/src/core/src/RngBase.C
@@ -23,7 +23,6 @@
 //-----------------------------------------------------------------------el-
 
 #include <queso/RngBase.h>
-#include <mpi.h>
 
 namespace QUESO {
 

--- a/src/core/src/RngBoost.C
+++ b/src/core/src/RngBoost.C
@@ -23,7 +23,6 @@
 //-----------------------------------------------------------------------el-
 
 #include <queso/RngBoost.h>
-#include <mpi.h>
 
 namespace QUESO {
 

--- a/src/core/src/RngGsl.C
+++ b/src/core/src/RngGsl.C
@@ -25,7 +25,6 @@
 #include <queso/Defines.h>
 #include <queso/RngGsl.h>
 #include <gsl/gsl_randist.h>
-#include <mpi.h>
 
 namespace QUESO {
 

--- a/src/core/src/TeuchosMatrix.C
+++ b/src/core/src/TeuchosMatrix.C
@@ -1673,7 +1673,7 @@ TeuchosMatrix::mpiSum( const MpiComm& comm, TeuchosMatrix& M_global ) const
 	  }
   }
 
-  comm.Allreduce((void*) &local[0], (void*) &global[0], size, RawValue_MPI_DOUBLE, RawValue_MPI_SUM,
+  comm.Allreduce<double>(&local[0], &global[0], size, RawValue_MPI_SUM,
                  "TeuchosMatrix::mpiSum()",
                  "failed MPI.Allreduce()");
 

--- a/src/core/src/TeuchosVector.C
+++ b/src/core/src/TeuchosVector.C
@@ -737,7 +737,7 @@ TeuchosVector::mpiBcast(int srcRank, const MpiComm& bcastComm)
   // Check number of participant nodes
   double localNumNodes = 1.;
   double totalNumNodes = 0.;
-  bcastComm.Allreduce((void *) &localNumNodes, (void *) &totalNumNodes, (int) 1, RawValue_MPI_DOUBLE, RawValue_MPI_SUM,
+  bcastComm.Allreduce<double>(&localNumNodes, &totalNumNodes, (int) 1, RawValue_MPI_SUM,
                       "TeuchosVector::mpiBcast()",
                       "failed MPI.Allreduce() for numNodes");
   queso_require_equal_to_msg(((int) totalNumNodes), bcastComm.NumProc(), "inconsistent numNodes");
@@ -745,7 +745,7 @@ TeuchosVector::mpiBcast(int srcRank, const MpiComm& bcastComm)
   // Check that all participant nodes have the same vector size
   double localVectorSize  = this->sizeLocal();
   double sumOfVectorSizes = 0.;
-  bcastComm.Allreduce((void *) &localVectorSize, (void *) &sumOfVectorSizes, (int) 1, RawValue_MPI_DOUBLE, RawValue_MPI_SUM,
+  bcastComm.Allreduce<double>(&localVectorSize, &sumOfVectorSizes, (int) 1, RawValue_MPI_SUM,
                       "TeuchosVector::mpiBcast()",
                       "failed MPI.Allreduce() for vectorSize");
 
@@ -794,7 +794,7 @@ TeuchosVector::mpiAllReduce(RawType_MPI_Op mpiOperation, const MpiComm& opComm, 
   for (unsigned int i = 0; i < size; ++i) {
     double srcValue = (*this)[i];
     double resultValue = 0.;
-    opComm.Allreduce((void *) &srcValue, (void *) &resultValue, (int) 1, RawValue_MPI_DOUBLE, mpiOperation,
+    opComm.Allreduce<double>(&srcValue, &resultValue, (int) 1, mpiOperation,
                      "TeuchosVector::mpiAllReduce()",
                      "failed MPI.Allreduce()");
     resultVec[i] = resultValue;
@@ -819,7 +819,7 @@ TeuchosVector::mpiAllQuantile(double probability, const MpiComm& opComm, Teuchos
   for (unsigned int i = 0; i < size; ++i) {
     double auxDouble = (int) (*this)[i];
     std::vector<double> vecOfDoubles(opComm.NumProc(),0.);
-    opComm.Gather((void *) &auxDouble, 1, RawValue_MPI_DOUBLE, (void *) &vecOfDoubles[0], (int) 1, RawValue_MPI_DOUBLE, 0,
+    opComm.Gather<double>(&auxDouble, 1, &vecOfDoubles[0], (int) 1, 0,
                   "TeuchosVector::mpiAllQuantile()",
                   "failed MPI.Gather()");
 

--- a/src/misc/src/Miscellaneous.C
+++ b/src/misc/src/Miscellaneous.C
@@ -486,7 +486,7 @@ MiscCheckForSameValueInAllNodes(T&                    inputValue, // Yes, 'not' 
 
   double localValue = (double) inputValue;
   double sumValue = 0.;
-  comm.Allreduce((void *) &localValue, (void *) &sumValue, (int) 1, RawValue_MPI_DOUBLE, RawValue_MPI_SUM,
+  comm.Allreduce<double>(&localValue, &sumValue, (int) 1, RawValue_MPI_SUM,
                  whereString,
                  "failed MPI on 'sumValue' inside MiscCheckForSameValueInAllNodes()");
 
@@ -496,7 +496,7 @@ MiscCheckForSameValueInAllNodes(T&                    inputValue, // Yes, 'not' 
 #if 1
   unsigned int boolResult = 0;
   if (testValue > acceptableTreshold) boolResult = 1;
-  comm.Allreduce((void *) &boolResult, (void *) &boolSum, (int) 1, RawValue_MPI_UNSIGNED, RawValue_MPI_SUM,
+  comm.Allreduce<unsigned int>(&boolResult, &boolSum, (int) 1, RawValue_MPI_SUM,
                  whereString,
                  "failed MPI on 'boolSum' inside MiscCheckForSameValueInAllNodes()");
 

--- a/src/stats/inc/MetropolisHastingsSG.h
+++ b/src/stats/inc/MetropolisHastingsSG.h
@@ -87,7 +87,7 @@ struct MHRawChainInfoStruct
   void reset ();
 
   //! Calculates the MPI sum of \c this.
-  void mpiSum(const MpiComm& comm, MHRawChainInfoStruct& sumInfo) const;
+  void mpiSum(const MpiComm& comm, MHRawChainInfoStruct& sumInfo);
   //@}
 
   double       runTime;

--- a/src/stats/src/MLSampling.C
+++ b/src/stats/src/MLSampling.C
@@ -172,7 +172,7 @@ MLSampling<P_V,P_M>::decideOnBalancedChains_all(
       // Gather information at proc 0: number of chains and positions per node
       //////////////////////////////////////////////////////////////////////////
       unsigned int auxUInt = indexOfFirstWeight;
-      m_env.inter0Comm().Gather((void *) &auxUInt, 1, RawValue_MPI_UNSIGNED, (void *) &allFirstIndexes[0], (int) 1, RawValue_MPI_UNSIGNED, 0, // LOAD BALANCE
+      m_env.inter0Comm().template Gather<unsigned int>(&auxUInt, 1, &allFirstIndexes[0], (int) 1, 0, // LOAD BALANCE
                                 "MLSampling<P_V,P_M>::decideOnBalancedChains_all()",
                                 "failed MPI.Gather() for first indexes");
 
@@ -181,7 +181,7 @@ MLSampling<P_V,P_M>::decideOnBalancedChains_all(
       }
 
       auxUInt = indexOfLastWeight;
-      m_env.inter0Comm().Gather((void *) &auxUInt, 1, RawValue_MPI_UNSIGNED, (void *) &allLastIndexes[0], (int) 1, RawValue_MPI_UNSIGNED, 0, // LOAD BALANCE
+      m_env.inter0Comm().template Gather<unsigned int>(&auxUInt, 1, &allLastIndexes[0], (int) 1, 0, // LOAD BALANCE
                                 "MLSampling<P_V,P_M>::decideOnBalancedChains_all()",
                                 "failed MPI.Gather() for last indexes");
 
@@ -416,7 +416,7 @@ MLSampling<P_V,P_M>::prepareBalLinkedChains_inter0( // EXTRA FOR LOAD BALANCE
   std::vector<double> auxBuf(1,0.);
   double minRatio = 0.;
   auxBuf[0] = finalRatioOfPosPerNode;
-  m_env.inter0Comm().Allreduce((void *) &auxBuf[0], (void *) &minRatio, (int) auxBuf.size(), RawValue_MPI_DOUBLE, RawValue_MPI_MIN, // LOAD BALANCE
+  m_env.inter0Comm().template Allreduce<double>(&auxBuf[0], &minRatio, (int) auxBuf.size(), RawValue_MPI_MIN, // LOAD BALANCE
                                "MLSampling<P_V,P_M>::prepareBalLinkedChains_inter0()",
                                "failed MPI.Allreduce() for min");
   //std::cout << m_env.worldRank() << ", minRatio = " << minRatio << std::endl;
@@ -424,7 +424,7 @@ MLSampling<P_V,P_M>::prepareBalLinkedChains_inter0( // EXTRA FOR LOAD BALANCE
 
   double maxRatio = 0.;
   auxBuf[0] = finalRatioOfPosPerNode;
-  m_env.inter0Comm().Allreduce((void *) &auxBuf[0], (void *) &maxRatio, (int) auxBuf.size(), RawValue_MPI_DOUBLE, RawValue_MPI_MAX, // LOAD BALANCE
+  m_env.inter0Comm().template Allreduce<double>(&auxBuf[0], &maxRatio, (int) auxBuf.size(), RawValue_MPI_MAX, // LOAD BALANCE
                                "MLSampling<P_V,P_M>::prepareBalLinkedChains_inter0()",
                                "failed MPI.Allreduce() for max");
   //std::cout << m_env.worldRank() << ", maxRatio = " << maxRatio << std::endl;
@@ -526,19 +526,19 @@ MLSampling<P_V,P_M>::prepareUnbLinkedChains_inter0(
 
   unsigned int minModifiedSubNumSamples = 0;
   auxBuf[0] = subNumSamples;
-  m_env.inter0Comm().Allreduce((void *) &auxBuf[0], (void *) &minModifiedSubNumSamples, (int) auxBuf.size(), RawValue_MPI_UNSIGNED, RawValue_MPI_MIN,
+  m_env.inter0Comm().template Allreduce<unsigned int>(&auxBuf[0], &minModifiedSubNumSamples, (int) auxBuf.size(), RawValue_MPI_MIN,
                                "MLSampling<P_V,P_M>::prepareUnbLinkedChains_inter0()",
                                "failed MPI.Allreduce() for min");
 
   unsigned int maxModifiedSubNumSamples = 0;
   auxBuf[0] = subNumSamples;
-  m_env.inter0Comm().Allreduce((void *) &auxBuf[0], (void *) &maxModifiedSubNumSamples, (int) auxBuf.size(), RawValue_MPI_UNSIGNED, RawValue_MPI_MAX,
+  m_env.inter0Comm().template Allreduce<unsigned int>(&auxBuf[0], &maxModifiedSubNumSamples, (int) auxBuf.size(), RawValue_MPI_MAX,
                                "MLSampling<P_V,P_M>::prepareUnbLinkedChains_inter0()",
                                "failed MPI.Allreduce() for max");
 
   unsigned int sumModifiedSubNumSamples = 0;
   auxBuf[0] = subNumSamples;
-  m_env.inter0Comm().Allreduce((void *) &auxBuf[0], (void *) &sumModifiedSubNumSamples, (int) auxBuf.size(), RawValue_MPI_UNSIGNED, RawValue_MPI_SUM,
+  m_env.inter0Comm().template Allreduce<unsigned int>(&auxBuf[0], &sumModifiedSubNumSamples, (int) auxBuf.size(), RawValue_MPI_SUM,
                                "MLSampling<P_V,P_M>::prepareUnbLinkedChains_inter0()",
                                "failed MPI.Allreduce() for sum");
 
@@ -672,19 +672,19 @@ MLSampling<P_V,P_M>::generateBalLinkedChains_all( // EXTRA FOR LOAD BALANCE
 
     unsigned int minNumberOfPositions = 0;
     auxBuf[0] = numberOfPositions;
-    m_env.inter0Comm().Allreduce((void *) &auxBuf[0], (void *) &minNumberOfPositions, (int) auxBuf.size(), RawValue_MPI_UNSIGNED, RawValue_MPI_MIN, // LOAD BALANCE
+    m_env.inter0Comm().template Allreduce<unsigned int>(&auxBuf[0], &minNumberOfPositions, (int) auxBuf.size(), RawValue_MPI_MIN, // LOAD BALANCE
                                  "MLSampling<P_V,P_M>::generateBalLinkedChains_all()",
                                  "failed MPI.Allreduce() for min");
 
     unsigned int maxNumberOfPositions = 0;
     auxBuf[0] = numberOfPositions;
-    m_env.inter0Comm().Allreduce((void *) &auxBuf[0], (void *) &maxNumberOfPositions, (int) auxBuf.size(), RawValue_MPI_UNSIGNED, RawValue_MPI_MAX, // LOAD BALANCE
+    m_env.inter0Comm().template Allreduce<unsigned int>(&auxBuf[0], &maxNumberOfPositions, (int) auxBuf.size(), RawValue_MPI_MAX, // LOAD BALANCE
                                  "MLSampling<P_V,P_M>::generateBalLinkedChains_all()",
                                  "failed MPI.Allreduce() for max");
 
     unsigned int sumNumberOfPositions = 0;
     auxBuf[0] = numberOfPositions;
-    m_env.inter0Comm().Allreduce((void *) &auxBuf[0], (void *) &sumNumberOfPositions, (int) auxBuf.size(), RawValue_MPI_UNSIGNED, RawValue_MPI_SUM, // LOAD BALANCE
+    m_env.inter0Comm().template Allreduce<unsigned int>(&auxBuf[0], &sumNumberOfPositions, (int) auxBuf.size(), RawValue_MPI_SUM, // LOAD BALANCE
                                  "MLSampling<P_V,P_M>::generateBalLinkedChains_all()",
                                  "failed MPI.Allreduce() for sum");
 
@@ -937,19 +937,19 @@ MLSampling<P_V,P_M>::generateUnbLinkedChains_all(
 
     unsigned int minNumberOfPositions = 0;
     auxBuf[0] = numberOfPositions;
-    m_env.inter0Comm().Allreduce((void *) &auxBuf[0], (void *) &minNumberOfPositions, (int) auxBuf.size(), RawValue_MPI_UNSIGNED, RawValue_MPI_MIN,
+    m_env.inter0Comm().template Allreduce<unsigned int>(&auxBuf[0], &minNumberOfPositions, (int) auxBuf.size(), RawValue_MPI_MIN,
                                  "MLSampling<P_V,P_M>::generateUnbLinkedChains_all()",
                                  "failed MPI.Allreduce() for min");
 
     unsigned int maxNumberOfPositions = 0;
     auxBuf[0] = numberOfPositions;
-    m_env.inter0Comm().Allreduce((void *) &auxBuf[0], (void *) &maxNumberOfPositions, (int) auxBuf.size(), RawValue_MPI_UNSIGNED, RawValue_MPI_MAX,
+    m_env.inter0Comm().template Allreduce<unsigned int>(&auxBuf[0], &maxNumberOfPositions, (int) auxBuf.size(), RawValue_MPI_MAX,
                                  "MLSampling<P_V,P_M>::generateUnbLinkedChains_all()",
                                  "failed MPI.Allreduce() for max");
 
     unsigned int sumNumberOfPositions = 0;
     auxBuf[0] = numberOfPositions;
-    m_env.inter0Comm().Allreduce((void *) &auxBuf[0], (void *) &sumNumberOfPositions, (int) auxBuf.size(), RawValue_MPI_UNSIGNED, RawValue_MPI_SUM,
+    m_env.inter0Comm().template Allreduce<unsigned int>(&auxBuf[0], &sumNumberOfPositions, (int) auxBuf.size(), RawValue_MPI_SUM,
                                  "MLSampling<P_V,P_M>::generateUnbLinkedChains_all()",
                                  "failed MPI.Allreduce() for sum");
 
@@ -1940,9 +1940,11 @@ MLSampling<P_V,P_M>::mpiExchangePositions_inter0( // EXTRA FOR LOAD BALANCE
                                  "failed MPI.Gatherv()");
     }
 #else
-    m_env.inter0Comm().Gatherv((void *) &sendbuf[0], (int) sendcnt, RawValue_MPI_DOUBLE, (void *) &recvbuf[0], (int *) &recvcnts[0], (int *) &displs[0], RawValue_MPI_DOUBLE, r, // LOAD BALANCE
-                               "MLSampling<P_V,P_M>::mpiExchangePositions_inter0()",
-                               "failed MPI.Gatherv()");
+    m_env.inter0Comm().template Gatherv<double>(&sendbuf[0], (int) sendcnt,
+        &recvbuf[0], (int *) &recvcnts[0], (int *) &displs[0],
+        r, // LOAD BALANCE
+        "MLSampling<P_V,P_M>::mpiExchangePositions_inter0()",
+        "failed MPI.Gatherv()");
 #endif
 
     //////////////////////////////////////////////////////////////////////////
@@ -2309,7 +2311,7 @@ MLSampling<P_V,P_M>::generateSequence_Level0_all(
 
     if (m_env.inter0Rank() >= 0) {
       unsigned int tmpSize = currOptions.m_rawChainSize;
-      m_env.inter0Comm().Allreduce((void *) &tmpSize, (void *) &unifiedRequestedNumSamples, (int) 1, RawValue_MPI_UNSIGNED, RawValue_MPI_SUM,
+      m_env.inter0Comm().template Allreduce<unsigned int>(&tmpSize, &unifiedRequestedNumSamples, (int) 1, RawValue_MPI_SUM,
                                    "MLSampling<P_V,P_M>::generateSequence()",
                                    "failed MPI.Allreduce() for requested num samples in level 0");
     }
@@ -2455,7 +2457,7 @@ MLSampling<P_V,P_M>::generateSequence_Step01_inter0(
       unsigned int tmpSize = currOptions->m_rawChainSize;
       // This computed 'unifiedRequestedNumSamples' needs to be recomputed only at the last
       // level, when 'currOptions' is replaced by 'lastLevelOptions' (see step 3 of 11)
-      m_env.inter0Comm().Allreduce((void *) &tmpSize, (void *) &unifiedRequestedNumSamples, (int) 1, RawValue_MPI_UNSIGNED, RawValue_MPI_SUM,
+      m_env.inter0Comm().template Allreduce<unsigned int>(&tmpSize, &unifiedRequestedNumSamples, (int) 1, RawValue_MPI_SUM,
                                    "MLSampling<P_V,P_M>::generateSequence()",
                                    "failed MPI.Allreduce() for requested num samples in step 1");
 
@@ -2717,7 +2719,7 @@ MLSampling<P_V,P_M>::generateSequence_Step03_inter0(
           }
 #endif
         }
-        m_env.inter0Comm().Allreduce((void *) &subWeightRatioSum, (void *) &unifiedWeightRatioSum, (int) 1, RawValue_MPI_DOUBLE, RawValue_MPI_SUM,
+        m_env.inter0Comm().template Allreduce<double>(&subWeightRatioSum, &unifiedWeightRatioSum, (int) 1, RawValue_MPI_SUM,
                                      "MLSampling<P_V,P_M>::generateSequence()",
                                      "failed MPI.Allreduce() for weight ratio sum");
 
@@ -2775,7 +2777,7 @@ MLSampling<P_V,P_M>::generateSequence_Step03_inter0(
 
         double subQuantity = effectiveSampleSize;
         effectiveSampleSize = 0.;
-        m_env.inter0Comm().Allreduce((void *) &subQuantity, (void *) &effectiveSampleSize, (int) 1, RawValue_MPI_DOUBLE, RawValue_MPI_SUM,
+        m_env.inter0Comm().template Allreduce<double>(&subQuantity, &effectiveSampleSize, (int) 1, RawValue_MPI_SUM,
                                      "MLSampling<P_V,P_M>::generateSequence()",
                                      "failed MPI.Allreduce() for effective sample size");
 
@@ -2964,7 +2966,7 @@ MLSampling<P_V,P_M>::generateSequence_Step04_inter0(
           double localValue = subCovMatrix(i,j);
           double sumValue = 0.;
           if (m_env.inter0Rank() >= 0) {
-            m_env.inter0Comm().Allreduce((void *) &localValue, (void *) &sumValue, (int) 1, RawValue_MPI_DOUBLE, RawValue_MPI_SUM,
+            m_env.inter0Comm().template Allreduce<double>(&localValue, &sumValue, (int) 1, RawValue_MPI_SUM,
                                          "MLSampling<P_V,P_M>::generateSequence()",
                                          "failed MPI.Allreduce() for cov matrix");
           }
@@ -3573,7 +3575,7 @@ MLSampling<P_V,P_M>::generateSequence_Step09_all(
         if (m_env.inter0Rank() >= 0) { // KAUST
           // If only one cov matrix is used, then the rejection should be assessed among all inter0Comm nodes // KAUST3
           unsigned int nowUnifiedRejections = 0;
-          m_env.inter0Comm().Allreduce((void *) &nowRejections, (void *) &nowUnifiedRejections, (int) 1, RawValue_MPI_UNSIGNED, RawValue_MPI_SUM,
+          m_env.inter0Comm().template Allreduce<unsigned int>(&nowRejections, &nowUnifiedRejections, (int) 1, RawValue_MPI_SUM,
                                        "MLSampling<P_V,P_M>::generateSequence_Step09_all()",
                                        "failed MPI.Allreduce() for now rejections");
 
@@ -3947,7 +3949,7 @@ MLSampling<P_V,P_M>::generateSequence_Step11_inter0(
     // Check if unified size of generated chain matches the unified requested size // KAUST
     unsigned int tmpSize = currChain.subSequenceSize();
     unsigned int unifiedGeneratedNumSamples = 0;
-    m_env.inter0Comm().Allreduce((void *) &tmpSize, (void *) &unifiedGeneratedNumSamples, (int) 1, RawValue_MPI_UNSIGNED, RawValue_MPI_SUM,
+    m_env.inter0Comm().template Allreduce<unsigned int>(&tmpSize, &unifiedGeneratedNumSamples, (int) 1, RawValue_MPI_SUM,
                                  "MLSampling<P_V,P_M>::generateSequence()",
                                  "failed MPI.Allreduce() for generated num samples in step 11");
     //std::cout << "unifiedGeneratedNumSamples = "   << unifiedGeneratedNumSamples
@@ -3957,7 +3959,7 @@ MLSampling<P_V,P_M>::generateSequence_Step11_inter0(
   }
 
   // Compute unified number of rejections
-  m_env.inter0Comm().Allreduce((void *) &cumulativeRawChainRejections, (void *) &unifiedNumberOfRejections, (int) 1, RawValue_MPI_UNSIGNED, RawValue_MPI_SUM,
+  m_env.inter0Comm().template Allreduce<unsigned int>(&cumulativeRawChainRejections, &unifiedNumberOfRejections, (int) 1, RawValue_MPI_SUM,
                                "MLSampling<P_V,P_M>::generateSequence()",
                                "failed MPI.Allreduce() for number of rejections");
 
@@ -4376,7 +4378,7 @@ MLSampling<P_V,P_M>::generateSequence(
         // It is necessary to recompute 'currUnifiedRequestedNumSamples' because
         // 'currOptions' has just been replaced by 'lastLevelOptions'
         unsigned int tmpSize = currOptions->m_rawChainSize;
-        m_env.inter0Comm().Allreduce((void *) &tmpSize, (void *) &currUnifiedRequestedNumSamples, (int) 1, RawValue_MPI_UNSIGNED, RawValue_MPI_SUM,
+        m_env.inter0Comm().template Allreduce<unsigned int>(&tmpSize, &currUnifiedRequestedNumSamples, (int) 1, RawValue_MPI_SUM,
                                      "MLSampling<P_V,P_M>::generateSequence()",
                                      "failed MPI.Allreduce() for requested num samples in step 3");
       }
@@ -4668,33 +4670,33 @@ MLSampling<P_V,P_M>::generateSequence(
 
     if (m_env.inter0Rank() >= 0) {
       double minCumulativeRawChainRunTime = 0.;
-      m_env.inter0Comm().Allreduce((void *) &cumulativeRawChainRunTime, (void *) &minCumulativeRawChainRunTime, (int) 1, RawValue_MPI_DOUBLE, RawValue_MPI_MIN,
+      m_env.inter0Comm().template Allreduce<double>(&cumulativeRawChainRunTime, &minCumulativeRawChainRunTime, (int) 1, RawValue_MPI_MIN,
                                    "MLSampling<P_V,P_M>::generateSequence()",
                                    "failed MPI.Allreduce() for min cumulative raw chain run time");
 
       double maxCumulativeRawChainRunTime = 0.;
-      m_env.inter0Comm().Allreduce((void *) &cumulativeRawChainRunTime, (void *) &maxCumulativeRawChainRunTime, (int) 1, RawValue_MPI_DOUBLE, RawValue_MPI_MAX,
+      m_env.inter0Comm().template Allreduce<double>(&cumulativeRawChainRunTime, &maxCumulativeRawChainRunTime, (int) 1, RawValue_MPI_MAX,
                                    "MLSampling<P_V,P_M>::generateSequence()",
                                    "failed MPI.Allreduce() for max cumulative raw chain run time");
 
       double avgCumulativeRawChainRunTime = 0.;
-      m_env.inter0Comm().Allreduce((void *) &cumulativeRawChainRunTime, (void *) &avgCumulativeRawChainRunTime, (int) 1, RawValue_MPI_DOUBLE, RawValue_MPI_SUM,
+      m_env.inter0Comm().template Allreduce<double>(&cumulativeRawChainRunTime, &avgCumulativeRawChainRunTime, (int) 1, RawValue_MPI_SUM,
                                    "MLSampling<P_V,P_M>::generateSequence()",
                                    "failed MPI.Allreduce() for sum cumulative raw chain run time");
       avgCumulativeRawChainRunTime /= ((double) m_env.inter0Comm().NumProc());
 
       double minLevelRunTime = 0.;
-      m_env.inter0Comm().Allreduce((void *) &levelRunTime, (void *) &minLevelRunTime, (int) 1, RawValue_MPI_DOUBLE, RawValue_MPI_MIN,
+      m_env.inter0Comm().template Allreduce<double>(&levelRunTime, &minLevelRunTime, (int) 1, RawValue_MPI_MIN,
                                    "MLSampling<P_V,P_M>::generateSequence()",
                                    "failed MPI.Allreduce() for min level run time");
 
       double maxLevelRunTime = 0.;
-      m_env.inter0Comm().Allreduce((void *) &levelRunTime, (void *) &maxLevelRunTime, (int) 1, RawValue_MPI_DOUBLE, RawValue_MPI_MAX,
+      m_env.inter0Comm().template Allreduce<double>(&levelRunTime, &maxLevelRunTime, (int) 1, RawValue_MPI_MAX,
                                    "MLSampling<P_V,P_M>::generateSequence()",
                                    "failed MPI.Allreduce() for max level run time");
 
       double avgLevelRunTime = 0.;
-      m_env.inter0Comm().Allreduce((void *) &levelRunTime, (void *) &avgLevelRunTime, (int) 1, RawValue_MPI_DOUBLE, RawValue_MPI_SUM,
+      m_env.inter0Comm().template Allreduce<double>(&levelRunTime, &avgLevelRunTime, (int) 1, RawValue_MPI_SUM,
                                    "MLSampling<P_V,P_M>::generateSequence()",
                                    "failed MPI.Allreduce() for sum level run time");
       avgLevelRunTime /= ((double) m_env.inter0Comm().NumProc());

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -118,13 +118,13 @@ MHRawChainInfoStruct::copy(const MHRawChainInfoStruct& rhs)
 }
 //---------------------------------------------------
 void
-MHRawChainInfoStruct::mpiSum(const MpiComm& comm, MHRawChainInfoStruct& sumInfo) const
+MHRawChainInfoStruct::mpiSum(const MpiComm& comm, MHRawChainInfoStruct& sumInfo)
 {
-  comm.Allreduce((void *) &runTime, (void *) &sumInfo.runTime, (int) 7, RawValue_MPI_DOUBLE, RawValue_MPI_SUM,
+  comm.Allreduce<double>(&runTime, &sumInfo.runTime, (int) 7, RawValue_MPI_SUM,
                  "MHRawChainInfoStruct::mpiSum()",
                  "failed MPI.Allreduce() for sum of doubles");
 
-  comm.Allreduce((void *) &numTargetCalls, (void *) &sumInfo.numTargetCalls, (int) 5, RawValue_MPI_UNSIGNED, RawValue_MPI_SUM,
+  comm.Allreduce<unsigned int>(&numTargetCalls, &sumInfo.numTargetCalls, (int) 5, RawValue_MPI_SUM,
                  "MHRawChainInfoStruct::mpiSum()",
                  "failed MPI.Allreduce() for sum of unsigned ints");
 

--- a/src/surrogates/src/InterpolationSurrogateBuilder.C
+++ b/src/surrogates/src/InterpolationSurrogateBuilder.C
@@ -26,6 +26,7 @@
 #include <queso/InterpolationSurrogateBuilder.h>
 
 // QUESO
+#include <queso/MpiComm.h>
 #include <queso/GslVector.h>
 #include <queso/GslMatrix.h>
 #include <queso/InterpolationSurrogateHelper.h>
@@ -156,17 +157,15 @@ namespace QUESO
 
         /*! \todo Would be more efficient to pack local_n and local_values
             togethers and do Gatherv only once. */
-        inter0comm.Gatherv( &local_n[0], local_n.size(), MPI_UNSIGNED,
-                            &all_indices[0], &m_njobs[0], &strides[0], MPI_UNSIGNED,
-                            0 /*root*/,
-                            "InterpolationSurrogateBuilder::sync_data()",
-                            "MpiComm::gatherv() failed!" );
+        inter0comm.template Gatherv<unsigned int>(&local_n[0], local_n.size(),
+            &all_indices[0], &m_njobs[0], &strides[0],
+            0 /*root*/, "InterpolationSurrogateBuilder::sync_data()",
+            "MpiComm::gatherv() failed!");
 
-        inter0comm.Gatherv( &local_values[0], local_values.size(), MPI_DOUBLE,
-                            &all_values[0], &m_njobs[0], &strides[0], MPI_DOUBLE,
-                            0 /*root*/,
-                            "InterpolationSurrogateBuilder::sync_data()",
-                            "MpiComm::gatherv() failed!" );
+        inter0comm.template Gatherv<double>(&local_values[0],
+            local_values.size(), &all_values[0], &m_njobs[0], &strides[0],
+            0 /*root*/, "InterpolationSurrogateBuilder::sync_data()",
+            "MpiComm::gatherv() failed!");
 
         // Now set the values.
         /* PB: Although we are guaranteed per-rank ordering of the data we gathered,

--- a/src/surrogates/src/InterpolationSurrogateData.C
+++ b/src/surrogates/src/InterpolationSurrogateData.C
@@ -26,6 +26,7 @@
 #include <queso/InterpolationSurrogateData.h>
 
 // QUESO
+#include <queso/MpiComm.h>
 #include <queso/GslVector.h>
 #include <queso/GslMatrix.h>
 
@@ -120,7 +121,7 @@ namespace QUESO
     MpiComm full_comm = this->m_domain.env().fullComm();
 
     full_comm.Bcast( &this->m_values[0], this->n_values(),
-                     MPI_DOUBLE, root,
+                     RawValue_MPI_DOUBLE, root,
                      "InterpolationSurrogateData::sync_values()",
                      "MpiComm::Bcast() failed!" );
   }

--- a/src/surrogates/src/InterpolationSurrogateIOASCII.C
+++ b/src/surrogates/src/InterpolationSurrogateIOASCII.C
@@ -26,6 +26,7 @@
 #include <queso/InterpolationSurrogateIOASCII.h>
 
 // QUESO
+#include <queso/MpiComm.h>
 #include <queso/StreamUtilities.h>
 #include <queso/GslVector.h>
 #include <queso/GslMatrix.h>
@@ -70,7 +71,7 @@ namespace QUESO
       }
 
     // Broadcast the parsed dimension
-    full_comm.Bcast( &dim, 1, MPI_UNSIGNED, root,
+    full_comm.Bcast( &dim, 1, RawValue_MPI_UNSIGNED, root,
                      "InterpolationSurrogateIOASCII::read()",
                      "MpiComm::Bcast() failed!" );
 
@@ -99,7 +100,7 @@ namespace QUESO
       }
 
     // Broadcast m_n_points
-    full_comm.Bcast( &this->m_n_points[0], dim, MPI_UNSIGNED, root,
+    full_comm.Bcast( &this->m_n_points[0], dim, RawValue_MPI_UNSIGNED, root,
                      "InterpolationSurrogateIOASCII::read()",
                      "MpiComm::Bcast() failed!" );
 
@@ -123,11 +124,11 @@ namespace QUESO
       }
 
     // Broadcast the bounds
-    full_comm.Bcast( &param_mins[0], dim, MPI_DOUBLE, root,
+    full_comm.Bcast( &param_mins[0], dim, RawValue_MPI_DOUBLE, root,
                      "InterpolationSurrogateIOASCII::read()",
                      "MpiComm::Bcast() failed!" );
 
-    full_comm.Bcast( &param_maxs[0], dim, MPI_DOUBLE, root,
+    full_comm.Bcast( &param_maxs[0], dim, RawValue_MPI_DOUBLE, root,
                      "InterpolationSurrogateIOASCII::read()",
                      "MpiComm::Bcast() failed!" );
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -53,6 +53,7 @@ check_PROGRAMS += test_BoostInputOptionsParser
 check_PROGRAMS += test_NoInputFile
 check_PROGRAMS += test_optimizer_options
 check_PROGRAMS += test_SharedPtr
+check_PROGRAMS += test_serialEnv
 
 LDADD       = $(top_builddir)/src/libqueso.la
 
@@ -131,6 +132,7 @@ test_BoostInputOptionsParser_SOURCES = test_InputOptionsParser/test_BoostInputOp
 test_NoInputFile_SOURCES = test_StatisticalInverseProblem/test_NoInputFile.C
 test_optimizer_options_SOURCES = test_optimizer/test_optimizer_options.C
 test_SharedPtr_SOURCES = pointers/test_SharedPtr.C
+test_serialEnv_SOURCES = test_Environment/test_serialEnv.C
 
 # Files to freedom stamp
 srcstamp =
@@ -181,6 +183,7 @@ srcstamp += $(test_BoostInputOptionsParser_SOURCES)
 srcstamp += $(test_NoInputFile_SOURCES)
 srcstamp += $(test_optimizer_options_SOURCES)
 srcstamp += $(test_SharedPtr_SOURCES)
+srcstamp += $(test_serialEnv_SOURCES)
 
 TESTS =
 TESTS += $(top_builddir)/test/test_uqEnvironmentNonFatal
@@ -231,6 +234,7 @@ TESTS += $(top_builddir)/test/test_BoostInputOptionsParser
 TESTS += $(top_builddir)/test/test_NoInputFile
 TESTS += $(top_builddir)/test/test_optimizer_options
 TESTS += $(top_builddir)/test/test_SharedPtr
+TESTS += $(top_builddir)/test/test_serialEnv
 
 XFAIL_TESTS = $(top_builddir)/test/test_SequenceOfVectorsErase
 
@@ -260,6 +264,7 @@ EXTRA_DIST += test_InputOptionsParser/test_options_good.txt.in
 EXTRA_DIST += test_InputOptionsParser/test_options_bad.txt.in
 EXTRA_DIST += test_InputOptionsParser/test_options_default.txt.in
 EXTRA_DIST += test_optimizer/input_test_optimizer_options.in
+EXTRA_DIST += test_Environment/input_test_serialEnv.in
 
 CLEANFILES =
 CLEANFILES += test_Environment/debug_output_sub0.txt
@@ -276,6 +281,7 @@ clean-local:
 	rm -rf $(top_builddir)/test/test_outputNoInputFile
 	rm -rf $(top_builddir)/test/test_output_interp_surrogates
 	rm -rf $(top_builddir)/test/output_test_optimizer_options
+	rm -rf $(top_builddir)/test/output_test_serialEnv
 
 if CODE_COVERAGE_ENABLED
   CLEANFILES += *.gcda *.gcno

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -237,6 +237,10 @@ TESTS += $(top_builddir)/test/test_SharedPtr
 TESTS += $(top_builddir)/test/test_serialEnv
 
 XFAIL_TESTS = $(top_builddir)/test/test_SequenceOfVectorsErase
+if ! MPI_ENABLED
+XFAIL_TESTS += $(top_builddir)/test/test_SequenceOfVectors/test_unifiedPositionsOfMaximum.sh
+endif
+
 
 EXTRA_DIST =
 EXTRA_DIST += common/compare.pl

--- a/test/gsl_tests/get_min_max_vec.C
+++ b/test/gsl_tests/get_min_max_vec.C
@@ -31,14 +31,20 @@ int main(int argc, char* argv[])
   int return_flag = 0;
 
    // Initialize environment
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc,&argv);
   QUESO::FullEnvironment* env = new QUESO::FullEnvironment(MPI_COMM_WORLD,"input","",NULL);
+#else
+  QUESO::FullEnvironment* env = new QUESO::FullEnvironment("input","",NULL);
+#endif
 
   return_flag = actualChecking(env);
 
   // Deallocate pointers we created.
   delete env;
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   // Fin.
   return return_flag;

--- a/test/gsl_tests/get_set_row_column.C
+++ b/test/gsl_tests/get_set_row_column.C
@@ -31,13 +31,19 @@ int main(int argc, char* argv[])
   int return_flag = 0;
 
    // Initialize environment
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc,&argv);
   QUESO::FullEnvironment* env = new QUESO::FullEnvironment(MPI_COMM_WORLD,"input","",NULL);
+#else
+  QUESO::FullEnvironment* env = new QUESO::FullEnvironment("input","",NULL);
+#endif
 
   return_flag = actualChecking(env);
 
   delete env;
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   // Fin.
   return return_flag;

--- a/test/gsl_tests/inverse_power_method.C
+++ b/test/gsl_tests/inverse_power_method.C
@@ -35,14 +35,19 @@ int main(int argc, char* argv[])
   int return_flag = 0;
 
    // Initialize environment
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc,&argv);
-
   QUESO::FullEnvironment* env = new QUESO::FullEnvironment(MPI_COMM_WORLD,"input","",NULL);
+#else
+  QUESO::FullEnvironment* env = new QUESO::FullEnvironment("input","",NULL);
+#endif
 
   return_flag = actualChecking(env);
 
   delete env;
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   // Fin.
   return return_flag;

--- a/test/gsl_tests/multiple_rhs_matrix_solve.C
+++ b/test/gsl_tests/multiple_rhs_matrix_solve.C
@@ -31,14 +31,19 @@ int main(int argc, char* argv[])
   int return_flag = 0;
 
    // Initialize environment
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc,&argv);
-
   QUESO::FullEnvironment* env = new QUESO::FullEnvironment(MPI_COMM_WORLD,"input","",NULL);
+#else
+  QUESO::FullEnvironment* env = new QUESO::FullEnvironment("input","",NULL);
+#endif
 
   return_flag = actualChecking(env);
 
   delete env;
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   // Fin.
   return return_flag;

--- a/test/gsl_tests/power_method.C
+++ b/test/gsl_tests/power_method.C
@@ -35,14 +35,19 @@ int main(int argc, char* argv[])
   int return_flag = 0;
 
    // Initialize environment
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc,&argv);
-
   QUESO::FullEnvironment* env = new QUESO::FullEnvironment(MPI_COMM_WORLD,"input","",NULL);
+#else
+  QUESO::FullEnvironment* env = new QUESO::FullEnvironment("input","",NULL);
+#endif
 
   return_flag = actualChecking(env);
 
   delete env;
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
   // Fin.
   return return_flag;
 }

--- a/test/t01_valid_cycle/TgaValidationCycle_gsl.C
+++ b/test/t01_valid_cycle/TgaValidationCycle_gsl.C
@@ -39,12 +39,16 @@ int main(int argc, char* argv[])
   //************************************************
   // Initialize environment
   //************************************************
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc,&argv);
   UQ_FATAL_TEST_MACRO(argc != 2,
                       QUESO::UQ_UNAVAILABLE_RANK,
                       "main()",
                       "input file must be specified in command line as argv[1], just after executable argv[0]");
   QUESO::FullEnvironment* env = new QUESO::FullEnvironment(MPI_COMM_WORLD,argv[1],"",NULL);
+#else
+  QUESO::FullEnvironment* env = new QUESO::FullEnvironment(argv[1],"",NULL);
+#endif
 
   //************************************************
   // Run application
@@ -59,6 +63,8 @@ int main(int argc, char* argv[])
   // Finalize environment
   //************************************************
   delete env;
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
   return 0;
 }

--- a/test/t02_sip_sfp/example_main.C
+++ b/test/t02_sip_sfp/example_main.C
@@ -27,6 +27,7 @@
 int main(int argc, char* argv[])
 {
   // Initialize environment
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc,&argv);
   UQ_FATAL_TEST_MACRO(argc != 2,
                       QUESO::UQ_UNAVAILABLE_RANK,
@@ -34,11 +35,17 @@ int main(int argc, char* argv[])
                       "input file must be specified in command line as argv[1], just after executable argv[0]");
   QUESO::FullEnvironment* env =
     new QUESO::FullEnvironment(MPI_COMM_WORLD,argv[1],"",NULL);
+#else
+  QUESO::FullEnvironment* env =
+    new QUESO::FullEnvironment(argv[1],"",NULL);
+#endif
   // Compute
   compute(*env);
 
   // Finalize environment
   delete env;
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
   return 0;
 }

--- a/test/t03_sequence/example_main.C
+++ b/test/t03_sequence/example_main.C
@@ -39,14 +39,20 @@
 int main(int argc, char* argv[])
 {
   // Initialize environment
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc,&argv);
   QUESO::FullEnvironment* env = new QUESO::FullEnvironment(MPI_COMM_WORLD,argv[1],"",NULL);
+#else
+  QUESO::FullEnvironment* env = new QUESO::FullEnvironment(argv[1],"",NULL);
+#endif
 
   // Compute
   compute(*env);
 
   // Finalize environment
   delete env;
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
   return 0;
 }

--- a/test/t04_bimodal/example_main.C
+++ b/test/t04_bimodal/example_main.C
@@ -27,14 +27,20 @@
 int main(int argc, char* argv[])
 {
   // Initialize environment
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc,&argv);
   QUESO::FullEnvironment* env = new QUESO::FullEnvironment(MPI_COMM_WORLD,argv[1],"",NULL);
+#else
+  QUESO::FullEnvironment* env = new QUESO::FullEnvironment(argv[1],"",NULL);
+#endif
 
   // Compute
   compute(*env);
 
   // Finalize environment
   delete env;
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
   return 0;
 }

--- a/test/test_DistArray/test_DistArrayCopy.C
+++ b/test/test_DistArray/test_DistArrayCopy.C
@@ -1,4 +1,3 @@
-#include <mpi.h>
 #include <queso/Environment.h>
 #include <queso/EnvironmentOptions.h>
 #include <queso/MpiComm.h>
@@ -6,13 +5,20 @@
 #include <queso/DistArray.h>
 
 int main(int argc, char **argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
+#endif
 
   QUESO::EnvOptionsValues options;
   options.m_numSubEnvironments = 1;
 
+#ifdef QUESO_HAS_MPI
   QUESO::FullEnvironment *env =
     new QUESO::FullEnvironment(MPI_COMM_WORLD, "", "", &options);
+#else
+  QUESO::FullEnvironment *env =
+    new QUESO::FullEnvironment("", "", &options);
+#endif
 
   const QUESO::MpiComm & comm = env->fullComm();
 
@@ -28,6 +34,8 @@ int main(int argc, char **argv) {
     return 0;
   }
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
   return 1;
 }

--- a/test/test_DistArray/test_DistArrayEquals.C
+++ b/test/test_DistArray/test_DistArrayEquals.C
@@ -1,4 +1,3 @@
-#include <mpi.h>
 #include <queso/Environment.h>
 #include <queso/EnvironmentOptions.h>
 #include <queso/MpiComm.h>
@@ -6,13 +5,20 @@
 #include <queso/DistArray.h>
 
 int main(int argc, char **argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
+#endif
 
   QUESO::EnvOptionsValues options;
   options.m_numSubEnvironments = 1;
 
+#ifdef QUESO_HAS_MPI
   QUESO::FullEnvironment *env =
     new QUESO::FullEnvironment(MPI_COMM_WORLD, "", "", &options);
+#else
+  QUESO::FullEnvironment *env =
+    new QUESO::FullEnvironment("", "", &options);
+#endif
 
   const QUESO::MpiComm & comm = env->fullComm();
 
@@ -29,6 +35,8 @@ int main(int argc, char **argv) {
     return 0;
   }
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
   return 1;
 }

--- a/test/test_DistArray/test_DistArrayMisc.C
+++ b/test/test_DistArray/test_DistArrayMisc.C
@@ -1,4 +1,3 @@
-#include <mpi.h>
 #include <queso/Environment.h>
 #include <queso/EnvironmentOptions.h>
 #include <queso/MpiComm.h>
@@ -6,13 +5,20 @@
 #include <queso/DistArray.h>
 
 int main(int argc, char **argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
+#endif
 
   QUESO::EnvOptionsValues options;
   options.m_numSubEnvironments = 1;
 
+#ifdef QUESO_HAS_MPI
   QUESO::FullEnvironment *env =
     new QUESO::FullEnvironment(MPI_COMM_WORLD, "", "", &options);
+#else
+  QUESO::FullEnvironment *env =
+    new QUESO::FullEnvironment("", "", &options);
+#endif
 
   const QUESO::MpiComm & comm = env->fullComm();
 
@@ -34,6 +40,8 @@ int main(int argc, char **argv) {
   std::cerr << "d is: " << std::endl;
   std::cerr << d << std::endl;
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
   return 0;
 }

--- a/test/test_Environment/input_test_serialEnv.in
+++ b/test/test_Environment/input_test_serialEnv.in
@@ -1,0 +1,51 @@
+###############################################
+# UQ Environment
+###############################################
+#env_help                = anything
+env_numSubEnvironments   = 1
+env_subDisplayFileName   = output_test_serialEnv/display
+env_subDisplayAllowAll   = 0
+env_subDisplayAllowedSet = 0
+env_displayVerbosity     = 2
+env_syncVerbosity        = 0
+env_seed                 = 0
+
+###############################################
+# Statistical inverse problem (ip)
+###############################################
+#ip_help                 = anything
+ip_computeSolution      = 1
+ip_dataOutputFileName   = output_test_serialEnv/sipOutput
+ip_dataOutputAllowedSet = 0
+
+###############################################
+# 'ip_': information for Metropolis-Hastings algorithm
+###############################################
+#ip_mh_help                 = anything
+ip_mh_dataOutputFileName   = output_test_serialEnv/sipOutput
+ip_mh_dataOutputAllowedSet = 0 1
+
+ip_mh_rawChain_dataInputFileName    = .
+ip_mh_rawChain_size                 = 10
+ip_mh_rawChain_generateExtra        = 0
+ip_mh_rawChain_displayPeriod        = 50000
+ip_mh_rawChain_measureRunTimes      = 1
+ip_mh_rawChain_dataOutputFileName   = output_test_serialEnv/ip_raw_chain
+ip_mh_rawChain_dataOutputAllowedSet = 0 1
+ip_mh_rawChain_computeStats         = 1
+
+ip_mh_displayCandidates             = 0
+ip_mh_putOutOfBoundsInChain         = 0
+ip_mh_tk_useLocalHessian            = 0
+ip_mh_tk_useNewtonComponent         = 1
+ip_mh_dr_maxNumExtraStages          = 1
+ip_mh_dr_listOfScalesForExtraStages = 5.
+ip_mh_am_initialNonAdaptInterval    = 0
+ip_mh_am_adaptInterval              = 100
+ip_mh_am_eta                        = 1.92
+ip_mh_am_epsilon                    = 1.e-5
+
+ip_mh_filteredChain_generate             = 0
+
+ip_mh_outputLogLikelihood = 0
+ip_mh_outputLogTarget = 0

--- a/test/test_Environment/test_serialEnv.C
+++ b/test/test_Environment/test_serialEnv.C
@@ -12,13 +12,9 @@ class Likelihood : public QUESO::BaseScalarFunction<V, M>
 public:
 
   Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domain)
-    : QUESO::BaseScalarFunction<V, M>(prefix, domain)
-  {
-  }
+    : QUESO::BaseScalarFunction<V, M>(prefix, domain) {}
 
-  virtual ~Likelihood()
-  {
-  }
+  virtual ~Likelihood() {}
 
   virtual double lnValue(const V & domainVector, const V * domainDirection,
       V * gradVector, M * hessianMatrix, V * hessianEffect) const
@@ -37,12 +33,8 @@ public:
 };
 
 int main(int argc, char ** argv) {
-#ifdef QUESO_HAS_MPI
-  MPI_Init(&argc, &argv);
-  QUESO::FullEnvironment env(MPI_COMM_WORLD, argv[1], "", NULL);
-#else
-  QUESO::FullEnvironment env(argv[1], "", NULL);
-#endif
+  QUESO::FullEnvironment env("test_Environment/input_test_serialEnv", "",
+      NULL);
 
   QUESO::VectorSpace<> paramSpace(env, "param_", 1, NULL);
 
@@ -71,10 +63,6 @@ int main(int argc, char ** argv) {
   proposalCovMatrix(0, 0) = 0.1;
 
   ip.solveWithBayesMetropolisHastings(NULL, paramInitials, &proposalCovMatrix);
-
-#ifdef QUESO_HAS_MPI
-  MPI_Finalize();
-#endif
 
   return 0;
 }

--- a/test/test_Environment/test_uqEnvironmentNonFatal.C
+++ b/test/test_Environment/test_uqEnvironmentNonFatal.C
@@ -3,12 +3,12 @@
 #include <queso/EnvironmentOptions.h>
 #include <queso/Defines.h>
 
-#include <mpi.h>
-
 using namespace std;
 
 int main(int argc, char **argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
+#endif
 
   QUESO::EnvOptionsValues options;
   options.m_numSubEnvironments = 1;
@@ -24,7 +24,11 @@ int main(int argc, char **argv) {
   /* options.m_subDisplayAllowedSet = subDisplayAllowed; */
   /* options.m_subDisplayAllowAll = 0; */
 
+#ifdef QUESO_HAS_MPI
   QUESO::FullEnvironment *env = new QUESO::FullEnvironment(MPI_COMM_WORLD, "", "", &options);
+#else
+  QUESO::FullEnvironment *env = new QUESO::FullEnvironment("", "", &options);
+#endif
 
   if (!env->fullEnvIsReady()) {
     std::cerr << "Full env ready test failed" << std::endl;
@@ -102,7 +106,9 @@ int main(int argc, char **argv) {
   }
 
   delete env;
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   /*
    * This code should never get here. If it does, the bash script that wraps

--- a/test/test_GaussianVectorRVClass/test_VectorPdf_gsl.C
+++ b/test/test_GaussianVectorRVClass/test_VectorPdf_gsl.C
@@ -25,10 +25,16 @@ int require_close(double a, double b, double tol) {
 
 int main(int argc, char ** argv) {
   // Initialize
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
+#endif
 
   EnvOptionsValues envOptionsValues;
+#ifdef QUESO_HAS_MPI
   FullEnvironment env(MPI_COMM_WORLD, "", "", &envOptionsValues);
+#else
+  FullEnvironment env("", "", &envOptionsValues);
+#endif
 
   VectorSpace<GslVector, GslMatrix> domainSpace(env, "test_space", 2, NULL);
   Map eMap(2, 0, env.fullComm());
@@ -272,7 +278,9 @@ int main(int argc, char ** argv) {
 
   delete gaussianPdf;
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/test/test_GaussianVectorRVClass/test_VectorRV_gsl.C
+++ b/test/test_GaussianVectorRVClass/test_VectorRV_gsl.C
@@ -24,10 +24,16 @@ int require_close(double a, double b, double tol) {
 }
 
 int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
+#endif
 
   EnvOptionsValues envOptionsValues;
+#ifdef QUESO_HAS_MPI
   FullEnvironment env(MPI_COMM_WORLD, "", "", &envOptionsValues);
+#else
+  FullEnvironment env("", "", &envOptionsValues);
+#endif
 
   VectorSpace<GslVector, GslMatrix> imageSpace(env, "test_space", 2, NULL);
   Map eMap(2, 0, env.fullComm());
@@ -73,7 +79,9 @@ int main(int argc, char ** argv) {
   std::cout << myRealization;
 
   // finalize
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/test/test_GaussianVectorRVClass/test_VectorRealizer_gsl.C
+++ b/test/test_GaussianVectorRVClass/test_VectorRealizer_gsl.C
@@ -30,10 +30,16 @@ int require_close(double a, double b, double tol) {
 }
 
 int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
+#endif
 
   EnvOptionsValues envOptionsValues;
+#ifdef QUESO_HAS_MPI
   FullEnvironment env(MPI_COMM_WORLD, "", "", &envOptionsValues);
+#else
+  FullEnvironment env("", "", &envOptionsValues);
+#endif
 
   VectorSpace<GslVector, GslMatrix> imageSpace(env, "test_space", 2, NULL);
   Map eMap(2, 0, env.fullComm());
@@ -94,7 +100,9 @@ int main(int argc, char ** argv) {
   delete gaussianRealizer;
 
   // Clean up
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/test/test_GaussianVectorRVClass/test_uqGaussianVectorRVClass.C
+++ b/test/test_GaussianVectorRVClass/test_uqGaussianVectorRVClass.C
@@ -26,8 +26,12 @@ int main(int argc, char **argv) {
   QUESO::EnvOptionsValues *opts = new QUESO::EnvOptionsValues();
   opts->m_seed = seed;
 
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
   QUESO::FullEnvironment *env = new QUESO::FullEnvironment(MPI_COMM_WORLD, "", "", opts);
+#else
+  QUESO::FullEnvironment *env = new QUESO::FullEnvironment("", "", opts);
+#endif
 
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> *param_space;
   param_space = new QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>(
@@ -108,6 +112,8 @@ int main(int argc, char **argv) {
   delete param_space;
   delete param_domain;
   delete prior;
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
   return return_val;
 }

--- a/test/test_GslBlockMatrix/test_GslBlockMatrixInvertMultiply.C
+++ b/test/test_GslBlockMatrix/test_GslBlockMatrixInvertMultiply.C
@@ -1,5 +1,3 @@
-#include <mpi.h>
-
 #include <queso/Environment.h>
 #include <queso/EnvironmentOptions.h>
 #include <queso/VectorSpace.h>
@@ -10,12 +8,18 @@
 #define TOL 1e-10
 
 int main(int argc, char **argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
+#endif
 
   QUESO::EnvOptionsValues options;
   options.m_numSubEnvironments = 1;
 
+#ifdef QUESO_HAS_MPI
   QUESO::FullEnvironment env(MPI_COMM_WORLD, "", "", &options);
+#else
+  QUESO::FullEnvironment env("", "", &options);
+#endif
 
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
       "param_", 3, NULL);
@@ -64,6 +68,8 @@ int main(int argc, char **argv) {
     queso_error_msg("TEST: GslBlockMatrix::invertMultiply failed.");
   }
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
   return 0;
 }

--- a/test/test_GslMatrix/test_uqGslMatrix.C
+++ b/test/test_GslMatrix/test_uqGslMatrix.C
@@ -4,7 +4,6 @@
 #include <queso/GslVector.h>
 #include <queso/GslMatrix.h>
 
-#include <mpi.h>
 #define TOL 1e-10
 
 using namespace std;
@@ -44,12 +43,19 @@ int main(int argc, char **argv) {
   unsigned int i, j;
   double diagValue = 1.5;
 
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
+#endif
   QUESO::EnvOptionsValues options;
   options.m_numSubEnvironments = 1;
 
+#ifdef QUESO_HAS_MPI
   QUESO::FullEnvironment *env =
     new QUESO::FullEnvironment(MPI_COMM_WORLD, "", "", &options);
+#else
+  QUESO::FullEnvironment *env =
+    new QUESO::FullEnvironment("", "", &options);
+#endif
 
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> *param_space =
     new QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>(*env, "param_", 3, NULL);
@@ -237,6 +243,8 @@ int main(int argc, char **argv) {
     return 1;
   }
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
   return 0;
 }

--- a/test/test_GslVector/test_uqGslVector.C
+++ b/test/test_GslVector/test_uqGslVector.C
@@ -6,8 +6,6 @@
 #include <queso/Environment.h>
 #include <queso/EnvironmentOptions.h>
 
-#include <mpi.h>
-
 #define TOL 1e-10
 
 int checkLinearSpacing(const QUESO::GslVector &v, double d1, double d2) {
@@ -29,12 +27,18 @@ int main(int argc, char **argv) {
   double d1 = 0.0;
   double d2 = 1.0;
 
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
+#endif
 
   QUESO::EnvOptionsValues options;
   options.m_numSubEnvironments = 1;
 
+#ifdef QUESO_HAS_MPI
   QUESO::FullEnvironment *env = new QUESO::FullEnvironment(MPI_COMM_WORLD, "", "", &options);
+#else
+  QUESO::FullEnvironment *env = new QUESO::FullEnvironment("", "", &options);
+#endif
 
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> *param_space =
     new QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>(*env, "param_", 3, NULL);
@@ -224,6 +228,8 @@ int main(int argc, char **argv) {
   }
   delete env;
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
   return 0;
 }

--- a/test/test_GslVectorSpace/test_GslVectorSpaceMisc.C
+++ b/test/test_GslVectorSpace/test_GslVectorSpaceMisc.C
@@ -9,7 +9,9 @@
 #include <queso/VectorSpace.h>
 
 int main(int argc, char **argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
+#endif
 
   QUESO::EnvOptionsValues options;
   options.m_numSubEnvironments = 1;
@@ -20,8 +22,13 @@ int main(int argc, char **argv) {
   options.m_checkingLevel = 1;
   options.m_displayVerbosity = 20;
 
+#ifdef QUESO_HAS_MPI
   QUESO::FullEnvironment *env = new QUESO::FullEnvironment(MPI_COMM_WORLD, "",
       "", &options);
+#else
+  QUESO::FullEnvironment *env = new QUESO::FullEnvironment("",
+      "", &options);
+#endif
 
   std::vector<std::string> names(1);
   names[0] = "my_name";
@@ -76,7 +83,9 @@ int main(int argc, char **argv) {
   std::cout << std::endl;
 
   delete diag_matrix;
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/test/test_InterpolationSurrogate/test_1D_LinearLagrangeInterpolationSurrogate.C
+++ b/test/test_InterpolationSurrogate/test_1D_LinearLagrangeInterpolationSurrogate.C
@@ -33,8 +33,12 @@ double one_d_fn( double x );
 
 int main(int argc, char ** argv)
 {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
   QUESO::FullEnvironment env(MPI_COMM_WORLD, "test_InterpolationSurrogate/queso_input.txt", "", NULL);
+#else
+  QUESO::FullEnvironment env("test_InterpolationSurrogate/queso_input.txt", "", NULL);
+#endif
 
   int return_flag = 0;
 
@@ -95,6 +99,9 @@ int main(int argc, char ** argv)
       return_flag = 1;
     }
 
+#ifdef QUESO_HAS_MPI
+  MPI_Finalize();
+#endif
   return return_flag;
 }
 

--- a/test/test_InterpolationSurrogate/test_2D_LinearLagrangeInterpolationSurrogate.C
+++ b/test/test_InterpolationSurrogate/test_2D_LinearLagrangeInterpolationSurrogate.C
@@ -33,8 +33,12 @@ double two_d_fn( double x, double y );
 
 int main(int argc, char ** argv)
 {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
   QUESO::FullEnvironment env(MPI_COMM_WORLD, "test_InterpolationSurrogate/queso_input.txt", "", NULL);
+#else
+  QUESO::FullEnvironment env("test_InterpolationSurrogate/queso_input.txt", "", NULL);
+#endif
 
   int return_flag = 0;
 
@@ -106,6 +110,9 @@ int main(int argc, char ** argv)
       return_flag = 1;
     }
 
+#ifdef QUESO_HAS_MPI
+  MPI_Finalize();
+#endif
   return return_flag;
 }
 

--- a/test/test_InterpolationSurrogate/test_3D_LinearLagrangeInterpolationSurrogate.C
+++ b/test/test_InterpolationSurrogate/test_3D_LinearLagrangeInterpolationSurrogate.C
@@ -33,8 +33,12 @@ double three_d_fn( double x, double y, double z );
 
 int main(int argc, char ** argv)
 {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
   QUESO::FullEnvironment env(MPI_COMM_WORLD, "test_InterpolationSurrogate/queso_input.txt", "", NULL);
+#else
+  QUESO::FullEnvironment env("test_InterpolationSurrogate/queso_input.txt", "", NULL);
+#endif
 
   int return_flag = 0;
 
@@ -115,6 +119,9 @@ int main(int argc, char ** argv)
       return_flag = 1;
     }
 
+#ifdef QUESO_HAS_MPI
+  MPI_Finalize();
+#endif
   return return_flag;
 }
 

--- a/test/test_InterpolationSurrogate/test_4D_LinearLagrangeInterpolationSurrogate.C
+++ b/test/test_InterpolationSurrogate/test_4D_LinearLagrangeInterpolationSurrogate.C
@@ -33,8 +33,12 @@ double four_d_fn( double x, double y, double z, double a );
 
 int main(int argc, char ** argv)
 {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
   QUESO::FullEnvironment env(MPI_COMM_WORLD, "test_InterpolationSurrogate/queso_input.txt", "", NULL);
+#else
+  QUESO::FullEnvironment env("test_InterpolationSurrogate/queso_input.txt", "", NULL);
+#endif
 
   int return_flag = 0;
 
@@ -121,6 +125,9 @@ int main(int argc, char ** argv)
       return_flag = 1;
     }
 
+#ifdef QUESO_HAS_MPI
+  MPI_Finalize();
+#endif
   return return_flag;
 }
 

--- a/test/test_InterpolationSurrogate/test_build_InterpolationSurrogateBuilder.C
+++ b/test/test_InterpolationSurrogate/test_build_InterpolationSurrogateBuilder.C
@@ -56,8 +56,12 @@ public:
 
 int main(int argc, char ** argv)
 {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
   QUESO::FullEnvironment env(MPI_COMM_WORLD, "test_InterpolationSurrogate/queso_input.txt", "", NULL);
+#else
+  QUESO::FullEnvironment env("test_InterpolationSurrogate/queso_input.txt", "", NULL);
+#endif
 
   int return_flag = 0;
 
@@ -161,6 +165,9 @@ int main(int argc, char ** argv)
       test_val( test_val_2, exact_val_2, tol, "test_read_2" );
   }
 
+#ifdef QUESO_HAS_MPI
+  MPI_Finalize();
+#endif
   return return_flag;
 }
 

--- a/test/test_IntersectionSubset/test_IntersectionSubsetContains.C
+++ b/test/test_IntersectionSubset/test_IntersectionSubsetContains.C
@@ -11,7 +11,9 @@
 #include <queso/IntersectionSubset.h>
 
 int main(int argc, char **argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
+#endif
 
   QUESO::EnvOptionsValues options;
   options.m_numSubEnvironments = 1;
@@ -22,8 +24,13 @@ int main(int argc, char **argv) {
   options.m_checkingLevel = 1;
   options.m_displayVerbosity = 55;
 
+#ifdef QUESO_HAS_MPI
   QUESO::FullEnvironment *env = new QUESO::FullEnvironment(MPI_COMM_WORLD, "",
             "", &options);
+#else
+  QUESO::FullEnvironment *env = new QUESO::FullEnvironment("",
+            "", &options);
+#endif
 
   std::vector<std::string> names(1);
   names[0] = "my_name";
@@ -75,7 +82,9 @@ int main(int argc, char **argv) {
   // Print out some info
   intersection.print(std::cout);
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/test/test_Regression/test_gpmsa_cobra.C
+++ b/test/test_Regression/test_gpmsa_cobra.C
@@ -88,11 +88,16 @@ int main(int argc, char ** argv) {
   unsigned int numEta = 1;  // Number of responses the model is returning
   unsigned int experimentSize = 1;  // Size of each experiment
 
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
 
   // Step 1: Set up QUESO environment
   QUESO::FullEnvironment env(MPI_COMM_WORLD,
       "test_Regression/gpmsa_cobra_input.txt", "", NULL);
+#else
+  QUESO::FullEnvironment env(
+      "test_Regression/gpmsa_cobra_input.txt", "", NULL);
+#endif
 
   // Step 2: Set up prior for calibration parameters
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
@@ -274,7 +279,9 @@ int main(int argc, char ** argv) {
 
   ip.solveWithBayesMetropolisHastings(NULL, paramInitials, &proposalCovMatrix);
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/test/test_Regression/test_jeffreys.C
+++ b/test/test_Regression/test_jeffreys.C
@@ -107,17 +107,24 @@ void compute(const QUESO::FullEnvironment& env) {
 
 int main(int argc, char ** argv) {
   //init env
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc,&argv);
   // Step 1: Set up QUESO environment
   QUESO::FullEnvironment* env =
     new QUESO::FullEnvironment(MPI_COMM_WORLD,"test_Regression/jeffreys_input.txt","",NULL);
+#else
+  QUESO::FullEnvironment* env =
+    new QUESO::FullEnvironment("test_Regression/jeffreys_input.txt","",NULL);
+#endif
 
   //compute
   compute(*env);
 
   //finalize enviroment
   delete env;
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/test/test_Regression/test_logitadaptedcov.C
+++ b/test/test_Regression/test_logitadaptedcov.C
@@ -45,10 +45,14 @@ public:
 };
 
 int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
-
   QUESO::FullEnvironment env(MPI_COMM_WORLD,
       "test_Regression/adaptedcov_input.txt", "", NULL);
+#else
+  QUESO::FullEnvironment env(
+      "test_Regression/adaptedcov_input.txt", "", NULL);
+#endif
 
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
       "param_", 2, NULL);
@@ -127,7 +131,9 @@ int main(int argc, char ** argv) {
     result = 0;
   }
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return result;
 }

--- a/test/test_SequenceOfVectors/test_SequenceOfVectorsErase.C
+++ b/test/test_SequenceOfVectors/test_SequenceOfVectorsErase.C
@@ -10,7 +10,9 @@
 #include <queso/SequenceOfVectors.h>
 
 int main(int argc, char **argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
+#endif
 
   QUESO::EnvOptionsValues options;
   options.m_numSubEnvironments = 1;
@@ -21,7 +23,11 @@ int main(int argc, char **argv) {
   options.m_checkingLevel = 1;
   options.m_displayVerbosity = 55;
 
+#ifdef QUESO_HAS_MPI
   QUESO::FullEnvironment env(MPI_COMM_WORLD, "", "", &options);
+#else
+  QUESO::FullEnvironment env("", "", &options);
+#endif
 
   // Create a vector space
   std::vector<std::string> names(1);
@@ -53,6 +59,8 @@ int main(int argc, char **argv) {
     return 0;
   }
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
   return 1;
 }

--- a/test/test_SequenceOfVectors/test_unifiedPositionsOfMaximum.C
+++ b/test/test_SequenceOfVectors/test_unifiedPositionsOfMaximum.C
@@ -9,6 +9,9 @@
 #include <queso/SequenceOfVectors.h>
 
 int main(int argc, char **argv) {
+#ifndef QUESO_HAS_MPI
+  return 77;
+#else
   MPI_Init(&argc, &argv);
 
   QUESO::EnvOptionsValues options;
@@ -69,4 +72,5 @@ int main(int argc, char **argv) {
   MPI_Finalize();
 
   return 0;
+#endif
 }

--- a/test/test_StatisticalInverseProblem/test_NoInputFile.C
+++ b/test/test_StatisticalInverseProblem/test_NoInputFile.C
@@ -41,7 +41,9 @@ public:
 };
 
 int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
+#endif
 
   QUESO::EnvOptionsValues envOptions;
   envOptions.m_numSubEnvironments = 1;
@@ -51,7 +53,11 @@ int main(int argc, char ** argv) {
   envOptions.m_syncVerbosity = 0;
   envOptions.m_seed = 0;
 
+#ifdef QUESO_HAS_MPI
   QUESO::FullEnvironment env(MPI_COMM_WORLD, "", "", &envOptions);
+#else
+  QUESO::FullEnvironment env("", "", &envOptions);
+#endif
 
   unsigned int dim = 2;
   QUESO::VectorSpace<> paramSpace(env, "param_", dim, NULL);
@@ -118,7 +124,9 @@ int main(int argc, char ** argv) {
   ip.solveWithBayesMetropolisHastings(&mhOptions, paramInitials,
       &proposalCovMatrix);
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/test/test_exception/test_exception.C
+++ b/test/test_exception/test_exception.C
@@ -18,7 +18,9 @@ using namespace std;
 
 int main(int argc, char **argv)
 {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
+#endif
 
   // hit with exception
   try
@@ -28,7 +30,9 @@ int main(int argc, char **argv)
   catch(...)
     {
       printf("Caught QUESO exception!\n");
+#ifdef QUESO_HAS_MPI
       MPI_Finalize();
+#endif
       return 0;
     }
 

--- a/test/test_gaussian_likelihoods/test_blockDiagonalCovariance.C
+++ b/test/test_gaussian_likelihoods/test_blockDiagonalCovariance.C
@@ -59,9 +59,12 @@ public:
 };
 
 int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
-
   QUESO::FullEnvironment env(MPI_COMM_WORLD, "test_gaussian_likelihoods/queso_input.txt", "", NULL);
+#else
+  QUESO::FullEnvironment env("test_gaussian_likelihoods/queso_input.txt", "", NULL);
+#endif
 
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
       "param_", 1, NULL);
@@ -136,7 +139,9 @@ int main(int argc, char ** argv) {
     queso_error();
   }
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/test/test_gaussian_likelihoods/test_blockDiagonalCovarianceChain.C
+++ b/test/test_gaussian_likelihoods/test_blockDiagonalCovarianceChain.C
@@ -110,8 +110,13 @@ class BayesianInverseProblem
 public:
   BayesianInverseProblem(unsigned int likelihoodFlag)
   {
+#ifdef QUESO_HAS_MPI
     this->env = new QUESO::FullEnvironment(MPI_COMM_WORLD,
         "test_gaussian_likelihoods/gaussian_consistency_input.txt", "", NULL);
+#else
+    this->env = new QUESO::FullEnvironment(
+        "test_gaussian_likelihoods/gaussian_consistency_input.txt", "", NULL);
+#endif
 
     this->paramSpace =
       new QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>(*env,
@@ -227,7 +232,9 @@ public:
 };
 
 int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
+#endif
 
   // Instantiate each inverse problem
   BayesianInverseProblem<QUESO::GslVector, QUESO::GslMatrix> b1(1);
@@ -246,7 +253,9 @@ int main(int argc, char ** argv) {
     }
   }
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/test/test_gaussian_likelihoods/test_blockDiagonalCovarianceRandomCoefficients.C
+++ b/test/test_gaussian_likelihoods/test_blockDiagonalCovarianceRandomCoefficients.C
@@ -59,9 +59,12 @@ public:
 };
 
 int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
-
   QUESO::FullEnvironment env(MPI_COMM_WORLD, "test_gaussian_likelihoods/queso_input.txt", "", NULL);
+#else
+  QUESO::FullEnvironment env("test_gaussian_likelihoods/queso_input.txt", "", NULL);
+#endif
 
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
       "param_", 3, NULL);
@@ -139,7 +142,9 @@ int main(int argc, char ** argv) {
     queso_error();
   }
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/test/test_gaussian_likelihoods/test_diagonalCovariance.C
+++ b/test/test_gaussian_likelihoods/test_diagonalCovariance.C
@@ -60,9 +60,12 @@ public:
 };
 
 int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
-
   QUESO::FullEnvironment env(MPI_COMM_WORLD, "test_gaussian_likelihoods/queso_input.txt", "", NULL);
+#else
+  QUESO::FullEnvironment env("test_gaussian_likelihoods/queso_input.txt", "", NULL);
+#endif
 
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
       "param_", 1, NULL);
@@ -121,7 +124,9 @@ int main(int argc, char ** argv) {
     queso_error();
   }
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/test/test_gaussian_likelihoods/test_diagonalCovarianceChain.C
+++ b/test/test_gaussian_likelihoods/test_diagonalCovarianceChain.C
@@ -106,8 +106,13 @@ class BayesianInverseProblem
 public:
   BayesianInverseProblem(unsigned int likelihoodFlag)
   {
+#ifdef QUESO_HAS_MPI
     this->env = new QUESO::FullEnvironment(MPI_COMM_WORLD,
         "test_gaussian_likelihoods/gaussian_consistency_input.txt", "", NULL);
+#else
+    this->env = new QUESO::FullEnvironment(
+        "test_gaussian_likelihoods/gaussian_consistency_input.txt", "", NULL);
+#endif
 
     this->paramSpace =
       new QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>(*env,
@@ -209,7 +214,9 @@ public:
 };
 
 int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
+#endif
 
   // Instantiate each inverse problem
   BayesianInverseProblem<QUESO::GslVector, QUESO::GslMatrix> b1(1);
@@ -228,7 +235,9 @@ int main(int argc, char ** argv) {
     }
   }
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/test/test_gaussian_likelihoods/test_fullCovariance.C
+++ b/test/test_gaussian_likelihoods/test_fullCovariance.C
@@ -59,9 +59,12 @@ public:
 };
 
 int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
-
   QUESO::FullEnvironment env(MPI_COMM_WORLD, "test_gaussian_likelihoods/queso_input.txt", "", NULL);
+#else
+  QUESO::FullEnvironment env("test_gaussian_likelihoods/queso_input.txt", "", NULL);
+#endif
 
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
       "param_", 1, NULL);
@@ -122,7 +125,9 @@ int main(int argc, char ** argv) {
     queso_error();
   }
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/test/test_gaussian_likelihoods/test_fullCovarianceChain.C
+++ b/test/test_gaussian_likelihoods/test_fullCovarianceChain.C
@@ -106,8 +106,13 @@ class BayesianInverseProblem
 public:
   BayesianInverseProblem(unsigned int likelihoodFlag)
   {
+#ifdef QUESO_HAS_MPI
     this->env = new QUESO::FullEnvironment(MPI_COMM_WORLD,
         "test_gaussian_likelihoods/gaussian_consistency_input.txt", "", NULL);
+#else
+    this->env = new QUESO::FullEnvironment(
+        "test_gaussian_likelihoods/gaussian_consistency_input.txt", "", NULL);
+#endif
 
     this->paramSpace =
       new QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>(*env,
@@ -211,7 +216,9 @@ public:
 };
 
 int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
+#endif
 
   // Instantiate each inverse problem
   BayesianInverseProblem<QUESO::GslVector, QUESO::GslMatrix> b1(1);
@@ -230,7 +237,9 @@ int main(int argc, char ** argv) {
     }
   }
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/test/test_gaussian_likelihoods/test_fullCovarianceRandomCoefficient.C
+++ b/test/test_gaussian_likelihoods/test_fullCovarianceRandomCoefficient.C
@@ -59,9 +59,12 @@ public:
 };
 
 int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
-
   QUESO::FullEnvironment env(MPI_COMM_WORLD, "test_gaussian_likelihoods/queso_input.txt", "", NULL);
+#else
+  QUESO::FullEnvironment env("test_gaussian_likelihoods/queso_input.txt", "", NULL);
+#endif
 
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
       "param_", 2, NULL);
@@ -128,7 +131,9 @@ int main(int argc, char ** argv) {
     queso_error();
   }
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/test/test_gaussian_likelihoods/test_scalarCovariance.C
+++ b/test/test_gaussian_likelihoods/test_scalarCovariance.C
@@ -58,9 +58,12 @@ public:
 };
 
 int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
-
   QUESO::FullEnvironment env(MPI_COMM_WORLD, "test_gaussian_likelihoods/queso_input.txt", "", NULL);
+#else
+  QUESO::FullEnvironment env("test_gaussian_likelihoods/queso_input.txt", "", NULL);
+#endif
 
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
       "param_", 1, NULL);
@@ -113,7 +116,9 @@ int main(int argc, char ** argv) {
     queso_error();
   }
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/test/test_gaussian_likelihoods/test_scalarCovarianceChain.C
+++ b/test/test_gaussian_likelihoods/test_scalarCovarianceChain.C
@@ -102,8 +102,13 @@ class BayesianInverseProblem
 public:
   BayesianInverseProblem(unsigned int likelihoodFlag)
   {
+#ifdef QUESO_HAS_MPI
     this->env = new QUESO::FullEnvironment(MPI_COMM_WORLD,
         "test_gaussian_likelihoods/gaussian_consistency_input.txt", "", NULL);
+#else
+    this->env = new QUESO::FullEnvironment(
+        "test_gaussian_likelihoods/gaussian_consistency_input.txt", "", NULL);
+#endif
 
     this->paramSpace =
       new QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>(*env,
@@ -198,7 +203,9 @@ public:
 };
 
 int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
+#endif
 
   // Instantiate each inverse problem
   BayesianInverseProblem<QUESO::GslVector, QUESO::GslMatrix> b1(1);
@@ -217,7 +224,9 @@ int main(int argc, char ** argv) {
     }
   }
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/test/test_infinite/test_inf_gaussian.C
+++ b/test/test_infinite/test_inf_gaussian.C
@@ -13,8 +13,6 @@
 #include <queso/InfiniteDimensionalGaussian.h>
 #endif  // QUESO_HAVE_LIBMESH
 
-#include <mpi.h>
-
 int main(int argc, char **argv)
 {
 #ifdef QUESO_HAVE_LIBMESH
@@ -27,9 +25,12 @@ int main(int argc, char **argv)
   QUESO::EnvOptionsValues opts;
   opts.m_seed = -1;
 
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
-
   QUESO::FullEnvironment env(MPI_COMM_WORLD, "", "", &opts);
+#else
+  QUESO::FullEnvironment env("", "", &opts);
+#endif
 
 #ifdef LIBMESH_DEFAULT_SINGLE_PRECISION
   // SLEPc farts with libMesh::Real==float
@@ -109,7 +110,9 @@ int main(int argc, char **argv)
 }
 #endif  // LIBMESH_HAVE_SLEPC
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
   return 0;
 #else
   return 77;

--- a/test/test_infinite/test_inf_options.C
+++ b/test/test_infinite/test_inf_options.C
@@ -15,8 +15,6 @@
 #include <queso/InfiniteDimensionalMCMCSamplerOptions.h>
 #endif  // QUESO_HAVE_LIBMESH
 
-#include <mpi.h>
-
 #ifdef QUESO_HAVE_LIBMESH
 class Likelihood : public QUESO::InfiniteDimensionalLikelihoodBase {
 public:
@@ -49,9 +47,12 @@ int main(int argc, char **argv)
   // EnvOptionsValuesClass opts;
   // opts.m_seed = -1;
 
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
-
   QUESO::FullEnvironment env(MPI_COMM_WORLD, in_file_name, prefix, NULL);
+#else
+  QUESO::FullEnvironment env(in_file_name, prefix, NULL);
+#endif
 
 #ifdef LIBMESH_DEFAULT_SINGLE_PRECISION
   // SLEPc farts with libMesh::Real==float
@@ -94,7 +95,9 @@ int main(int argc, char **argv)
 }
 #endif  // LIBMESH_HAVE_SLEPC
 
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
   return 0;
 #else
   return 77;

--- a/test/test_infinite/test_operator.C
+++ b/test/test_infinite/test_operator.C
@@ -22,8 +22,6 @@
 #include <queso/InfiniteDimensionalGaussian.h>
 #endif  // QUESO_HAVE_LIBMESH
 
-#include <mpi.h>
-
 #define TEST_TOL 1e-8
 #define INTEGRATE_TOL 1e-2
 
@@ -34,8 +32,12 @@ int main(int argc, char **argv)
   QUESO::EnvOptionsValues opts;
   opts.m_seed = -1;
 
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
   QUESO::FullEnvironment env(MPI_COMM_WORLD, "", "", &opts);
+#else
+  QUESO::FullEnvironment env("", "", &opts);
+#endif
 
 #ifdef LIBMESH_DEFAULT_SINGLE_PRECISION
   // SLEPc currently gives us a nasty crash with Real==float
@@ -119,7 +121,9 @@ int main(int argc, char **argv)
   }
 }
 #endif  // LIBMESH_HAVE_SLEPC
+#ifdef QUESO_HAS_MPI
   MPI_Finalize();
+#endif
   return 0;
 #else
   return 77;

--- a/test/test_optimizer/test_gsloptimizer.C
+++ b/test/test_optimizer/test_gsloptimizer.C
@@ -44,9 +44,12 @@ public:
 };
 
 int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
-
   QUESO::FullEnvironment env(MPI_COMM_WORLD, "", "", NULL);
+#else
+  QUESO::FullEnvironment env("", "", NULL);
+#endif
 
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
       "space_", 3, NULL);
@@ -100,6 +103,10 @@ int main(int argc, char ** argv) {
   optimizer.minimize(&monitor);
 
   monitor.print(std::cout,false);
+
+#ifdef QUESO_HAS_MPI
+  MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/test/test_optimizer/test_optimizer_options.C
+++ b/test/test_optimizer/test_optimizer_options.C
@@ -40,9 +40,12 @@ public:
 };
 
 int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
-
   QUESO::FullEnvironment env(MPI_COMM_WORLD, "test_optimizer/input_test_optimizer_options", "", NULL);
+#else
+  QUESO::FullEnvironment env("test_optimizer/input_test_optimizer_options", "", NULL);
+#endif
 
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
       "space_", 1, NULL);

--- a/test/test_optimizer/test_seedwithmap.C
+++ b/test/test_optimizer/test_seedwithmap.C
@@ -40,9 +40,12 @@ public:
 };
 
 int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
-
   QUESO::FullEnvironment env(MPI_COMM_WORLD, "", "", NULL);
+#else
+  QUESO::FullEnvironment env("", "", NULL);
+#endif
 
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
       "space_", 1, NULL);
@@ -87,6 +90,10 @@ int main(int argc, char ** argv) {
     std::cerr << "Actual seed should be 0.0" << std::endl;
     queso_error();
   }
+
+#ifdef QUESO_HAS_MPI
+  MPI_Finalize();
+#endif
 
   return 0;
 }

--- a/test/test_optimizer/test_seedwithmap_fd.C
+++ b/test/test_optimizer/test_seedwithmap_fd.C
@@ -35,9 +35,12 @@ public:
 };
 
 int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
   MPI_Init(&argc, &argv);
-
   QUESO::FullEnvironment env(MPI_COMM_WORLD, "", "", NULL);
+#else
+  QUESO::FullEnvironment env("", "", NULL);
+#endif
 
   QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
       "space_", 1, NULL);
@@ -83,6 +86,10 @@ int main(int argc, char ** argv) {
     std::cerr << "Actual seed should be 0.0" << std::endl;
     queso_error();
   }
+
+#ifdef QUESO_HAS_MPI
+  MPI_Finalize();
+#endif
 
   return 0;
 }


### PR DESCRIPTION
MPI is now optional and can be disabled at configure-time with a `--disable-mpi` flag.  When setting up the `FullEnvironment`, you can pass `0` as the communicator.  All the examples and tests have been updated to use this pattern.

Tests are passing in serial (without MPI) and in parallel.

@briadam @mseldre Would you mind trying this branch out and letting me know if this works for you?