### PR TITLE
Fix typo in macro

### DIFF
--- a/src/misc/inc/math_macros.h
+++ b/src/misc/inc/math_macros.h
@@ -27,7 +27,7 @@
 
 #include <queso/config_queso.h>
 
-#ifdef QUESO_HAVE_CXX11_IS_NAN
+#ifdef QUESO_HAVE_CXX11_ISNAN
 #include <cmath>
 #elif QUESO_HAVE_BOOST_MATH_SPECIAL_FUNCTIONS_HPP
 #include <boost/math/special_functions.hpp>


### PR DESCRIPTION
This fixes the issue I raised in [this](https://github.com/libqueso/queso/pull/430#issuecomment-235745873) comment.

@pbauman This took me 6 hours to find.  I'll be invoicing you appropriately.