### PR TITLE
Demonstrate starting GPMSA from prior mean

### DIFF
--- a/examples/gp/vector/gpmsa_vector.C
+++ b/examples/gp/vector/gpmsa_vector.C
@@ -267,14 +267,11 @@ int main(int argc, char ** argv) {
       gpmsaFactory.prior().imageSet().vectorSpace().zeroVector());
 
   // Initial condition of the chain
-  // Have to set each of these by hand, *and* the sampler is sensitive to these
-  // values
-  paramInitials[0] = 0.5; // param 1
-  paramInitials[1] = 0.5; // param 2
-  paramInitials[2] = 0.5; // param 3
-  paramInitials[3] = 0.5; // param 4
-  paramInitials[4] = 0.5; // param 5
-  paramInitials[5]  = 0.4;  // not used.  emulator mean
+
+  // Start with the mean of the prior
+  gpmsaFactory.prior().pdf().distributionMean(paramInitials);
+
+  // But override whatever we want
   paramInitials[6]  = 0.4; // emulator precision
   paramInitials[7]  = 0.4; // weights0 precision
   paramInitials[8]  = 0.4; // weights1 precision

--- a/examples/gp/vector/gpmsa_vector.C
+++ b/examples/gp/vector/gpmsa_vector.C
@@ -272,19 +272,7 @@ int main(int argc, char ** argv) {
   gpmsaFactory.prior().pdf().distributionMean(paramInitials);
 
   // But override whatever we want
-  paramInitials[6]  = 0.4; // emulator precision
-  paramInitials[7]  = 0.4; // weights0 precision
-  paramInitials[8]  = 0.4; // weights1 precision
-  paramInitials[9]  = 0.97; // emulator corr str
-  paramInitials[10] = 0.97; // emulator corr str
-  paramInitials[11] = 0.97; // emulator corr str
-  paramInitials[12]  = 0.97; // emulator corr str
-  paramInitials[13]  = 0.20; // emulator corr str
-  paramInitials[14]  = 0.80; // emulator corr str
-  paramInitials[15]  = 10.0; // discrepancy precision
-  paramInitials[16]  = 0.97; // discrepancy corr str
-  paramInitials[17]  = 8000.0; // emulator data precision
-  paramInitials[18]  = 1.0;  // observation error precision
+  paramInitials[5]  = 0.4; // Not currently used.  Emulator mean
 
   QUESO::GslMatrix proposalCovMatrix(
       gpmsaFactory.prior().imageSet().vectorSpace().zeroVector());

--- a/test/test_gpmsa/test_gpmsa_vector.C
+++ b/test/test_gpmsa/test_gpmsa_vector.C
@@ -283,14 +283,15 @@ int main(int argc, char ** argv) {
       gpmsaFactory.prior().imageSet().vectorSpace().zeroVector());
 
   // Initial condition of the chain
-  // Have to set each of these by hand, *and* the sampler is sensitive to these
-  // values
-  paramInitials[0] = 0.5; // param 1
-  paramInitials[1] = 0.5; // param 2
-  paramInitials[2] = 0.5; // param 3
-  paramInitials[3] = 0.5; // param 4
-  paramInitials[4] = 0.5; // param 5
-  paramInitials[5]  = 0.4;  // not used.  emulator mean
+
+  // Start with the mean of the prior
+  gpmsaFactory.prior().pdf().distributionMean(paramInitials);
+
+  // But override whatever we want.
+  paramInitials[5]  = 0;   // Emulator mean, unused but don't leave it NaN!
+
+  // The rest of these we'll override, not because we have to, but
+  // because the regression gold standard predates distributionMean()
   paramInitials[6]  = 0.4; // emulator precision
   paramInitials[7]  = 0.4; // weights0 precision
   paramInitials[8]  = 0.4; // weights1 precision
@@ -303,7 +304,7 @@ int main(int argc, char ** argv) {
   paramInitials[15]  = 10.0; // discrepancy precision
   paramInitials[16]  = 0.97; // discrepancy corr str
   paramInitials[17]  = 8000.0; // emulator data precision
-  paramInitials[18]  = 1.0;  // observation error precision
+  // paramInitials[18]  = 1.0;  // observation error precision
 
   QUESO::GslMatrix proposalCovMatrix(
       gpmsaFactory.prior().imageSet().vectorSpace().zeroVector());


### PR DESCRIPTION
We ought to fix up the emulator mean prior, so we won't have to force users to override it, but we also ought to fix up the emulator mean prior so we can work with non-normalized inputs, so we'll those together later.