### PR TITLE
Fix a race condition in gsl test output directory

### DIFF
--- a/test/gsl_tests/input.in
+++ b/test/gsl_tests/input.in
@@ -2,10 +2,10 @@
 # UQ Environment
 ###############################################
 #env_help                = anything
-env_numSubEnvironments   = 1 
-env_subDisplayFileName   = outputData/display
+env_numSubEnvironments   = 1
+env_subDisplayFileName   = .
 env_subDisplayAllowAll   = 0
 env_subDisplayAllowedSet = 0
-env_displayVerbosity     = 0 
+env_displayVerbosity     = 0
 env_syncVerbosity        = 0
 env_seed                 = -1


### PR DESCRIPTION
The output isn't even needed, so this patch just turns it off.