### PR TITLE
Update documentation for Gamma distribution

### DIFF
--- a/src/stats/inc/GammaJointPdf.h
+++ b/src/stats/inc/GammaJointPdf.h
@@ -68,6 +68,10 @@ public:
    * Indeed, \c a and \c b are vectors and in multiple dimensions the pdf is
    * just the product of Gamma(a_i, b_i) pdfs distributions in each dimension.
    * That is, they are independent.
+   *
+   * Note: the parameters \c a and \c b correspond to the shape and scale
+   * parameters \c k and \f$\theta\f$ in the
+   * <a href="https://en.wikipedia.org/wiki/Gamma_distribution">Wikipedia entry for the Gamma distribution</a>.
    */
   GammaJointPdf(const char*                  prefix,
                        const VectorSet<V,M>& domainSet,

--- a/src/stats/inc/GammaJointPdf.h
+++ b/src/stats/inc/GammaJointPdf.h
@@ -39,30 +39,43 @@ namespace QUESO {
 class GslVector;
 class GslMatrix;
 
-//*****************************************************
-// Gamma probability density class [PDF-06]
-//*****************************************************
 /*!
  * \class GammaJointPdf
  * \brief A class for handling Gamma joint PDFs.
  *
- * This class allows the mathematical definition of a Gamma Joint PDF.*/
-
+ * This class allows the mathematical definition of a Gamma Joint PDF.
+ */
 template <class V = GslVector, class M = GslMatrix>
 class GammaJointPdf : public BaseJointPdf<V,M> {
 public:
   //! @name Constructor/Destructor methods
   //@{
-  //! Constructor
-  /*! Constructs a new object of the class, given a prefix, the domain set, and the parameters
-   * \c a and \c b of the Gamma PDF.  */
+  //! Constructor for a shape-scale parameterisation of a Gamma(a,b) pdf
+  //! defined on \c domainSet.
+  /*!
+   * Constructs a new object of the class, given a prefix, the domain set, and
+   * the parameters \c a and \c b of the Gamma PDF.
+   *
+   * The parameters \c a and \c b are the shape and scale parameters,
+   * respectively.  That is, the pdf is
+   *
+   * \f[
+   *   f(x) = C x^{a-1} \exp \left( x / b \right),
+   * \f]
+   *
+   * where \c C is a normalising constant.
+   *
+   * Indeed, \c a and \c b are vectors and in multiple dimensions the pdf is
+   * just the product of Gamma(a_i, b_i) pdfs distributions in each dimension.
+   * That is, they are independent.
+   */
   GammaJointPdf(const char*                  prefix,
                        const VectorSet<V,M>& domainSet,
                        const V&                     a,
                        const V&                     b);
   //! Destructor
- ~GammaJointPdf();
- //@}
+  ~GammaJointPdf();
+  //@}
 
   //! @name Math methods
   //@{

--- a/src/stats/inc/GammaVectorRV.h
+++ b/src/stats/inc/GammaVectorRV.h
@@ -39,24 +39,28 @@ namespace QUESO {
 class GslVector;
 class GslMatrix;
 
-//*****************************************************
-// Gamma class [RV-06]
-//*****************************************************
 /*!
  * \class GammaVectorRV
  * \brief A class representing a vector RV constructed via Gamma distribution.
  *
- * This class allows the user to compute the value of a Gamma PDF and to generate realizations
- * (samples) from it.\n
+ * This class allows the user to compute the value of a Gamma PDF and to
+ * generate realizations (samples) from it.
  *
- * The gamma probability density function for a given value x and given pair of parameters
- * \b a and \b b is:
- *  \f[ y=f(x|a,b)= \frac{1}{b^{a}\Gamma(a)} x^{a-1} e^{\frac{x}{b}}, \f]
+ * The gamma probability density function for a given value x and given pair of
+ * parameters \b a and \b b is:
+ * \f[
+ *   y = f(x|a,b) = \frac{1}{b^{a}\Gamma(a)} x^{a-1} e^{\frac{x}{b}},
+ * \f]
+ *
  * where \f$ \Gamma(.) \f$ is the Gamma function:
- * \f[  B(a,b)=\frac{\Gamma(a)\Gamma(b)}{\Gamma(a+b)}=\frac{(a-1)!(b-1)!}{(a+b-1)!}.\f]
- * The parameters \b a and \b b must all be positive, and the values \c x  must lie on the
- * interval \f$ (0, \infty)\f$. */
-
+ * \f[
+ *   B(a,b) = \frac{\Gamma(a)\Gamma(b)}{\Gamma(a+b)}
+ *          = \frac{(a-1)!(b-1)!}{(a+b-1)!}.
+ * \f]
+ *
+ * The parameters \b a and \b b are shape and scale parameters and must all be
+ * positive, and the values \c x must lie on the interval \f$ (0, \infty)\f$.
+ */
 template <class V = GslVector, class M = GslMatrix>
 class GammaVectorRV : public BaseVectorRV<V,M> {
 public:

--- a/src/stats/inc/GammaVectorRealizer.h
+++ b/src/stats/inc/GammaVectorRealizer.h
@@ -35,15 +35,14 @@ namespace QUESO {
 class GslVector;
 class GslMatrix;
 
-//*****************************************************
-// Gamma class [R-06]
-//*****************************************************
 /*!
  * \class GammaVectorRealizer
  * \brief A class for handling sampling from a Gamma probability density distribution.
  *
- * This class handles sampling from a Gamma probability density distribution, of
- * parameters \c a and \c b.*/
+ * This class handles sampling from a Gamma probability density distribution,
+ * with shape and scale parameters \c a and \c b.  See GammaJointPdf for more
+ * details on the parameterisation of the distribution function.
+ */
 template <class V = GslVector, class M = GslMatrix>
 class GammaVectorRealizer : public BaseVectorRealizer<V,M> {
 public:


### PR DESCRIPTION
GammaJointPdf had basically no documentation regarding what role the parameters
a and b of the distribution mean.  This patch adds docs for these.  This patch
also updates GammaVectorRealizer to add references to GammaJointPdf to guide
the user more easily through how the Gamma(a, b) distribution is defined.