### PR TITLE
Support hdf5 output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,4 @@ test/test_intercomm0_gravity
 test/test_intercomm0/gravity_1proc.txt
 test/test_intercomm0/gravity_2proc.txt
 test/test_intercomm0/test_intercomm0_gravity_run.sh
+test/test_seq_of_vec_hdf5_write

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,9 @@ QUESO: Quantification of Uncertainty for Estimation,
 Simulation, and Optimization.
 -----------------------------------------------------
 
+Version 0.55.0
+  * Add support for HDF5 output
+
 Version 0.54.0
   * Fix memory leak in test_GslVector
   * Make MPI optional

--- a/src/basic/src/ScalarSequence.C
+++ b/src/basic/src/ScalarSequence.C
@@ -2614,7 +2614,7 @@ ScalarSequence<T>::subWriteContents(
 
       // Create dataset
       hid_t dataset_id = H5Dcreate(filePtrSet.h5Var,
-                                   "samples",
+                                   "data",
                                    H5T_IEEE_F64LE,
                                    dataspace_id,
                                    H5P_DEFAULT,
@@ -2775,7 +2775,7 @@ ScalarSequence<T>::unifiedWriteContents(
               hid_t dataspace = H5Screate_simple(1, dimsf, NULL); // HDF5_rank = 2
               //std::cout << "In ScalarSequence<T>::unifiedWriteContents(): h5 case, data space created" << std::endl;
               hid_t dataset = H5Dcreate2(unifiedFilePtrSet.h5Var,
-                                         "seq_of_vectors",
+                                         "data",
                                          datatype,
                                          dataspace,
                                          H5P_DEFAULT,  // Link creation property list
@@ -3070,7 +3070,7 @@ ScalarSequence<T>::unifiedReadContents(
           else if (fileType == UQ_FILE_EXTENSION_FOR_HDF_FORMAT) {
             if (r == 0) {
               hid_t dataset = H5Dopen2(unifiedFilePtrSet.h5Var,
-                                       "seq_of_vectors",
+                                       "data",
                                        H5P_DEFAULT); // Dataset access property list
               hid_t datatype  = H5Dget_type(dataset);
               H5T_class_t t_class = H5Tget_class(datatype);

--- a/src/basic/src/ScalarSequence.C
+++ b/src/basic/src/ScalarSequence.C
@@ -2607,8 +2607,6 @@ ScalarSequence<T>::subWriteContents(
 
     m_env.closeFile(filePtrSet,fileType);
   }
-
-  return;
 }
 // --------------------------------------------------
 template <class T>

--- a/src/basic/src/ScalarSequence.C
+++ b/src/basic/src/ScalarSequence.C
@@ -2593,10 +2593,18 @@ ScalarSequence<T>::subWriteContents(
                            false, // A 'true' causes problems when the user chooses (via options
                                   // in the input file) to use just one file for all outputs.
                            filePtrSet)) {
-    this->subWriteContents(initialPos,
-                           numPos,
-                           *filePtrSet.ofsVar,
-                           fileType);
+
+    if (fileType == UQ_FILE_EXTENSION_FOR_MATLAB_FORMAT ||
+        fileType == UQ_FILE_EXTENSION_FOR_TXT_FORMAT) {
+      this->subWriteContents(initialPos,
+                             numPos,
+                             *filePtrSet.ofsVar,
+                             fileType);
+    }
+    else if (fileType == UQ_FILE_EXTENSION_FOR_HDF_FORMAT) {
+      // Do nothing
+    }
+
     m_env.closeFile(filePtrSet,fileType);
   }
 

--- a/src/basic/src/ScalarSequence.C
+++ b/src/basic/src/ScalarSequence.C
@@ -2770,10 +2770,9 @@ ScalarSequence<T>::unifiedWriteContents(
             if (r == 0) {
               hid_t datatype = H5Tcopy(H5T_NATIVE_DOUBLE);
               //std::cout << "In ScalarSequence<T>::unifiedWriteContents(): h5 case, data type created" << std::endl;
-              hsize_t dimsf[2];
-              dimsf[0] = numParams;
-              dimsf[1] = chainSize;
-              hid_t dataspace = H5Screate_simple(2, dimsf, NULL); // HDF5_rank = 2
+              hsize_t dimsf[1];
+              dimsf[0] = chainSize;
+              hid_t dataspace = H5Screate_simple(1, dimsf, NULL); // HDF5_rank = 2
               //std::cout << "In ScalarSequence<T>::unifiedWriteContents(): h5 case, data space created" << std::endl;
               hid_t dataset = H5Dcreate2(unifiedFilePtrSet.h5Var,
                                          "seq_of_vectors",
@@ -2789,21 +2788,6 @@ ScalarSequence<T>::unifiedWriteContents(
               iRC = gettimeofday(&timevalBegin,NULL);
               if (iRC) {}; // just to remove compiler warning
 
-              //double* dataOut[numParams]; // avoid compiler warning
-        std::vector<double*> dataOut((size_t) numParams,NULL);
-              dataOut[0] = (double*) malloc(numParams*chainSize*sizeof(double));
-              for (unsigned int i = 1; i < numParams; ++i) { // Yes, from '1'
-                dataOut[i] = dataOut[i-1] + chainSize; // Yes, just 'chainSize', not 'chainSize*sizeof(double)'
-              }
-              //std::cout << "In ScalarSequence<T>::unifiedWriteContents(): h5 case, memory allocated" << std::endl;
-              for (unsigned int j = 0; j < chainSize; ++j) {
-                T tmpScalar = m_seq[j];
-                for (unsigned int i = 0; i < numParams; ++i) {
-                  dataOut[i][j] = tmpScalar;
-                }
-              }
-              //std::cout << "In ScalarSequence<T>::unifiedWriteContents(): h5 case, memory filled" << std::endl;
-
               herr_t status;
               //std::cout << "\n In ScalarSequence<T>::unifiedWriteContents(), pos 002 \n" << std::endl;
               status = H5Dwrite(dataset,
@@ -2811,7 +2795,7 @@ ScalarSequence<T>::unifiedWriteContents(
                                 H5S_ALL,
                                 H5S_ALL,
                                 H5P_DEFAULT,
-                                (void*) dataOut[0]);
+                                &m_seq[0]);
               if (status) {}; // just to remove compiler warning
 
               //std::cout << "\n In ScalarSequence<T>::unifiedWriteContents(), pos 003 \n" << std::endl;
@@ -2838,10 +2822,6 @@ ScalarSequence<T>::unifiedWriteContents(
               //std::cout << "In ScalarSequence<T>::unifiedWriteContents(): h5 case, data space closed" << std::endl;
               H5Tclose(datatype);
               //std::cout << "In ScalarSequence<T>::unifiedWriteContents(): h5 case, data type closed" << std::endl;
-              //free(dataOut[0]); // related to the changes above for compiler warning
-              for (unsigned int tmpIndex = 0; tmpIndex < dataOut.size(); tmpIndex++) {
-                free (dataOut[tmpIndex]);
-              }
             }
             else {
               queso_error_msg("hdf file type not supported for multiple sub-environments yet");

--- a/src/basic/src/SequenceOfVectors.C
+++ b/src/basic/src/SequenceOfVectors.C
@@ -1353,7 +1353,7 @@ SequenceOfVectors<V,M>::subWriteContents(
 
     // Create dataset
     hid_t dataset_id = H5Dcreate(filePtrSet.h5Var,
-                                 "samples",
+                                 "data",
                                  H5T_IEEE_F64LE,
                                  dataspace_id,
                                  H5P_DEFAULT,
@@ -1626,7 +1626,7 @@ SequenceOfVectors<V,M>::unifiedWriteContents(
               hid_t dataspace = H5Screate_simple(2, dimsf, NULL); // HDF5_rank = 2
               //std::cout << "In SequenceOfVectors<V,M>::unifiedWriteContents(): h5 case, data space created" << std::endl;
               hid_t dataset = H5Dcreate2(unifiedFilePtrSet.h5Var,
-                                         "seq_of_vectors",
+                                         "data",
                                          datatype,
                                          dataspace,
                                          H5P_DEFAULT,  // Link creation property list
@@ -1924,7 +1924,7 @@ SequenceOfVectors<V,M>::unifiedReadContents(
           else if (fileType == UQ_FILE_EXTENSION_FOR_HDF_FORMAT) {
             if (r == 0) {
               hid_t dataset = H5Dopen2(unifiedFilePtrSet.h5Var,
-                                       "seq_of_vectors",
+                                       "data",
                                        H5P_DEFAULT); // Dataset access property list
               hid_t datatype  = H5Dget_type(dataset);
               H5T_class_t t_class = H5Tget_class(datatype);

--- a/src/core/src/Environment.C
+++ b/src/core/src/Environment.C
@@ -654,22 +654,6 @@ BaseEnvironment::openOutputFile(
           }
         } // only for matlab formats
       }
-      if (filePtrSet.ofsVar != NULL) {
-        if ((m_subDisplayFile) && (this->displayVerbosity() > 10)) { // output debug
-          *this->subDisplayFile() << "In BaseEnvironment::openOutputFile()"
-                                  << ", subId = "     << this->subId()
-                                  << ": succeeded on opening output file with base name '" << baseFileName << "." << fileType
-                                  << "'"
-                                  << ", writeOver = " << writeOver
-                                  << std::endl;
-        }
-      }
-      else {
-        std::cerr << "In BaseEnvironment::openOutputFile()"
-                  << ": failed to open output file with base name '" << baseFileName << "." << fileType
-                  << "'"
-                  << std::endl;
-      }
 
       // Check the file actually opened
       if ((fileType == UQ_FILE_EXTENSION_FOR_MATLAB_FORMAT) ||
@@ -678,7 +662,6 @@ BaseEnvironment::openOutputFile(
             (filePtrSet.ofsVar && filePtrSet.ofsVar->is_open()),
             "failed to open output file");
       }
-
     }
     else {
       returnValue = false;

--- a/src/core/src/Environment.C
+++ b/src/core/src/Environment.C
@@ -112,6 +112,10 @@ FilePtrSetStruct::FilePtrSetStruct()
   :
   ofsVar(NULL),
   ifsVar(NULL)
+#ifdef QUESO_HAS_HDF5
+  ,  // lol
+  h5Var(-1)
+#endif
 {
 }
 

--- a/src/core/src/GslVector.C
+++ b/src/core/src/GslVector.C
@@ -51,7 +51,6 @@ GslVector::GslVector(const BaseEnvironment& env, const Map& map)
   //          << "\n  map.NumMyElements()     = " << map.NumMyElements()
   //          << std::endl;
 
-  //std::cout << "Leaving GslVector::constructor(1)" << std::endl;
 }
 
 GslVector::GslVector(const BaseEnvironment& env, const Map& map, double value)
@@ -1091,7 +1090,6 @@ GslVector::abs() const
     }
 
   return abs_of_this_vec;
-
 }
 
 std::ostream&

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -59,6 +59,7 @@ check_PROGRAMS += test_gaussian_pdf_gradient
 check_PROGRAMS += test_log_normal_pdf_gradient
 check_PROGRAMS += test_beta_pdf_gradient
 check_PROGRAMS += test_intercomm0_gravity
+check_PROGRAMS += test_seq_of_vec_hdf5_write
 
 LDADD       = $(top_builddir)/src/libqueso.la
 
@@ -149,6 +150,7 @@ test_intercomm0_gravity_SOURCES += test_intercomm0/gravity_main.C
 test_intercomm0_gravity_SOURCES += test_intercomm0/gravity_qoi.C
 test_intercomm0_gravity_CPPFLAGS = -Itest_intercomm0 $(AM_CPPFLAGS)
 
+test_seq_of_vec_hdf5_write_SOURCES = test_SequenceOfVectors/test_HDF5Write.C
 
 # Files to freedom stamp
 srcstamp =
@@ -205,6 +207,7 @@ srcstamp += $(test_gaussian_pdf_gradient_SOURCES)
 srcstamp += $(test_log_normal_pdf_gradient_SOURCES)
 srcstamp += $(test_beta_pdf_gradient_SOURCES)
 srcstamp += $(test_intercomm0_gravity_SOURCES)
+srcstamp += $(test_seq_of_vec_hdf5_write_SOURCES)
 
 TESTS =
 TESTS += $(top_builddir)/test/test_uqEnvironmentNonFatal
@@ -261,6 +264,7 @@ TESTS += $(top_builddir)/test/test_gaussian_pdf_gradient
 TESTS += $(top_builddir)/test/test_log_normal_pdf_gradient
 TESTS += $(top_builddir)/test/test_beta_pdf_gradient
 TESTS += $(top_builddir)/test/test_intercomm0/test_intercomm0_gravity_run.sh
+TESTS += $(top_builddir)/test/test_seq_of_vec_hdf5_write
 
 XFAIL_TESTS = $(top_builddir)/test/test_SequenceOfVectorsErase
 if ! MPI_ENABLED
@@ -304,6 +308,7 @@ CLEANFILES += test_Environment/debug_output_sub0.txt
 CLEANFILES += gslvector_out_sub0.m
 CLEANFILES += test_write_InterpolationSurrogateBuilder_1.dat
 CLEANFILES += test_write_InterpolationSurrogateBuilder_2.dat
+CLEANFILES += output_test_hdf5_sub0.h5
 
 clean-local:
 	rm -rf $(top_builddir)/test/chain0

--- a/test/test_SequenceOfVectors/test_HDF5Write.C
+++ b/test/test_SequenceOfVectors/test_HDF5Write.C
@@ -1,0 +1,66 @@
+#include <vector>
+#include <string>
+#include <iostream>
+#include <set>
+#include <queso/Environment.h>
+#include <queso/EnvironmentOptions.h>
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/VectorSpace.h>
+#include <queso/SequenceOfVectors.h>
+
+int main(int argc, char **argv) {
+#ifndef QUESO_HAS_HDF5
+  // If we don't have HDF5, skip this test
+  return 77;
+#else
+#ifdef QUESO_HAS_MPI
+  MPI_Init(&argc, &argv);
+#endif
+
+  QUESO::EnvOptionsValues options;
+  options.m_numSubEnvironments = 1;
+  options.m_subDisplayFileName = ".";
+  options.m_subDisplayAllowAll = 0;
+  options.m_subDisplayAllowedSet.insert(0);
+  options.m_seed = 1.0;
+  options.m_checkingLevel = 1;
+  options.m_displayVerbosity = 0;
+
+#ifdef QUESO_HAS_MPI
+  QUESO::FullEnvironment env(MPI_COMM_WORLD, "", "", &options);
+#else
+  QUESO::FullEnvironment env("", "", &options);
+#endif
+
+  // Create a vector space
+  QUESO::VectorSpace<> vec_space(env, "", 2, NULL);
+
+  // Create some things to put in the sequence
+  QUESO::GslVector v1(vec_space.zeroVector());
+  v1[0] = 1.0;
+  v1[1] = 2.0;
+
+  QUESO::GslVector v2(vec_space.zeroVector());
+  v2[0] = 3.0;
+  v2[1] = 4.0;
+
+  // Create a sequence of vectors
+  QUESO::SequenceOfVectors<> vec_seq(vec_space, 2, "");
+
+  vec_seq.setPositionValues(0, v1);
+  vec_seq.setPositionValues(1, v2);
+
+  // Now write
+  if (env.fullRank() == 0) {
+    std::set<unsigned int> allowedIds;
+    allowedIds.insert(0);
+    vec_seq.subWriteContents(0, 2, "output_test_hdf5", "h5", allowedIds);
+  }
+
+#ifdef QUESO_HAS_MPI
+  MPI_Finalize();
+#endif
+  return 0;
+#endif  // QUESO_HAS_HDF
+}


### PR DESCRIPTION
Specifying, for example, `ip_mh_rawChain_dataOutputFileType = h5`, will write the raw chain to an HDF5 file.

The code here can definitely use some optimisation, but it's a good first start.