### PR TITLE
Use libMesh::UniquePtr rather than AutoPtr

### DIFF
--- a/src/core/src/LibMeshNegativeLaplacianOperator.C
+++ b/src/core/src/LibMeshNegativeLaplacianOperator.C
@@ -164,9 +164,9 @@ void LibMeshNegativeLaplacianOperator::assemble()
 
   // Build a Finite Element object of the specified type.  Since the
   // \p FEBase::build() member dynamically creates memory we will
-  // store the object as an \p AutoPtr<FEBase>.  This can be thought
+  // store the object as an \p UniquePtr<FEBase>.  This can be thought
   // of as a pointer that will clean up after itself.
-  libMesh::AutoPtr<libMesh::FEBase> fe (libMesh::FEBase::build(dim, fe_type));
+  libMesh::UniquePtr<libMesh::FEBase> fe (libMesh::FEBase::build(dim, fe_type));
 
   // A  Gauss quadrature rule for numerical integration.
   // Use the default quadrature order.


### PR DESCRIPTION
This is necessary to match the corresponding API return value in many
configurations of newer libMesh versions