### PR TITLE
GCC 4.4.7 compatibility: remove typename

### DIFF
--- a/src/core/inc/BoostInputOptionsParser.h
+++ b/src/core/inc/BoostInputOptionsParser.h
@@ -92,8 +92,8 @@ protected:
   // a non-temporary "" string for internal use.
   const std::string m_filename;
 
-  typename ScopedPtr<boost::program_options::options_description>::Type m_optionsDescription;
-  typename ScopedPtr<boost::program_options::variables_map>::Type m_optionsMap;
+  ScopedPtr<boost::program_options::options_description>::Type m_optionsDescription;
+  ScopedPtr<boost::program_options::variables_map>::Type m_optionsMap;
 
 private:
   bool m_scannedInputFile;


### PR DESCRIPTION
Small change to allow compilation on gcc-4.4.7. Not sure it's the right fix though, so request review.

Try again with new pull request, per discussion on https://github.com/libqueso/queso/pull/401
