### PR TITLE
Fix normalising constant hyperparameter in canned likelihoods

### DIFF
--- a/src/stats/inc/GaussianLikelihoodFullCovarianceRandomCoefficient.h
+++ b/src/stats/inc/GaussianLikelihoodFullCovarianceRandomCoefficient.h
@@ -36,7 +36,12 @@ class GslMatrix;
  * \file GaussianLikelihoodFullCovarianceRandomCoefficient.h
  *
  * \class GaussianLikelihoodFullCovarianceRandomCoefficient
- * \brief A class that represents a Gaussian likelihood with full covariance and random coefficient
+ * \brief A class that represents a Gaussian likelihood with full covariance
+ * and random coefficient.
+ *
+ * The random coefficient is a scalar that pre-multiplies the covariance
+ * matrix.  This is treated as a hyperparameter to be inferred during
+ * the sampling procedure.
  */
 
 template <class V = GslVector, class M = GslMatrix>
@@ -71,7 +76,6 @@ public:
       V * gradVector, M * hessianMatrix, V * hessianEffect) const;
 
 private:
-  double m_covarianceCoefficient;
   const M & m_covariance;
 };
 

--- a/src/stats/src/GaussianLikelihoodFullCovarianceRandomCoefficient.C
+++ b/src/stats/src/GaussianLikelihoodFullCovarianceRandomCoefficient.C
@@ -90,7 +90,7 @@ GaussianLikelihoodFullCovarianceRandomCoefficient<V, M>::lnValue(
   // The last element of domainVector is the multiplicative coefficient of the
   // covariance matrix
   double cov_coeff = domainVector[domainVector.sizeLocal()-1];
-  cov_coeff = std::pow(std::sqrt(cov_coeff), domainVector.sizeGlobal());
+  cov_coeff = std::pow(std::sqrt(cov_coeff), this->m_observations.sizeLocal());
 
   return -0.5 * norm2_squared / cov_coeff - std::log(cov_coeff * deter_cov);
 }

--- a/src/stats/src/GaussianLikelihoodFullCovarianceRandomCoefficient.C
+++ b/src/stats/src/GaussianLikelihoodFullCovarianceRandomCoefficient.C
@@ -81,9 +81,18 @@ GaussianLikelihoodFullCovarianceRandomCoefficient<V, M>::lnValue(
   // This is square of 2-norm
   double norm2_squared = modelOutput.sumOfComponents();
 
+  // Get the determinant of the covariance matrix |\Sigma|
+  double deter_cov = this->m_covariance.determinant();
+
+  deter_cov = std::sqrt(deter_cov);
+
+  // Set the right hyperparameter coefficient
   // The last element of domainVector is the multiplicative coefficient of the
   // covariance matrix
-  return -0.5 * norm2_squared / (domainVector[domainVector.sizeLocal()-1]);
+  double cov_coeff = domainVector[domainVector.sizeLocal()-1];
+  cov_coeff = std::pow(std::sqrt(cov_coeff), domainVector.sizeGlobal());
+
+  return -0.5 * norm2_squared / cov_coeff - std::log(cov_coeff * deter_cov);
 }
 
 }  // End namespace QUESO

--- a/test/test_gaussian_likelihoods/test_blockDiagonalCovarianceRandomCoefficients.C
+++ b/test/test_gaussian_likelihoods/test_blockDiagonalCovarianceRandomCoefficients.C
@@ -127,10 +127,10 @@ int main(int argc, char ** argv) {
   point[1] = 4.0;
   point[2] = 2.0;
   lhood_value = lhood.actualValue(point, NULL, NULL, NULL, NULL);
-  truth_value = std::exp(-1.75);
+  truth_value = std::exp(-1.75) / 8.0;
 
   if (std::abs(lhood_value - truth_value) > TOL) {
-    std::cerr << "Random coefficient Gaussian test case failure." << std::endl;
+    std::cerr << "Random coefficient Gaussian test case 1 failure." << std::endl;
     std::cerr << "Computed likelihood value is: " << lhood_value << std::endl;
     std::cerr << "Likelihood value should be: " << truth_value << std::endl;
     queso_error();
@@ -140,10 +140,10 @@ int main(int argc, char ** argv) {
   point[1] = 1.0;
   point[2] = 1.0;
   lhood_value = lhood.actualValue(point, NULL, NULL, NULL, NULL);
-  truth_value = 1.0;
+  truth_value = 1.0 / 2.0;
 
   if (std::abs(lhood_value - truth_value) > TOL) {
-    std::cerr << "Random coefficient Gaussian test case failure." << std::endl;
+    std::cerr << "Random coefficient Gaussian test case 2 failure." << std::endl;
     std::cerr << "Computed likelihood value is: " << lhood_value << std::endl;
     std::cerr << "Likelihood value should be: " << truth_value << std::endl;
     queso_error();

--- a/test/test_gaussian_likelihoods/test_fullCovarianceRandomCoefficient.C
+++ b/test/test_gaussian_likelihoods/test_fullCovarianceRandomCoefficient.C
@@ -117,7 +117,7 @@ int main(int argc, char ** argv) {
   point[0] = 0.0;
   point[1] = 2.0;  // Multiplicative coefficient of obs matrix
   lhood_value = lhood.actualValue(point, NULL, NULL, NULL, NULL);
-  truth_value = std::exp(-5.0/4.0);
+  truth_value = std::exp(-5.0/4.0) / 4.0;
 
   if (std::abs(lhood_value - truth_value) > TOL) {
     std::cerr << "Random coefficient Gaussian test case failure." << std::endl;
@@ -129,7 +129,7 @@ int main(int argc, char ** argv) {
   point[0] = -2.0;
   point[1] = 1.0;
   lhood_value = lhood.actualValue(point, NULL, NULL, NULL, NULL);
-  truth_value = 1.0;
+  truth_value = 1.0 / 2.0;
 
   if (std::abs(lhood_value - truth_value) > TOL) {
     std::cerr << "Random coefficient Gaussian test case failure." << std::endl;


### PR DESCRIPTION
Replaces #395.