### PR TITLE
Fix issue involving unified MLE on non-inter0Comm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,9 @@ test/test_jeffreys_pdf
 test/test_gaussian_pdf_gradient
 test/test_log_normal_pdf_gradient
 test/test_beta_pdf_gradient
+test/output_test_intercomm0_gravity_1
+test/output_test_intercomm0_gravity_2
+test/test_intercomm0_gravity
+test/test_intercomm0/gravity_1proc.txt
+test/test_intercomm0/gravity_2proc.txt
+test/test_intercomm0/test_intercomm0_gravity_run.sh

--- a/configure.ac
+++ b/configure.ac
@@ -241,6 +241,8 @@ AC_CONFIG_FILES([
   test/test_InputOptionsParser/test_options_default.txt
   test/test_optimizer/input_test_optimizer_options
   test/test_Environment/input_test_serialEnv
+  test/test_intercomm0/gravity_1proc.txt
+  test/test_intercomm0/gravity_2proc.txt
 ])
 
 AC_CONFIG_FILES([test/test_Regression/test_cobra_samples_diff.sh
@@ -268,6 +270,13 @@ AC_CONFIG_FILES([
 ],
 [
   chmod +x test/test_SequenceOfVectors/test_unifiedPositionsOfMaximum.sh
+])
+
+AC_CONFIG_FILES([
+  test/test_intercomm0/test_intercomm0_gravity_run.sh
+],
+[
+  chmod +x test/test_intercomm0/test_intercomm0_gravity_run.sh
 ])
 
 dnl ----------------------------------------------

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -1215,8 +1215,8 @@ MetropolisHastingsSG<P_V,P_M>::generateSequence(
                                                    m_optionsObj->m_rawChainDataOutputFileType);
     }
 
-    // Compute raw unified MLE
-    if (workingLogLikelihoodValues) {
+    // Compute raw unified MLE only in inter0Comm
+    if (workingLogLikelihoodValues && (m_env.subRank() == 0)) {
       SequenceOfVectors<P_V,P_M> rawUnifiedMLEpositions(m_vectorSpace,0,m_optionsObj->m_prefix+"rawUnifiedMLEseq");
 
       double rawUnifiedMLEvalue = workingChain.unifiedPositionsOfMaximum(*workingLogLikelihoodValues,
@@ -1240,8 +1240,8 @@ MetropolisHastingsSG<P_V,P_M>::generateSequence(
       }
     }
 
-    // Compute raw unified MAP
-    if (workingLogTargetValues) {
+    // Compute raw unified MAP only in inter0Comm
+    if (workingLogTargetValues && (m_env.subRank() == 0)) {
       SequenceOfVectors<P_V,P_M> rawUnifiedMAPpositions(m_vectorSpace,0,m_optionsObj->m_prefix+"rawUnifiedMAPseq");
       double rawUnifiedMAPvalue = workingChain.unifiedPositionsOfMaximum(*workingLogTargetValues,
                                                                          rawUnifiedMAPpositions);

--- a/src/stats/src/StatisticalForwardProblem.C
+++ b/src/stats/src/StatisticalForwardProblem.C
@@ -279,17 +279,21 @@ StatisticalForwardProblem<P_V,P_M,Q_V,Q_M>::solveWithMonteCarlo(
                               << ": instantiating cov and corr matrices"
                               << std::endl;
     }
-    pqCovarianceMatrix = new P_M(m_env,
-                                 m_paramRv.imageSet().vectorSpace().map(),       // number of rows
-                                 m_qoiRv.imageSet().vectorSpace().dimGlobal());  // number of cols
-    pqCorrelationMatrix = new P_M(m_env,
-                                  m_paramRv.imageSet().vectorSpace().map(),      // number of rows
-                                  m_qoiRv.imageSet().vectorSpace().dimGlobal()); // number of cols
-    ComputeCovCorrMatricesBetweenVectorSequences(*m_paramChain,
-                                                   *m_qoiChain,
-                                                   std::min(m_paramRv.realizer().subPeriod(),m_qoiRv.realizer().subPeriod()), // FIX ME: might be INFINITY
-                                                   *pqCovarianceMatrix,
-                                                   *pqCorrelationMatrix);
+
+    // Only compute correlations on the inter0Comm communicator
+    if (m_env.subRank() == 0) {
+      pqCovarianceMatrix = new P_M(m_env,
+                                   m_paramRv.imageSet().vectorSpace().map(),       // number of rows
+                                   m_qoiRv.imageSet().vectorSpace().dimGlobal());  // number of cols
+      pqCorrelationMatrix = new P_M(m_env,
+                                    m_paramRv.imageSet().vectorSpace().map(),      // number of rows
+                                    m_qoiRv.imageSet().vectorSpace().dimGlobal()); // number of cols
+      ComputeCovCorrMatricesBetweenVectorSequences(*m_paramChain,
+                                                     *m_qoiChain,
+                                                     std::min(m_paramRv.realizer().subPeriod(),m_qoiRv.realizer().subPeriod()), // FIX ME: might be INFINITY
+                                                     *pqCovarianceMatrix,
+                                                     *pqCorrelationMatrix);
+    }
   }
 
   // Write data out

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -58,6 +58,7 @@ check_PROGRAMS += test_jeffreys_pdf
 check_PROGRAMS += test_gaussian_pdf_gradient
 check_PROGRAMS += test_log_normal_pdf_gradient
 check_PROGRAMS += test_beta_pdf_gradient
+check_PROGRAMS += test_intercomm0_gravity
 
 LDADD       = $(top_builddir)/src/libqueso.la
 
@@ -142,6 +143,13 @@ test_gaussian_pdf_gradient_SOURCES = test_pdfs/test_gaussian_pdf_gradient.C
 test_log_normal_pdf_gradient_SOURCES = test_pdfs/test_log_normal_pdf_gradient.C
 test_beta_pdf_gradient_SOURCES = test_pdfs/test_beta_pdf_gradient.C
 
+test_intercomm0_gravity_SOURCES =
+test_intercomm0_gravity_SOURCES += test_intercomm0/gravity_likelihood.C
+test_intercomm0_gravity_SOURCES += test_intercomm0/gravity_main.C
+test_intercomm0_gravity_SOURCES += test_intercomm0/gravity_qoi.C
+test_intercomm0_gravity_CPPFLAGS = -Itest_intercomm0 $(AM_CPPFLAGS)
+
+
 # Files to freedom stamp
 srcstamp =
 srcstamp += $(test_uqEnvironmentNonFatal_SOURCES)
@@ -196,6 +204,7 @@ srcstamp += $(test_jeffreys_pdf_SOURCES)
 srcstamp += $(test_gaussian_pdf_gradient_SOURCES)
 srcstamp += $(test_log_normal_pdf_gradient_SOURCES)
 srcstamp += $(test_beta_pdf_gradient_SOURCES)
+srcstamp += $(test_intercomm0_gravity_SOURCES)
 
 TESTS =
 TESTS += $(top_builddir)/test/test_uqEnvironmentNonFatal
@@ -251,6 +260,7 @@ TESTS += $(top_builddir)/test/test_jeffreys_pdf
 TESTS += $(top_builddir)/test/test_gaussian_pdf_gradient
 TESTS += $(top_builddir)/test/test_log_normal_pdf_gradient
 TESTS += $(top_builddir)/test/test_beta_pdf_gradient
+TESTS += $(top_builddir)/test/test_intercomm0/test_intercomm0_gravity_run.sh
 
 XFAIL_TESTS = $(top_builddir)/test/test_SequenceOfVectorsErase
 if ! MPI_ENABLED
@@ -285,6 +295,9 @@ EXTRA_DIST += test_InputOptionsParser/test_options_bad.txt.in
 EXTRA_DIST += test_InputOptionsParser/test_options_default.txt.in
 EXTRA_DIST += test_optimizer/input_test_optimizer_options.in
 EXTRA_DIST += test_Environment/input_test_serialEnv.in
+EXTRA_DIST += test_intercomm0/gravity_1proc.txt.in
+EXTRA_DIST += test_intercomm0/gravity_2proc.txt.in
+EXTRA_DIST += test_intercomm0/test_intercomm0_gravity_run.sh.in
 
 CLEANFILES =
 CLEANFILES += test_Environment/debug_output_sub0.txt
@@ -302,6 +315,8 @@ clean-local:
 	rm -rf $(top_builddir)/test/test_output_interp_surrogates
 	rm -rf $(top_builddir)/test/output_test_optimizer_options
 	rm -rf $(top_builddir)/test/output_test_serialEnv
+	rm -rf $(top_builddir)/test/output_test_intercomm0_gravity_1
+	rm -rf $(top_builddir)/test/output_test_intercomm0_gravity_2
 
 if CODE_COVERAGE_ENABLED
   CLEANFILES += *.gcda *.gcno

--- a/test/test_intercomm0/gravity_1proc.txt.in
+++ b/test/test_intercomm0/gravity_1proc.txt.in
@@ -1,0 +1,73 @@
+###############################################
+# UQ Environment
+###############################################
+env_numSubEnvironments   = 1
+env_subDisplayFileName   = output_test_intercomm0_gravity_1/display_env
+env_subDisplayAllowAll   = 0
+env_subDisplayAllowedSet = 0 1 2 3 4 5 6 7
+env_displayVerbosity     = 2
+env_seed                 = -1
+
+###############################################
+# Statistical inverse problem (ip)
+###############################################
+ip_computeSolution      = 1
+ip_dataOutputFileName   = output_test_intercomm0_gravity_1/sip_gravity
+ip_dataOutputAllowedSet = 0 1
+
+###############################################
+# Information for Metropolis-Hastings algorithm
+###############################################
+ip_mh_dataOutputFileName   = output_test_intercomm0_gravity_1/sip_gravity
+ip_mh_dataOutputAllowedSet = 0 1
+
+ip_mh_rawChain_dataInputFileName    = .
+ip_mh_rawChain_size                 = 20000
+ip_mh_rawChain_generateExtra        = 0
+ip_mh_rawChain_displayPeriod        = 2000
+ip_mh_rawChain_measureRunTimes      = 1
+ip_mh_rawChain_dataOutputFileName   = output_test_intercomm0_gravity_1/sip_gravity_raw_chain
+ip_mh_rawChain_dataOutputAllowedSet = 0 1 2 3 4 5 6 7
+
+ip_mh_displayCandidates             = 0
+ip_mh_putOutOfBoundsInChain         = 0
+ip_mh_dr_maxNumExtraStages          = 3
+ip_mh_dr_listOfScalesForExtraStages = 5. 10. 20.
+ip_mh_am_initialNonAdaptInterval    = 0
+ip_mh_am_adaptInterval              = 100
+ip_mh_am_eta                        = 1.98  	#(2.4^2)/d, d is the dimension of the problem
+ip_mh_am_epsilon                    = 1.e-5
+
+ip_mh_filteredChain_generate             = 1
+ip_mh_filteredChain_discardedPortion     = 0.
+ip_mh_filteredChain_lag                  = 20
+ip_mh_filteredChain_dataOutputFileName   = output_test_intercomm0_gravity_1/sip_gravity_filtered_chain
+ip_mh_filteredChain_dataOutputAllowedSet = 0 1
+
+###############################################
+# Statistical forward problem (fp)
+###############################################
+fp_help                 = anything
+fp_computeSolution      = 1
+fp_computeCovariances   = 1
+fp_computeCorrelations  = 1
+fp_dataOutputFileName   = output_test_intercomm0_gravity_1/sfp_gravity
+fp_dataOutputAllowedSet = 0 1
+
+###############################################
+# 'fp_': information for Monte Carlo algorithm
+###############################################
+fp_mc_help                 = anything
+fp_mc_dataOutputFileName   = output_test_intercomm0_gravity_1/sfp_gravity
+fp_mc_dataOutputAllowedSet = 0 1
+
+fp_mc_pseq_dataOutputFileName   = output_test_intercomm0_gravity_1/sfp_gravity_p_seq
+fp_mc_pseq_dataOutputAllowedSet = 0 1
+
+fp_mc_qseq_dataInputFileName    = .
+fp_mc_qseq_size                 = 16384
+fp_mc_qseq_displayPeriod        = 20000
+fp_mc_qseq_measureRunTimes      = 1
+fp_mc_qseq_dataOutputFileName   = output_test_intercomm0_gravity_1/sfp_gravity_qoi_seq
+fp_mc_qseq_dataOutputAllowedSet = 0 1
+

--- a/test/test_intercomm0/gravity_2proc.txt.in
+++ b/test/test_intercomm0/gravity_2proc.txt.in
@@ -1,0 +1,73 @@
+###############################################
+# UQ Environment
+###############################################
+env_numSubEnvironments   = 1
+env_subDisplayFileName   = output_test_intercomm0_gravity_2/display_env
+env_subDisplayAllowAll   = 0
+env_subDisplayAllowedSet = 0 1 2 3 4 5 6 7
+env_displayVerbosity     = 2
+env_seed                 = -1
+
+###############################################
+# Statistical inverse problem (ip)
+###############################################
+ip_computeSolution      = 1
+ip_dataOutputFileName   = output_test_intercomm0_gravity_2/sip_gravity
+ip_dataOutputAllowedSet = 0 1
+
+###############################################
+# Information for Metropolis-Hastings algorithm
+###############################################
+ip_mh_dataOutputFileName   = output_test_intercomm0_gravity_2/sip_gravity
+ip_mh_dataOutputAllowedSet = 0 1
+
+ip_mh_rawChain_dataInputFileName    = .
+ip_mh_rawChain_size                 = 20000
+ip_mh_rawChain_generateExtra        = 0
+ip_mh_rawChain_displayPeriod        = 2000
+ip_mh_rawChain_measureRunTimes      = 1
+ip_mh_rawChain_dataOutputFileName   = output_test_intercomm0_gravity_2/sip_gravity_raw_chain
+ip_mh_rawChain_dataOutputAllowedSet = 0 1 2 3 4 5 6 7
+
+ip_mh_displayCandidates             = 0
+ip_mh_putOutOfBoundsInChain         = 0
+ip_mh_dr_maxNumExtraStages          = 3
+ip_mh_dr_listOfScalesForExtraStages = 5. 10. 20.
+ip_mh_am_initialNonAdaptInterval    = 0
+ip_mh_am_adaptInterval              = 100
+ip_mh_am_eta                        = 1.98  	#(2.4^2)/d, d is the dimension of the problem
+ip_mh_am_epsilon                    = 1.e-5
+
+ip_mh_filteredChain_generate             = 1
+ip_mh_filteredChain_discardedPortion     = 0.
+ip_mh_filteredChain_lag                  = 20
+ip_mh_filteredChain_dataOutputFileName   = output_test_intercomm0_gravity_2/sip_gravity_filtered_chain
+ip_mh_filteredChain_dataOutputAllowedSet = 0 1
+
+###############################################
+# Statistical forward problem (fp)
+###############################################
+fp_help                 = anything
+fp_computeSolution      = 1
+fp_computeCovariances   = 1
+fp_computeCorrelations  = 1
+fp_dataOutputFileName   = output_test_intercomm0_gravity_2/sfp_gravity
+fp_dataOutputAllowedSet = 0 1
+
+###############################################
+# 'fp_': information for Monte Carlo algorithm
+###############################################
+fp_mc_help                 = anything
+fp_mc_dataOutputFileName   = output_test_intercomm0_gravity_2/sfp_gravity
+fp_mc_dataOutputAllowedSet = 0 1
+
+fp_mc_pseq_dataOutputFileName   = output_test_intercomm0_gravity_2/sfp_gravity_p_seq
+fp_mc_pseq_dataOutputAllowedSet = 0 1
+
+fp_mc_qseq_dataInputFileName    = .
+fp_mc_qseq_size                 = 16384
+fp_mc_qseq_displayPeriod        = 20000
+fp_mc_qseq_measureRunTimes      = 1
+fp_mc_qseq_dataOutputFileName   = output_test_intercomm0_gravity_2/sfp_gravity_qoi_seq
+fp_mc_qseq_dataOutputAllowedSet = 0 1
+

--- a/test/test_intercomm0/gravity_likelihood.C
+++ b/test/test_intercomm0/gravity_likelihood.C
@@ -1,0 +1,93 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <cmath>
+
+#include <queso/GenericScalarFunction.h>
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/UniformVectorRV.h>
+#include <queso/StatisticalInverseProblem.h>
+#include <queso/ScalarFunction.h>
+#include <queso/VectorSet.h>
+
+#include <gravity_likelihood.h>
+
+template<class V, class M>
+Likelihood<V, M>::Likelihood(const char * prefix,
+    const QUESO::VectorSet<V, M> & domain)
+  : QUESO::BaseScalarFunction<V, M>(prefix, domain),
+    m_heights(0),
+    m_times(0),
+    m_stdDevs(0)
+{
+  double const heights[] = {10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110,
+                            120, 130, 140};
+
+  double const times  [] = {1.41, 2.14, 2.49, 2.87, 3.22, 3.49, 3.81, 4.07,
+                            4.32, 4.47, 4.75, 4.99, 5.16, 5.26};
+
+  double const stdDevs[] = {0.020, 0.120, 0.020, 0.010, 0.030, 0.010, 0.030,
+                            0.030, 0.030, 0.050, 0.010, 0.040, 0.010, 0.09};
+
+  std::size_t const n = sizeof(heights) / sizeof(*heights);
+  m_heights.assign(heights, heights + n);
+  m_times.assign(times, times + n);
+  m_stdDevs.assign(stdDevs, stdDevs + n);
+}
+
+template<class V, class M>
+Likelihood<V, M>::~Likelihood()
+{
+  // Deconstruct here
+}
+
+template<class V, class M>
+double
+Likelihood<V, M>::lnValue(const V & domainVector, const V * domainDirection,
+    V * gradVector, M * hessianMatrix, V * hessianEffect) const
+{
+  double g = domainVector[0];
+
+  double misfitValue = 0.0;
+  for (unsigned int i = 0; i < m_heights.size(); ++i) {
+    double modelTime = std::sqrt(2.0 * m_heights[i] / g);
+    double ratio = (modelTime - m_times[i]) / m_stdDevs[i];
+    misfitValue += ratio * ratio;
+  }
+
+  return -0.5 * misfitValue;
+}
+
+template<class V, class M>
+double
+Likelihood<V, M>::actualValue(const V & domainVector,
+    const V * domainDirection, V * gradVector, M * hessianMatrix,
+    V * hessianEffect) const
+{
+  return std::exp(this->lnValue(domainVector, domainDirection, gradVector,
+        hessianMatrix, hessianEffect));
+}
+
+template class Likelihood<QUESO::GslVector, QUESO::GslMatrix>;

--- a/test/test_intercomm0/gravity_likelihood.h
+++ b/test/test_intercomm0/gravity_likelihood.h
@@ -1,0 +1,48 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef QUESO_EXAMPLE_GRAVITY_LIKELIHOOD_H
+#define QUESO_EXAMPLE_GRAVITY_LIKELIHOOD_H
+
+#include <queso/ScalarFunction.h>
+#include <queso/GslMatrix.h>
+
+template<class V = QUESO::GslVector, class M = QUESO::GslMatrix>
+class Likelihood : public QUESO::BaseScalarFunction<V, M>
+{
+public:
+  Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domain);
+  virtual ~Likelihood();
+  virtual double lnValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const;
+  virtual double actualValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const;
+
+private:
+  std::vector<double> m_heights; // heights
+  std::vector<double> m_times;   // times
+  std::vector<double> m_stdDevs; // uncertainties in time measurements
+};
+
+#endif

--- a/test/test_intercomm0/gravity_main.C
+++ b/test/test_intercomm0/gravity_main.C
@@ -1,0 +1,174 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+/*
+ * Brief description of this file:
+ *
+ * The SIP consists on calibrating the magnitude 'g' of acceleration gravity
+ * using measurements of the time that it takes for an object in free fall to
+ * reach the ground from a given height and zero initial velocity. The
+ * solution of the SIP is the posterior probability density function (PDF) of
+ * 'g'.
+ *
+ * The SFP consists of calculating the maximum distance traveled by an object
+ * in projectile motion. The posterior PDF of 'g' from the SIP might be used
+ * as input to the SFP.
+ *
+ * The code consists of 7 files:
+ * - 'gravity_main.C' (this file)
+ * - 'gravity_likelihood.C' (necessary for the SIP)
+ * - 'gravity_likelihood.h'
+ * - 'gravity_qoi.C' (necessary for the SFP)
+ * - 'gravity_qoi.h'
+ */
+
+#include <cmath>
+
+#include <queso/GslMatrix.h>
+#include <queso/GenericScalarFunction.h>
+#include <queso/GenericVectorFunction.h>
+#include <queso/GaussianVectorRV.h>
+#include <queso/UniformVectorRV.h>
+#include <queso/GenericVectorRV.h>
+#include <queso/StatisticalInverseProblem.h>
+#include <queso/StatisticalForwardProblem.h>
+
+#include <gravity_likelihood.h>
+#include <gravity_qoi.h>
+
+int main(int argc, char* argv[])
+{
+#ifndef QUESO_HAS_MPI
+  // Skip this test if we're not in parallel
+  return 77;
+#else
+
+  MPI_Init(&argc, &argv);
+
+  // Initialize QUESO environment
+  QUESO::FullEnvironment env(MPI_COMM_WORLD, argv[1], "", NULL);
+
+  //================================================================
+  // Statistical inverse problem (SIP): find posterior PDF for 'g'
+  //================================================================
+
+  //------------------------------------------------------
+  // SIP Step 1 of 6: Instantiate the parameter space
+  //------------------------------------------------------
+  QUESO::VectorSpace<> paramSpace(env, "param_", 1, NULL);
+
+  //------------------------------------------------------
+  // SIP Step 2 of 6: Instantiate the parameter domain
+  //------------------------------------------------------
+  QUESO::GslVector paramMinValues(paramSpace.zeroVector());
+  QUESO::GslVector paramMaxValues(paramSpace.zeroVector());
+
+  paramMinValues[0] = 8.;
+  paramMaxValues[0] = 11.;
+
+  QUESO::BoxSubset<> paramDomain("param_", paramSpace, paramMinValues,
+      paramMaxValues);
+
+  //------------------------------------------------------
+  // SIP Step 3 of 6: Instantiate the likelihood function
+  // object to be used by QUESO.
+  //------------------------------------------------------
+  Likelihood<> lhood("like_", paramDomain);
+
+  //------------------------------------------------------
+  // SIP Step 4 of 6: Define the prior RV
+  //------------------------------------------------------
+  QUESO::UniformVectorRV<> priorRv("prior_", paramDomain);
+
+  //------------------------------------------------------
+  // SIP Step 5 of 6: Instantiate the inverse problem
+  //------------------------------------------------------
+  // Extra prefix before the default "rv_" prefix
+  QUESO::GenericVectorRV<> postRv("post_", paramSpace);
+
+  // No extra prefix before the default "ip_" prefix
+  QUESO::StatisticalInverseProblem<> ip("", NULL, priorRv, lhood, postRv);
+
+  //------------------------------------------------------
+  // SIP Step 6 of 6: Solve the inverse problem, that is,
+  // set the 'pdf' and the 'realizer' of the posterior RV
+  //------------------------------------------------------
+  QUESO::GslVector paramInitials(paramSpace.zeroVector());
+  priorRv.realizer().realization(paramInitials);
+
+  QUESO::GslMatrix proposalCovMatrix(paramSpace.zeroVector());
+  proposalCovMatrix(0,0) = std::pow(std::abs(paramInitials[0]) / 20.0, 2.0);
+
+  ip.solveWithBayesMetropolisHastings(NULL, paramInitials, &proposalCovMatrix);
+
+  //================================================================
+  // Statistical forward problem (SFP): find the max distance
+  // traveled by an object in projectile motion; input pdf for 'g'
+  // is the solution of the SIP above.
+  //================================================================
+
+  //------------------------------------------------------
+  // SFP Step 1 of 6: Instantiate the parameter *and* qoi spaces.
+  // SFP input RV = FIP posterior RV, so SFP parameter space
+  // has been already defined.
+  //------------------------------------------------------
+  QUESO::VectorSpace<> qoiSpace(env, "qoi_", 1, NULL);
+
+  //------------------------------------------------------
+  // SFP Step 2 of 6: Instantiate the parameter domain
+  //------------------------------------------------------
+
+  // Not necessary because input RV of the SFP = output RV of SIP.
+  // Thus, the parameter domain has been already defined.
+
+  //------------------------------------------------------
+  // SFP Step 3 of 6: Instantiate the qoi object
+  // to be used by QUESO.
+  //------------------------------------------------------
+  Qoi<> qoi("qoi_", paramDomain, qoiSpace);
+
+  //------------------------------------------------------
+  // SFP Step 4 of 6: Define the input RV
+  //------------------------------------------------------
+
+  // Not necessary because input RV of SFP = output RV of SIP
+  // (postRv).
+
+  //------------------------------------------------------
+  // SFP Step 5 of 6: Instantiate the forward problem
+  //------------------------------------------------------
+  QUESO::GenericVectorRV<> qoiRv("qoi_", qoiSpace);
+
+  QUESO::StatisticalForwardProblem<> fp("", NULL, postRv, qoi, qoiRv);
+
+  //------------------------------------------------------
+  // SFP Step 6 of 6: Solve the forward problem
+  //------------------------------------------------------
+  fp.solveWithMonteCarlo(NULL);
+
+  MPI_Finalize();
+
+  return 0;
+#endif  // QUESO_HAS_MPI
+}

--- a/test/test_intercomm0/gravity_qoi.C
+++ b/test/test_intercomm0/gravity_qoi.C
@@ -1,0 +1,79 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+/*
+ * Brief description of this file:
+ *
+ * This file contains the code for the user defined qoi routine.
+ */
+
+#include <cmath>
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <gravity_qoi.h>
+
+template<class P_V, class P_M, class Q_V, class Q_M>
+Qoi<P_V, P_M, Q_V, Q_M>::Qoi(const char * prefix,
+    const QUESO::VectorSet<P_V, P_M> & domainSet,
+    const QUESO::VectorSet<Q_V, Q_M> & imageSet)
+  : QUESO::BaseVectorFunction<P_V, P_M, Q_V, Q_M>(prefix, domainSet, imageSet),
+    m_angle(M_PI / 4.0),
+    m_initialVelocity(5.0),
+    m_initialHeight(0.0)
+{
+}
+
+template<class P_V, class P_M, class Q_V, class Q_M>
+Qoi<P_V, P_M, Q_V, Q_M>::~Qoi()
+{
+  // Deconstruct here
+}
+
+template<class P_V, class P_M, class Q_V, class Q_M>
+void
+Qoi<P_V, P_M, Q_V, Q_M>::compute(const P_V & domainVector,
+    const P_V * domainDirection,
+    Q_V & imageVector, QUESO::DistArray<P_V *> * gradVectors,
+    QUESO::DistArray<P_M *> * hessianMatrices,
+    QUESO::DistArray<P_V *> * hessianEffects) const
+{
+  if (domainVector.sizeLocal() != 1) {
+    queso_error_msg("domainVector does not have size 1");
+  }
+  if (imageVector.sizeLocal() != 1) {
+    queso_error_msg("imageVector does not have size 1");
+  }
+
+  double g = domainVector[0];  // Sample of the RV 'gravity acceleration'
+  double distanceTraveled = 0.0;
+  double aux = m_initialVelocity * std::sin(m_angle);
+  distanceTraveled = (m_initialVelocity * std::cos(m_angle) / g) *
+    (aux + std::sqrt(std::pow(aux, 2) + 2.0 * g * m_initialHeight));
+
+  imageVector[0] = distanceTraveled;
+}
+
+template class Qoi<QUESO::GslVector, QUESO::GslMatrix, QUESO::GslVector,
+                   QUESO::GslMatrix>;

--- a/test/test_intercomm0/gravity_qoi.h
+++ b/test/test_intercomm0/gravity_qoi.h
@@ -1,0 +1,60 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+/*
+ * Brief description of this file:
+ *
+ * This is the header file from gravity_qoi.C.
+ */
+
+#ifndef QUESO_EXAMPLE_GRAVITY_QOI_H
+#define QUESO_EXAMPLE_GRAVITY_QOI_H
+
+#include <queso/VectorFunction.h>
+#include <queso/DistArray.h>
+
+template<class P_V = QUESO::GslVector, class P_M = QUESO::GslMatrix,
+         class Q_V = QUESO::GslVector, class Q_M = QUESO::GslMatrix>
+class Qoi : public QUESO::BaseVectorFunction<P_V, P_M, Q_V, Q_M>
+{
+public:
+  Qoi(const char * prefix, const QUESO::VectorSet<P_V, P_M> & domainSet,
+      const QUESO::VectorSet<Q_V, Q_M> & imageSet);
+  virtual ~Qoi();
+  virtual void compute(const P_V & domainVector, const P_V * domainDirection,
+      Q_V & imageVector, QUESO::DistArray<P_V *> * gradVectors,
+      QUESO::DistArray<P_M *> * hessianMatrices,
+      QUESO::DistArray<P_V *> * hessianEffects) const;
+
+  void setAngle(double angle);
+  void setInitialVelocity(double velocity);
+  void setInitialHeight(double height);
+
+private:
+  double m_angle;
+  double m_initialVelocity;
+  double m_initialHeight;
+};
+
+#endif

--- a/test/test_intercomm0/test_intercomm0_gravity_run.sh.in
+++ b/test/test_intercomm0/test_intercomm0_gravity_run.sh.in
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -eu
+set -o pipefail
+
+if (( @HAVE_MPI@ )); then
+  mpirun -np 1 ../libtool --mode=execute ./test_intercomm0_gravity \
+    test_intercomm0/gravity_1proc.txt
+
+  mpirun -np 2 ../libtool --mode=execute ./test_intercomm0_gravity \
+    test_intercomm0/gravity_2proc.txt
+
+  for i in output_test_intercomm0_gravity_1/*.m; do
+    j=`basename $i`;
+    diff output_test_intercomm0_gravity_1/$j output_test_intercomm0_gravity_2/$j;
+  done
+else
+  exit 77
+fi


### PR DESCRIPTION
This patch adds some safeguards to avoid code that does inter0Comm computing
from being executed by processes that don't belong to the inter0Comm.
Specifically, computing the unified MLE (and positions) and computing
correlation matrices are to only be done on the inter0Comm, since this is where
all the samples live anyway.

Marked as 'do not merge' because this still needs a test.