### PR TITLE
Inline GSLMatrix::operator()

### DIFF
--- a/src/core/inc/GslMatrix.h
+++ b/src/core/inc/GslMatrix.h
@@ -101,10 +101,23 @@ public:
   //! @name Accessor methods
   //@{
   //! Element access method (non-const).
-  double& operator()(unsigned int i, unsigned int j);
+  double& operator()(unsigned int i, unsigned int j)
+  {
+    // Changing the matrix changes its decomposition(s).  We'll
+    // invalidate for now; recalculate later if needed.
+    this->resetLU();
+    queso_require_less_msg(i, m_mat->size1, "i is too large");
+    queso_require_less_msg(j, m_mat->size2, "j is too large");
+    return *gsl_matrix_ptr(m_mat,i,j);
+  }
 
   //! Element access method (const).
-  const double& operator()(unsigned int i, unsigned int j) const;
+  const double& operator()(unsigned int i, unsigned int j) const
+  {
+    queso_require_less_msg(i, m_mat->size1, "i is too large");
+    queso_require_less_msg(j, m_mat->size2, "j is too large");
+    return *gsl_matrix_ptr(m_mat,i,j);
+  }
 
 
   //@}

--- a/src/core/src/GslMatrix.C
+++ b/src/core/src/GslMatrix.C
@@ -214,32 +214,7 @@ GslMatrix::operator-=(const GslMatrix& rhs)
   return *this;
 }
 
-// Acessor methods (operators) ----------------------------------------
-double&
-GslMatrix::operator()(unsigned int i, unsigned int j)
-{
-  this->resetLU();
-  if ((i >= m_mat->size1) ||
-      (j >= m_mat->size2)) {
-    std::cerr << "In GslMatrix::operator(i,j)"
-              << ": i = " << i
-              << ", j = " << j
-              << ", m_mat->size1 = " << m_mat->size1
-              << ", m_mat->size2 = " << m_mat->size2
-              << std::endl;
-    queso_require_less_msg(i, m_mat->size1, "i is too large");
-    queso_require_less_msg(j, m_mat->size2, "j is too large");
-  }
-  return *gsl_matrix_ptr(m_mat,i,j);
-}
 
-const double&
-GslMatrix::operator()(unsigned int i, unsigned int j) const
-{
-  queso_require_less_msg(i, m_mat->size1, "i is too large");
-  queso_require_less_msg(j, m_mat->size2, "j is too large");
-  return *gsl_matrix_const_ptr(m_mat,i,j);
-}
 
 void
 GslMatrix::copy(const GslMatrix& src)


### PR DESCRIPTION
And trim some of the redundant non-disablable range tests while we're
at it.

Matrix access isn't as pervasive as Vector, but it's still too
inner-loopy to want a function call and non-debug-mode range checking
on every entry.

I probably should have thought to check this when I did #391, not just upon
"I'm writing code to copy out a submatrix; wonder how fast that's going to be..."