### PR TITLE
Converting asserts don't work for many data types

### DIFF
--- a/src/core/inc/asserts.h
+++ b/src/core/inc/asserts.h
@@ -68,29 +68,14 @@
 
 #define queso_require_msg(asserted, msg)  do { if (!(asserted)) { std::cerr << "Assertion `" #asserted "' failed.\n" << msg << std::endl; queso_error(); } } while(0)
 
-// When using C++11, we can test asserts comparing two different types
-// robustly
-//#if __cplusplus > 199711L // http://gcc.gnu.org/bugzilla/show_bug.cgi?id=1773
-#ifdef QUESO_HAVE_CXX11
-#define queso_require_types(expr1,expr2) typedef typename std::remove_reference<decltype(expr1)>::type type1; typedef typename std::remove_reference<decltype(expr2)>::type type2
-#define queso_require_equal_to_msg(expr1,expr2,msg)  do { queso_require_types(expr1,expr2); if (!((expr1 == static_cast<type1>(expr2)) && static_cast<type2>(expr1) == expr2)) { std::cerr << "Assertion `" #expr1 " == " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; queso_error(); } } while(0)
-#define queso_require_not_equal_to_msg(expr1,expr2,msg)  do { queso_require_types(expr1,expr2); if (!((expr1 != static_cast<type1>(expr2)) && (static_cast<type2>(expr1) != expr2))) { std::cerr << "Assertion `" #expr1 " != " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; queso_error(); } } while(0)
-#define queso_require_less_msg(expr1,expr2,msg)  do { queso_require_types(expr1,expr2); if (!((static_cast<type2>(expr1) < expr2) && (expr1 < static_cast<type1>(expr2)))) { std::cerr << "Assertion `" #expr1 " < " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; queso_error(); } } while(0)
-#define queso_require_greater_msg(expr1,expr2,msg)  do { queso_require_types(expr1,expr2); if (!((static_cast<type2>(expr1) > expr2) && (expr1 > static_cast<type1>(expr2)))) { std::cerr << "Assertion `" #expr1 " > " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; queso_error(); } } while(0)
-#define queso_require_less_equal_msg(expr1,expr2,msg)  do { queso_require_types(expr1,expr2); if (!((static_cast<type2>(expr1) <= expr2) && (expr1 <= static_cast<type1>(expr2)))) { std::cerr << "Assertion `" #expr1 " <= " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; queso_error(); } } while(0)
-#define queso_require_greater_equal_msg(expr1,expr2,msg)  do { queso_require_types(expr1,expr2); if (!((static_cast<type2>(expr1) >= expr2) && (expr1 >= static_cast<type1>(expr2)))) { std::cerr << "Assertion `" #expr1 " >= " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; queso_error(); } } while(0)
-
-// When using C++98, we let the compiler pick the type conversion and
-// hope for the best.
-#else
+// We can get more descriptive error messages if we're testing a
+// simple standard binary operation.
 #define queso_require_equal_to_msg(expr1,expr2,msg)  do { if (!(expr1 == expr2)) { std::cerr << "Assertion `" #expr1 " == " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; queso_error(); } } while(0)
 #define queso_require_not_equal_to_msg(expr1,expr2,msg)  do { if (!(expr1 != expr2)) { std::cerr << "Assertion `" #expr1 " != " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; queso_error(); } } while(0)
 #define queso_require_less_msg(expr1,expr2,msg)  do { if (!(expr1 < expr2)) { std::cerr << "Assertion `" #expr1 " < " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; queso_error(); } } while(0)
 #define queso_require_greater_msg(expr1,expr2,msg)  do { if (!(expr1 > expr2)) { std::cerr << "Assertion `" #expr1 " > " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; queso_error(); } } while(0)
 #define queso_require_less_equal_msg(expr1,expr2,msg)  do { if (!(expr1 <= expr2)) { std::cerr << "Assertion `" #expr1 " <= " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; queso_error(); } } while(0)
 #define queso_require_greater_equal_msg(expr1,expr2,msg)  do { if (!(expr1 >= expr2)) { std::cerr << "Assertion `" #expr1 " >= " #expr2 "' failed.\n" #expr1 " = " << (expr1) << "\n" #expr2 " = " << (expr2) << '\n' << msg << std::endl; queso_error(); } } while(0)
-
-#endif //QUESO_HAVE_CXX11
 
 // When not debugging, we don't test any asserts
 #ifdef NDEBUG


### PR DESCRIPTION
These were designed for numeric comparisons, but try to do something
as innocuous as compare std::string to const char * and they fail with
compiler errors.  Best to remove them entirely for now.