### PR TITLE
Implement a factory pattern for transition kernels

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,8 @@ Version 0.56.0 (in progress)
   * Prefer C++11 smart pointers/isnan/isfinite over boost equivalent if
     compiler is new enough
   * Make boost program options optional (and use getpot when disabled)
+  * Implement a transition kernel factory pattern so users may implement custom
+    samplers
 
 Version 0.55.0 (Jun 17, 2016)
   * Fix bug in JeffreysJointPdf

--- a/inc/queso/Makefile.am
+++ b/inc/queso/Makefile.am
@@ -38,6 +38,7 @@ BUILT_SOURCES += DistArray.h
 BUILT_SOURCES += Environment.h
 BUILT_SOURCES += EnvironmentOptions.h
 BUILT_SOURCES += Factory.h
+BUILT_SOURCES += FactoryWithVectorSpace.h
 BUILT_SOURCES += FunctionBase.h
 BUILT_SOURCES += FunctionOperatorBuilder.h
 BUILT_SOURCES += GslBlockMatrix.h
@@ -267,6 +268,8 @@ Environment.h: $(top_srcdir)/src/core/inc/Environment.h
 EnvironmentOptions.h: $(top_srcdir)/src/core/inc/EnvironmentOptions.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 Factory.h: $(top_srcdir)/src/core/inc/Factory.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+FactoryWithVectorSpace.h: $(top_srcdir)/src/core/inc/FactoryWithVectorSpace.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 FunctionBase.h: $(top_srcdir)/src/core/inc/FunctionBase.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@

--- a/inc/queso/Makefile.am
+++ b/inc/queso/Makefile.am
@@ -38,7 +38,6 @@ BUILT_SOURCES += DistArray.h
 BUILT_SOURCES += Environment.h
 BUILT_SOURCES += EnvironmentOptions.h
 BUILT_SOURCES += Factory.h
-BUILT_SOURCES += FactoryWithVectorSpace.h
 BUILT_SOURCES += FunctionBase.h
 BUILT_SOURCES += FunctionOperatorBuilder.h
 BUILT_SOURCES += GslBlockMatrix.h
@@ -65,6 +64,8 @@ BUILT_SOURCES += RngBoost.h
 BUILT_SOURCES += RngGsl.h
 BUILT_SOURCES += ScopedPtr.h
 BUILT_SOURCES += SharedPtr.h
+BUILT_SOURCES += TKFactoryRandomWalk.h
+BUILT_SOURCES += TKFactoryStochasticNewton.h
 BUILT_SOURCES += TeuchosMatrix.h
 BUILT_SOURCES += TeuchosVector.h
 BUILT_SOURCES += TransitionKernelFactory.h
@@ -269,8 +270,6 @@ EnvironmentOptions.h: $(top_srcdir)/src/core/inc/EnvironmentOptions.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 Factory.h: $(top_srcdir)/src/core/inc/Factory.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
-FactoryWithVectorSpace.h: $(top_srcdir)/src/core/inc/FactoryWithVectorSpace.h
-	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 FunctionBase.h: $(top_srcdir)/src/core/inc/FunctionBase.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 FunctionOperatorBuilder.h: $(top_srcdir)/src/core/inc/FunctionOperatorBuilder.h
@@ -322,6 +321,10 @@ RngGsl.h: $(top_srcdir)/src/core/inc/RngGsl.h
 ScopedPtr.h: $(top_srcdir)/src/core/inc/ScopedPtr.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 SharedPtr.h: $(top_srcdir)/src/core/inc/SharedPtr.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+TKFactoryRandomWalk.h: $(top_srcdir)/src/core/inc/TKFactoryRandomWalk.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+TKFactoryStochasticNewton.h: $(top_srcdir)/src/core/inc/TKFactoryStochasticNewton.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 TeuchosMatrix.h: $(top_srcdir)/src/core/inc/TeuchosMatrix.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@

--- a/inc/queso/Makefile.am
+++ b/inc/queso/Makefile.am
@@ -105,6 +105,7 @@ BUILT_SOURCES += StdOneDGrid.h
 BUILT_SOURCES += StreamUtilities.h
 BUILT_SOURCES += UniformOneDGrid.h
 BUILT_SOURCES += math_macros.h
+BUILT_SOURCES += AcceptanceRatio.h
 BUILT_SOURCES += BayesianJointPdf.h
 BUILT_SOURCES += BetaJointPdf.h
 BUILT_SOURCES += BetaVectorRV.h
@@ -404,6 +405,8 @@ StreamUtilities.h: $(top_srcdir)/src/misc/inc/StreamUtilities.h
 UniformOneDGrid.h: $(top_srcdir)/src/misc/inc/UniformOneDGrid.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 math_macros.h: $(top_srcdir)/src/misc/inc/math_macros.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+AcceptanceRatio.h: $(top_srcdir)/src/stats/inc/AcceptanceRatio.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 BayesianJointPdf.h: $(top_srcdir)/src/stats/inc/BayesianJointPdf.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@

--- a/inc/queso/Makefile.am
+++ b/inc/queso/Makefile.am
@@ -28,6 +28,7 @@ BUILT_SOURCES += VectorSet.h
 BUILT_SOURCES += VectorSpace.h
 BUILT_SOURCES += VectorSubset.h
 BUILT_SOURCES += getpot.h
+BUILT_SOURCES += AlgorithmFactory.h
 BUILT_SOURCES += BaseInputOptionsParser.h
 BUILT_SOURCES += BasicPdfsBase.h
 BUILT_SOURCES += BasicPdfsBoost.h
@@ -105,7 +106,7 @@ BUILT_SOURCES += StdOneDGrid.h
 BUILT_SOURCES += StreamUtilities.h
 BUILT_SOURCES += UniformOneDGrid.h
 BUILT_SOURCES += math_macros.h
-BUILT_SOURCES += AcceptanceRatio.h
+BUILT_SOURCES += Algorithm.h
 BUILT_SOURCES += BayesianJointPdf.h
 BUILT_SOURCES += BetaJointPdf.h
 BUILT_SOURCES += BetaVectorRV.h
@@ -251,6 +252,8 @@ VectorSpace.h: $(top_srcdir)/src/basic/inc/VectorSpace.h
 VectorSubset.h: $(top_srcdir)/src/basic/inc/VectorSubset.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 getpot.h: $(top_srcdir)/src/contrib/getpot/getpot.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+AlgorithmFactory.h: $(top_srcdir)/src/core/inc/AlgorithmFactory.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 BaseInputOptionsParser.h: $(top_srcdir)/src/core/inc/BaseInputOptionsParser.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
@@ -406,7 +409,7 @@ UniformOneDGrid.h: $(top_srcdir)/src/misc/inc/UniformOneDGrid.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 math_macros.h: $(top_srcdir)/src/misc/inc/math_macros.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
-AcceptanceRatio.h: $(top_srcdir)/src/stats/inc/AcceptanceRatio.h
+Algorithm.h: $(top_srcdir)/src/stats/inc/Algorithm.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 BayesianJointPdf.h: $(top_srcdir)/src/stats/inc/BayesianJointPdf.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@

--- a/inc/queso/Makefile.am
+++ b/inc/queso/Makefile.am
@@ -37,6 +37,7 @@ BUILT_SOURCES += Defines.h
 BUILT_SOURCES += DistArray.h
 BUILT_SOURCES += Environment.h
 BUILT_SOURCES += EnvironmentOptions.h
+BUILT_SOURCES += Factory.h
 BUILT_SOURCES += FunctionBase.h
 BUILT_SOURCES += FunctionOperatorBuilder.h
 BUILT_SOURCES += GslBlockMatrix.h
@@ -65,6 +66,7 @@ BUILT_SOURCES += ScopedPtr.h
 BUILT_SOURCES += SharedPtr.h
 BUILT_SOURCES += TeuchosMatrix.h
 BUILT_SOURCES += TeuchosVector.h
+BUILT_SOURCES += TransitionKernelFactory.h
 BUILT_SOURCES += Vector.h
 BUILT_SOURCES += asserts.h
 BUILT_SOURCES += exceptions.h
@@ -264,6 +266,8 @@ Environment.h: $(top_srcdir)/src/core/inc/Environment.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 EnvironmentOptions.h: $(top_srcdir)/src/core/inc/EnvironmentOptions.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+Factory.h: $(top_srcdir)/src/core/inc/Factory.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 FunctionBase.h: $(top_srcdir)/src/core/inc/FunctionBase.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 FunctionOperatorBuilder.h: $(top_srcdir)/src/core/inc/FunctionOperatorBuilder.h
@@ -319,6 +323,8 @@ SharedPtr.h: $(top_srcdir)/src/core/inc/SharedPtr.h
 TeuchosMatrix.h: $(top_srcdir)/src/core/inc/TeuchosMatrix.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 TeuchosVector.h: $(top_srcdir)/src/core/inc/TeuchosVector.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+TransitionKernelFactory.h: $(top_srcdir)/src/core/inc/TransitionKernelFactory.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 Vector.h: $(top_srcdir)/src/core/inc/Vector.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@

--- a/inc/queso/Makefile.am
+++ b/inc/queso/Makefile.am
@@ -64,6 +64,7 @@ BUILT_SOURCES += RngBoost.h
 BUILT_SOURCES += RngGsl.h
 BUILT_SOURCES += ScopedPtr.h
 BUILT_SOURCES += SharedPtr.h
+BUILT_SOURCES += TKFactoryLogitRandomWalk.h
 BUILT_SOURCES += TKFactoryRandomWalk.h
 BUILT_SOURCES += TKFactoryStochasticNewton.h
 BUILT_SOURCES += TeuchosMatrix.h
@@ -321,6 +322,8 @@ RngGsl.h: $(top_srcdir)/src/core/inc/RngGsl.h
 ScopedPtr.h: $(top_srcdir)/src/core/inc/ScopedPtr.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 SharedPtr.h: $(top_srcdir)/src/core/inc/SharedPtr.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+TKFactoryLogitRandomWalk.h: $(top_srcdir)/src/core/inc/TKFactoryLogitRandomWalk.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 TKFactoryRandomWalk.h: $(top_srcdir)/src/core/inc/TKFactoryRandomWalk.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -85,6 +85,7 @@ libqueso_la_SOURCES += core/src/TransitionKernelFactory.C
 libqueso_la_SOURCES += core/src/TKFactoryStochasticNewton.C
 libqueso_la_SOURCES += core/src/TKFactoryRandomWalk.C
 libqueso_la_SOURCES += core/src/TKFactoryLogitRandomWalk.C
+libqueso_la_SOURCES += core/src/AlgorithmFactory.C
 
 
 # Sources that need libmesh
@@ -252,7 +253,7 @@ libqueso_la_SOURCES += stats/src/GaussianLikelihoodFullCovariance.C
 libqueso_la_SOURCES += stats/src/GaussianLikelihoodFullCovarianceRandomCoefficient.C
 libqueso_la_SOURCES += stats/src/GaussianLikelihoodBlockDiagonalCovariance.C
 libqueso_la_SOURCES += stats/src/GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.C
-libqueso_la_SOURCES += stats/src/AcceptanceRatio.C
+libqueso_la_SOURCES += stats/src/Algorithm.C
 
 # Sources from surrogates/src
 libqueso_la_SOURCES += surrogates/src/InterpolationSurrogateData.C
@@ -320,6 +321,7 @@ libqueso_include_HEADERS += core/inc/TransitionKernelFactory.h
 libqueso_include_HEADERS += core/inc/TKFactoryStochasticNewton.h
 libqueso_include_HEADERS += core/inc/TKFactoryRandomWalk.h
 libqueso_include_HEADERS += core/inc/TKFactoryLogitRandomWalk.h
+libqueso_include_HEADERS += core/inc/AlgorithmFactory.h
 
 # Headers that need libmesh
 libqueso_include_HEADERS += core/inc/FunctionBase.h
@@ -465,7 +467,7 @@ libqueso_include_HEADERS += stats/inc/GaussianLikelihoodFullCovariance.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodFullCovarianceRandomCoefficient.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodBlockDiagonalCovariance.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.h
-libqueso_include_HEADERS += stats/inc/AcceptanceRatio.h
+libqueso_include_HEADERS += stats/inc/Algorithm.h
 
 # Headers to install from surrogates/inc
 libqueso_include_HEADERS += surrogates/inc/SurrogateBase.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -82,6 +82,8 @@ libqueso_la_SOURCES += core/src/OptimizerOptions.C
 libqueso_la_SOURCES += core/src/BaseInputOptionsParser.C
 libqueso_la_SOURCES += core/src/BoostInputOptionsParser.C
 libqueso_la_SOURCES += core/src/TransitionKernelFactory.C
+libqueso_la_SOURCES += core/src/TKFactoryStochasticNewton.C
+libqueso_la_SOURCES += core/src/TKFactoryRandomWalk.C
 
 
 # Sources that need libmesh
@@ -313,6 +315,8 @@ libqueso_include_HEADERS += core/inc/BaseInputOptionsParser.h
 libqueso_include_HEADERS += core/inc/BoostInputOptionsParser.h
 libqueso_include_HEADERS += core/inc/Factory.h
 libqueso_include_HEADERS += core/inc/TransitionKernelFactory.h
+libqueso_include_HEADERS += core/inc/TKFactoryStochasticNewton.h
+libqueso_include_HEADERS += core/inc/TKFactoryRandomWalk.h
 
 # Headers that need libmesh
 libqueso_include_HEADERS += core/inc/FunctionBase.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -81,6 +81,7 @@ libqueso_la_SOURCES += core/src/OptimizerMonitor.C
 libqueso_la_SOURCES += core/src/OptimizerOptions.C
 libqueso_la_SOURCES += core/src/BaseInputOptionsParser.C
 libqueso_la_SOURCES += core/src/BoostInputOptionsParser.C
+libqueso_la_SOURCES += core/src/TransitionKernelFactory.C
 
 
 # Sources that need libmesh
@@ -310,6 +311,8 @@ libqueso_include_HEADERS += core/inc/OptimizerMonitor.h
 libqueso_include_HEADERS += core/inc/OptimizerOptions.h
 libqueso_include_HEADERS += core/inc/BaseInputOptionsParser.h
 libqueso_include_HEADERS += core/inc/BoostInputOptionsParser.h
+libqueso_include_HEADERS += core/inc/Factory.h
+libqueso_include_HEADERS += core/inc/TransitionKernelFactory.h
 
 # Headers that need libmesh
 libqueso_include_HEADERS += core/inc/FunctionBase.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -252,6 +252,7 @@ libqueso_la_SOURCES += stats/src/GaussianLikelihoodFullCovariance.C
 libqueso_la_SOURCES += stats/src/GaussianLikelihoodFullCovarianceRandomCoefficient.C
 libqueso_la_SOURCES += stats/src/GaussianLikelihoodBlockDiagonalCovariance.C
 libqueso_la_SOURCES += stats/src/GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.C
+libqueso_la_SOURCES += stats/src/AcceptanceRatio.C
 
 # Sources from surrogates/src
 libqueso_la_SOURCES += surrogates/src/InterpolationSurrogateData.C
@@ -464,6 +465,7 @@ libqueso_include_HEADERS += stats/inc/GaussianLikelihoodFullCovariance.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodFullCovarianceRandomCoefficient.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodBlockDiagonalCovariance.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.h
+libqueso_include_HEADERS += stats/inc/AcceptanceRatio.h
 
 # Headers to install from surrogates/inc
 libqueso_include_HEADERS += surrogates/inc/SurrogateBase.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -84,6 +84,7 @@ libqueso_la_SOURCES += core/src/BoostInputOptionsParser.C
 libqueso_la_SOURCES += core/src/TransitionKernelFactory.C
 libqueso_la_SOURCES += core/src/TKFactoryStochasticNewton.C
 libqueso_la_SOURCES += core/src/TKFactoryRandomWalk.C
+libqueso_la_SOURCES += core/src/TKFactoryLogitRandomWalk.C
 
 
 # Sources that need libmesh
@@ -317,6 +318,7 @@ libqueso_include_HEADERS += core/inc/Factory.h
 libqueso_include_HEADERS += core/inc/TransitionKernelFactory.h
 libqueso_include_HEADERS += core/inc/TKFactoryStochasticNewton.h
 libqueso_include_HEADERS += core/inc/TKFactoryRandomWalk.h
+libqueso_include_HEADERS += core/inc/TKFactoryLogitRandomWalk.h
 
 # Headers that need libmesh
 libqueso_include_HEADERS += core/inc/FunctionBase.h

--- a/src/core/inc/AlgorithmFactory.h
+++ b/src/core/inc/AlgorithmFactory.h
@@ -90,6 +90,23 @@ AlgorithmFactory::create()
   return new_alg;
 }
 
+/**
+ * AlgorithmFactoryImp implementation of AlgorithmFactory
+ */
+template <class DerivedAlgorithm>
+class AlgorithmFactoryImp : public AlgorithmFactory
+{
+public:
+  AlgorithmFactoryImp(const std::string & name)
+    : AlgorithmFactory(name)
+  {}
+
+  virtual ~AlgorithmFactoryImp() {}
+
+private:
+  virtual SharedPtr<Algorithm<GslVector, GslMatrix> >::Type build_algorithm();
+};
+
 } // namespace QUESO
 
 #endif // QUESO_ALGORITHM_FACTORY_H

--- a/src/core/inc/AlgorithmFactory.h
+++ b/src/core/inc/AlgorithmFactory.h
@@ -1,0 +1,95 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef QUESO_ALGORITHM_FACTORY_H
+#define QUESO_ALGORITHM_FACTORY_H
+
+#include <queso/Factory.h>
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/VectorSpace.h>
+#include <queso/Algorithm.h>
+
+namespace QUESO
+{
+
+/**
+ * AlgorithmFactory class defintion.
+ */
+class AlgorithmFactory : public Factory<Algorithm<GslVector, GslMatrix> >
+{
+public:
+  /**
+   * Constructor. Takes the name to be mapped.
+   */
+  AlgorithmFactory(const std::string & name)
+    : Factory<Algorithm<GslVector, GslMatrix> >(name)
+  {}
+
+  /**
+   * Destructor. (Empty.)
+   */
+  virtual ~AlgorithmFactory() {}
+
+  static void set_environment(const BaseEnvironment & env)
+  {
+    m_env = &env;
+  }
+
+  static void set_tk(const BaseTKGroup<GslVector, GslMatrix> & tk)
+  {
+    m_tk = &tk;
+  }
+
+protected:
+  virtual SharedPtr<Algorithm<GslVector, GslMatrix> >::Type build_algorithm() = 0;
+
+  static const BaseEnvironment * m_env;
+  static const BaseTKGroup<GslVector, GslMatrix> * m_tk;
+
+private:
+  /**
+   * Create a Base class.  Force this to be implemented
+   * later.
+   */
+  virtual typename SharedPtr<Algorithm<GslVector, GslMatrix> >::Type create();
+};
+
+inline
+typename SharedPtr<Algorithm<GslVector, GslMatrix> >::Type
+AlgorithmFactory::create()
+{
+  queso_require_msg(m_env, "ERROR: must call set_environment() before building alg!");
+  queso_require_msg(m_tk, "ERROR: must call set_tk() before building alg!");
+
+  SharedPtr<Algorithm<GslVector, GslMatrix> >::Type new_alg = this->build_algorithm();
+
+  queso_assert(new_alg);
+
+  return new_alg;
+}
+
+} // namespace QUESO
+
+#endif // QUESO_ALGORITHM_FACTORY_H

--- a/src/core/inc/Factory.h
+++ b/src/core/inc/Factory.h
@@ -25,10 +25,13 @@
 #ifndef QUESO_FACTORY_H
 #define QUESO_FACTORY_H
 
-// C++ includes
+#include <queso/asserts.h>
+#include <queso/SharedPtr.h>
+
 #include <cstddef>
 #include <map>
 #include <string>
+#include <iostream>
 
 namespace QUESO
 {
@@ -54,13 +57,13 @@ public:
   /**
    * Builds an object of type Base identified by name.
    */
-  static UniquePtr<Base> build(const std::string & name);
+  static typename SharedPtr<Base>::Type build(const std::string & name);
 
   /**
    * Create a Base class.  Force this to be implemented
    * later.
    */
-  virtual UniquePtr<Base> create() = 0;
+  virtual typename SharedPtr<Base>::Type create() = 0;
 
 protected:
   /**
@@ -90,7 +93,7 @@ private:
   /**
    * @returns a new object of type Derived.
    */
-  virtual UniquePtr<Base> create();
+  virtual typename SharedPtr<Base>::Type create();
 };
 
 // -----------------------------------------------------
@@ -108,27 +111,27 @@ Factory<Base>::Factory(const std::string & name)
 
 template <class Base>
 inline
-UniquePtr<Base> Factory<Base>::build(const std::string & name)
+typename SharedPtr<Base>::Type Factory<Base>::build(const std::string & name)
 {
   // name not found in the map
   if (!factory_map().count(name))
     {
-      std::err << "Tried to build an unknown type: " << name << std::endl;
+      std::cerr << "Tried to build an unknown type: " << name << std::endl;
 
-      std::err << "valid options are:" << std::endl;
+      std::cerr << "valid options are:" << std::endl;
 
       for (typename std::map<std::string,Factory<Base> *>::const_iterator
              it = factory_map().begin(); it != factory_map().end(); ++it)
-        std::err << "  " << it->first << std::endl;
+        std::cerr << "  " << it->first << std::endl;
 
       queso_error_msg("Exiting...");
 
       // We'll never get here
-      return UniquePtr<Base>();
+      return typename SharedPtr<Base>::Type();
     }
 
   Factory<Base> * f = factory_map()[name];
-  return UniquePtr<Base>(f->create());
+  return typename SharedPtr<Base>::Type(f->create());
 }
 
 // Note - this cannot be inlined!
@@ -142,9 +145,9 @@ UniquePtr<Base> Factory<Base>::build(const std::string & name)
 
 template <class Derived, class Base>
 inline
-UniquePtr<Base> FactoryImp<Derived,Base>::create()
+typename SharedPtr<Base>::Type FactoryImp<Derived,Base>::create()
 {
-  return UniquePtr<Base>(new Derived);
+  return typename SharedPtr<Base>::Type(new Derived);
 }
 
 } // namespace QUESO

--- a/src/core/inc/Factory.h
+++ b/src/core/inc/Factory.h
@@ -1,0 +1,152 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef QUESO_FACTORY_H
+#define QUESO_FACTORY_H
+
+// C++ includes
+#include <cstddef>
+#include <map>
+#include <string>
+
+namespace QUESO
+{
+
+/**
+ * Factory class defintion.
+ */
+template <class Base>
+class Factory
+{
+protected:
+  /**
+   * Constructor. Takes the name to be mapped.
+   */
+  Factory(const std::string & name);
+
+public:
+  /**
+   * Destructor. (Empty.)
+   */
+  virtual ~Factory() {}
+
+  /**
+   * Builds an object of type Base identified by name.
+   */
+  static UniquePtr<Base> build(const std::string & name);
+
+  /**
+   * Create a Base class.  Force this to be implemented
+   * later.
+   */
+  virtual UniquePtr<Base> create() = 0;
+
+protected:
+  /**
+   * Map from a name to a Factory<Base> * pointer.
+   */
+  static std::map<std::string, Factory<Base> *> & factory_map();
+};
+
+/**
+ * Factory implementation class.
+ */
+template <class Derived, class Base>
+class FactoryImp: public Factory<Base>
+{
+public:
+  /**
+   * Constructor.  Takes a name as input.
+   */
+  FactoryImp(const std::string & name) : Factory<Base>(name) { }
+
+  /**
+   * Destructor.  Empty.
+   */
+  ~FactoryImp() {}
+
+private:
+  /**
+   * @returns a new object of type Derived.
+   */
+  virtual UniquePtr<Base> create();
+};
+
+// -----------------------------------------------------
+// Factory members
+template <class Base>
+inline
+Factory<Base>::Factory(const std::string & name)
+{
+  // Make sure we haven't already added this name
+  // to the map
+  queso_assert(!factory_map().count(name));
+
+  factory_map()[name] = this;
+}
+
+template <class Base>
+inline
+UniquePtr<Base> Factory<Base>::build(const std::string & name)
+{
+  // name not found in the map
+  if (!factory_map().count(name))
+    {
+      std::err << "Tried to build an unknown type: " << name << std::endl;
+
+      std::err << "valid options are:" << std::endl;
+
+      for (typename std::map<std::string,Factory<Base> *>::const_iterator
+             it = factory_map().begin(); it != factory_map().end(); ++it)
+        std::err << "  " << it->first << std::endl;
+
+      queso_error_msg("Exiting...");
+
+      // We'll never get here
+      return UniquePtr<Base>();
+    }
+
+  Factory<Base> * f = factory_map()[name];
+  return UniquePtr<Base>(f->create());
+}
+
+// Note - this cannot be inlined!
+// template <class Base>
+// std::map<std::string, Factory<Base> *> & Factory<Base>::factory_map()
+// {
+//   static std::map<std::string, Factory<Base> *> _factory_map;
+
+//   return _factory_map;
+// }
+
+template <class Derived, class Base>
+inline
+UniquePtr<Base> FactoryImp<Derived,Base>::create()
+{
+  return UniquePtr<Base>(new Derived);
+}
+
+} // namespace QUESO
+
+#endif // QUESO_FACTORY_H

--- a/src/core/inc/FactoryWithVectorSpace.h
+++ b/src/core/inc/FactoryWithVectorSpace.h
@@ -1,0 +1,59 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef QUESO_FACTORYWITHVECTORSPACE_H
+#define QUESO_FACTORYWITHVECTORSPACE_H
+
+#include <queso/Factory.h>
+#include <queso/VectorSpace.h>
+
+namespace QUESO
+{
+
+/**
+ * FactoryWithVectorSpace class defintion.
+ */
+template <class Base>
+class FactoryWithVectorSpace : public Factory<Base>
+{
+public:
+  FactoryWithVectorSpace(const std::string & name)
+    : Factory<Base>(name)
+  {}
+
+  virtual ~FactoryWithVectorSpace() {}
+
+  static void set_vectorspace(const VectorSpace<GslVector, GslMatrix> & v)
+  {
+    m_vectorSpace = &v;
+  }
+
+protected:
+  // We are not taking ownership of this, so we don't want it to be deleted.
+  static const VectorSpace<GslVector, GslMatrix> * m_vectorSpace;
+};
+
+} // namespace QUESO
+
+#endif // QUESO_FACTORYWITHVECTORSPACE_H

--- a/src/core/inc/TKFactoryLogitRandomWalk.h
+++ b/src/core/inc/TKFactoryLogitRandomWalk.h
@@ -22,8 +22,8 @@
 //
 //-----------------------------------------------------------------------el-
 
-#ifndef QUESO_TK_FACTORY_RANDOM_WALK_H
-#define QUESO_TK_FACTORY_RANDOM_WALK_H
+#ifndef QUESO_TK_FACTORY_LOGIT_RANDOM_WALK_H
+#define QUESO_TK_FACTORY_LOGIT_RANDOM_WALK_H
 
 #include <queso/TransitionKernelFactory.h>
 #include <queso/TKGroup.h>
@@ -32,23 +32,23 @@ namespace QUESO
 {
 
 /**
- * TKFactoryRandomWalk class defintion.
+ * TKFactoryLogitRandomWalk class defintion.
  */
 template <class DerivedTK>
-class TKFactoryRandomWalk : public TransitionKernelFactory
+class TKFactoryLogitRandomWalk : public TransitionKernelFactory
 {
 public:
   /**
    * Constructor. Takes the name to be mapped.
    */
-  TKFactoryRandomWalk(const std::string & name)
+  TKFactoryLogitRandomWalk(const std::string & name)
     : TransitionKernelFactory(name)
   {}
 
   /**
    * Destructor. (Empty.)
    */
-  virtual ~TKFactoryRandomWalk() {}
+  virtual ~TKFactoryLogitRandomWalk() {}
 
 protected:
   virtual SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type build_tk();
@@ -56,4 +56,4 @@ protected:
 
 } // namespace QUESO
 
-#endif  // QUESO_TK_FACTORY_RANDOM_WALK_H
+#endif  // QUESO_TK_FACTORY_LOGIT_RANDOM_WALK_H

--- a/src/core/inc/TKFactoryLogitRandomWalk.h
+++ b/src/core/inc/TKFactoryLogitRandomWalk.h
@@ -32,7 +32,10 @@ namespace QUESO
 {
 
 /**
- * TKFactoryLogitRandomWalk class defintion.
+ * TKFactoryLogitRandomWalk class defintion.  Implements a factory for
+ * random-walk type transition kernels along with a variable transformation to
+ * allow more efficient sampling for problems with parameters bounds in
+ * high-dimensional state spaces.
  */
 template <class DerivedTK>
 class TKFactoryLogitRandomWalk : public TransitionKernelFactory

--- a/src/core/inc/TKFactoryRandomWalk.h
+++ b/src/core/inc/TKFactoryRandomWalk.h
@@ -32,7 +32,8 @@ namespace QUESO
 {
 
 /**
- * TKFactoryRandomWalk class defintion.
+ * TKFactoryRandomWalk class defintion.  Implements a factory for random-walk
+ * type transition kernels.  Supports delayed rejection.
  */
 template <class DerivedTK>
 class TKFactoryRandomWalk : public TransitionKernelFactory

--- a/src/core/inc/TKFactoryRandomWalk.h
+++ b/src/core/inc/TKFactoryRandomWalk.h
@@ -1,0 +1,59 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef QUESO_TK_FACTORY_RANDOM_WALK_H
+#define QUESO_TK_FACTORY_RANDOM_WALK_H
+
+#include <queso/TransitionKernelFactory.h>
+#include <queso/TKGroup.h>
+
+namespace QUESO
+{
+
+/**
+ * TKFactoryRandomWalk class defintion.
+ */
+template <class DerivedTK>
+class TKFactoryRandomWalk : public TransitionKernelFactory
+{
+public:
+  /**
+   * Constructor. Takes the name to be mapped.
+   */
+  TKFactoryRandomWalk(const std::string & name)
+    : TransitionKernelFactory(name)
+  {}
+
+  /**
+   * Destructor. (Empty.)
+   */
+  virtual ~TKFactoryRandomWalk() {}
+
+protected:
+  virtual SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type build_tk();
+};
+
+} // namespace QUESO
+
+#endif // QUESO_TK_FACTORY_RANDOM_WALK_H

--- a/src/core/inc/TKFactoryStochasticNewton.h
+++ b/src/core/inc/TKFactoryStochasticNewton.h
@@ -1,0 +1,59 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef QUESO_TK_FACTORY_STOCHASTIC_NEWTON_H
+#define QUESO_TK_FACTORY_STOCHASTIC_NEWTON_H
+
+#include <queso/TransitionKernelFactory.h>
+#include <queso/TKGroup.h>
+
+namespace QUESO
+{
+
+/**
+ * TKFactoryStochasticNewton class defintion.
+ */
+template <class DerivedTK>
+class TKFactoryStochasticNewton : public TransitionKernelFactory
+{
+public:
+  /**
+   * Constructor. Takes the name to be mapped.
+   */
+  TKFactoryStochasticNewton(const std::string & name)
+    : TransitionKernelFactory(name)
+  {}
+
+  /**
+   * Destructor. (Empty.)
+   */
+  virtual ~TKFactoryStochasticNewton() {}
+
+protected:
+  virtual SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type build_tk();
+};
+
+} // namespace QUESO
+
+#endif // QUESO_TK_FACTORY_STOCHASTIC_NEWTON_H

--- a/src/core/inc/TKFactoryStochasticNewton.h
+++ b/src/core/inc/TKFactoryStochasticNewton.h
@@ -32,7 +32,8 @@ namespace QUESO
 {
 
 /**
- * TKFactoryStochasticNewton class defintion.
+ * TKFactoryStochasticNewton class defintion.  Implements a factory for the
+ * transition kernel used in Stochastic Newton (?)
  */
 template <class DerivedTK>
 class TKFactoryStochasticNewton : public TransitionKernelFactory

--- a/src/core/inc/TransitionKernelFactory.h
+++ b/src/core/inc/TransitionKernelFactory.h
@@ -25,9 +25,10 @@
 #ifndef QUESO_TK_FACTORY_H
 #define QUESO_TK_FACTORY_H
 
-#include <queso/FactoryWithVectorSpace.h>
+#include <queso/Factory.h>
 #include <queso/GslVector.h>
 #include <queso/GslMatrix.h>
+#include <queso/VectorSpace.h>
 #include <queso/TKGroup.h>
 #include <queso/MetropolisHastingsSGOptions.h>
 
@@ -37,20 +38,25 @@ namespace QUESO
 /**
  * TransitionKernelFactory class defintion.
  */
-class TransitionKernelFactory : public FactoryWithVectorSpace<BaseTKGroup<GslVector, GslMatrix> >
+class TransitionKernelFactory : public Factory<BaseTKGroup<GslVector, GslMatrix> >
 {
 public:
   /**
    * Constructor. Takes the name to be mapped.
    */
   TransitionKernelFactory(const std::string & name)
-    : FactoryWithVectorSpace<BaseTKGroup<GslVector, GslMatrix> >(name)
+    : Factory<BaseTKGroup<GslVector, GslMatrix> >(name)
   {}
 
   /**
    * Destructor. (Empty.)
    */
   virtual ~TransitionKernelFactory() {}
+
+  static void set_vectorspace(const VectorSpace<GslVector, GslMatrix> & v)
+  {
+    m_vectorSpace = &v;
+  }
 
   static void set_dr_scales(const std::vector<double> & scales)
   {
@@ -86,6 +92,7 @@ protected:
       GslMatrix & initial_cov_matrix,
       const BaseJointPdf<GslVector, GslMatrix> & target_pdf);
 
+  static const VectorSpace<GslVector, GslMatrix> * m_vectorSpace;
   static const std::vector<double> * m_dr_scales;
   static const ScalarFunctionSynchronizer<GslVector, GslMatrix> * m_pdf_synchronizer;
   static GslMatrix * m_initial_cov_matrix;

--- a/src/core/inc/TransitionKernelFactory.h
+++ b/src/core/inc/TransitionKernelFactory.h
@@ -1,0 +1,61 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef QUESO_TK_FACTORY_H
+#define QUESO_TK_FACTORY_H
+
+#include <queso/Factory.h>
+
+namespace QUESO
+{
+
+/**
+ * TransitionKernelFactory class defintion.
+ */
+template <class Base>
+class TransitionKernelFactory : public Factory<Base>
+{
+public:
+  /**
+   * Constructor. Takes the name to be mapped.
+   */
+  TransitionKernelFactory(const std::string & name)
+    : Factory<Base>(name)
+  {}
+
+  /**
+   * Destructor. (Empty.)
+   */
+  virtual ~TransitionKernelFactory() {}
+
+  /**
+   * Create a Base class.  Force this to be implemented
+   * later.
+   */
+  virtual typename SharedPtr<Base>::Type create() = 0;
+};
+
+} // namespace QUESO
+
+#endif // QUESO_TK_FACTORY_H

--- a/src/core/inc/TransitionKernelFactory.h
+++ b/src/core/inc/TransitionKernelFactory.h
@@ -29,6 +29,7 @@
 #include <queso/GslVector.h>
 #include <queso/GslMatrix.h>
 #include <queso/TKGroup.h>
+#include <queso/MetropolisHastingsSGOptions.h>
 
 namespace QUESO
 {
@@ -67,7 +68,13 @@ protected:
     m_initial_cov_matrix = &cov_matrix;
   }
 
+  static void set_options(const MhOptionsValues & options)
+  {
+    m_options = &options;
+  }
+
   virtual SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type build_tk(
+      const MhOptionsValues & options,
       const VectorSpace<GslVector, GslMatrix> & v,
       const std::vector<double> & dr_scales,
       const ScalarFunctionSynchronizer<GslVector, GslMatrix> & pdf_synchronizer,
@@ -76,6 +83,7 @@ protected:
   static const std::vector<double> * m_dr_scales;
   static const ScalarFunctionSynchronizer<GslVector, GslMatrix> * m_pdf_synchronizer;
   static const GslMatrix * m_initial_cov_matrix;
+  static const MhOptionsValues * m_options;
 
 private:
   /**
@@ -92,8 +100,10 @@ typename SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type TransitionKernelFac
   queso_require_msg(m_dr_scales, "ERROR: must call set_dr_scales() before building tk!");
   queso_require_msg(m_pdf_synchronizer, "ERROR: must call set_pdf_synchronizer() before building tk!");
   queso_require_msg(m_initial_cov_matrix, "ERROR: must call set_initial_cov_matrix() before building tk!");
+  queso_require_msg(m_options, "ERROR: must call set_options() before building tk!");
 
   SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type new_tk = this->build_tk(
+      *m_options,
       *m_vectorSpace,
       *m_dr_scales,
       *m_pdf_synchronizer,

--- a/src/core/inc/TransitionKernelFactory.h
+++ b/src/core/inc/TransitionKernelFactory.h
@@ -53,31 +53,51 @@ public:
    */
   virtual ~TransitionKernelFactory() {}
 
+  /**
+   * Static method to set the vector space the transition kernel is defined on
+   */
   static void set_vectorspace(const VectorSpace<GslVector, GslMatrix> & v)
   {
     m_vectorSpace = &v;
   }
 
+  /**
+   * Static method to set the vector of scale factor to scale a proposal
+   * covariance matrix by for the purpose of delayed rejection
+   */
   static void set_dr_scales(const std::vector<double> & scales)
   {
     m_dr_scales = &scales;
   }
 
+  /**
+   * Static method to set the pdf synchronizer.  Used by Stochastic Newton?
+   */
   static void set_pdf_synchronizer(const ScalarFunctionSynchronizer<GslVector, GslMatrix> & synchronizer)
   {
     m_pdf_synchronizer = &synchronizer;
   }
 
+  /**
+   * Static method to set the initial proposal covariance matrix
+   */
   static void set_initial_cov_matrix(GslMatrix & cov_matrix)
   {
     m_initial_cov_matrix = &cov_matrix;
   }
 
+  /**
+   * Static method to set the options object.  Useful for passing input file
+   * options to transition kernels.
+   */
   static void set_options(const MhOptionsValues & options)
   {
     m_options = &options;
   }
 
+  /**
+   * Static method to set the pdf we wish to draw samples from
+   */
   static void set_target_pdf(const BaseJointPdf<GslVector, GslMatrix> & target_pdf)
   {
     m_target_pdf = &target_pdf;

--- a/src/core/inc/TransitionKernelFactory.h
+++ b/src/core/inc/TransitionKernelFactory.h
@@ -52,7 +52,6 @@ public:
    */
   virtual ~TransitionKernelFactory() {}
 
-protected:
   static void set_dr_scales(const std::vector<double> & scales)
   {
     m_dr_scales = &scales;
@@ -63,7 +62,7 @@ protected:
     m_pdf_synchronizer = &synchronizer;
   }
 
-  static void set_initial_cov_matrix(const GslMatrix & cov_matrix)
+  static void set_initial_cov_matrix(GslMatrix & cov_matrix)
   {
     m_initial_cov_matrix = &cov_matrix;
   }
@@ -73,17 +72,25 @@ protected:
     m_options = &options;
   }
 
+  static void set_target_pdf(const BaseJointPdf<GslVector, GslMatrix> & target_pdf)
+  {
+    m_target_pdf = &target_pdf;
+  }
+
+protected:
   virtual SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type build_tk(
       const MhOptionsValues & options,
       const VectorSpace<GslVector, GslMatrix> & v,
       const std::vector<double> & dr_scales,
       const ScalarFunctionSynchronizer<GslVector, GslMatrix> & pdf_synchronizer,
-      const GslMatrix & initial_cov_matrix);
+      GslMatrix & initial_cov_matrix,
+      const BaseJointPdf<GslVector, GslMatrix> & target_pdf);
 
   static const std::vector<double> * m_dr_scales;
   static const ScalarFunctionSynchronizer<GslVector, GslMatrix> * m_pdf_synchronizer;
-  static const GslMatrix * m_initial_cov_matrix;
+  static GslMatrix * m_initial_cov_matrix;
   static const MhOptionsValues * m_options;
+  static const BaseJointPdf<GslVector, GslMatrix> * m_target_pdf;
 
 private:
   /**
@@ -101,13 +108,15 @@ typename SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type TransitionKernelFac
   queso_require_msg(m_pdf_synchronizer, "ERROR: must call set_pdf_synchronizer() before building tk!");
   queso_require_msg(m_initial_cov_matrix, "ERROR: must call set_initial_cov_matrix() before building tk!");
   queso_require_msg(m_options, "ERROR: must call set_options() before building tk!");
+  queso_require_msg(m_target_pdf, "ERROR: must call set_target_pdf() before building tk!");
 
   SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type new_tk = this->build_tk(
       *m_options,
       *m_vectorSpace,
       *m_dr_scales,
       *m_pdf_synchronizer,
-      *m_initial_cov_matrix);
+      *m_initial_cov_matrix,
+      *m_target_pdf);
 
   queso_assert(new_tk);
 

--- a/src/core/inc/TransitionKernelFactory.h
+++ b/src/core/inc/TransitionKernelFactory.h
@@ -52,8 +52,27 @@ public:
   virtual ~TransitionKernelFactory() {}
 
 protected:
+  static void set_dr_scales(const std::vector<double> & scales)
+  {
+    m_dr_scales = &scales;
+  }
+
+  static void set_pdf_synchronizer(const ScalarFunctionSynchronizer<GslVector, GslMatrix> & synchronizer)
+  {
+    m_pdf_synchronizer = &synchronizer;
+  }
+
+  static void set_initial_cov_matrix(const GslMatrix & cov_matrix)
+  {
+    m_initial_cov_matrix = &cov_matrix;
+  }
+
   virtual SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type build_tk(
       const VectorSpace<GslVector, GslMatrix> & v);
+
+  static const std::vector<double> * m_dr_scales;
+  static const ScalarFunctionSynchronizer<GslVector, GslMatrix> * m_pdf_synchronizer;
+  static const GslMatrix * m_initial_cov_matrix;
 
 private:
   /**
@@ -67,6 +86,9 @@ inline
 typename SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type TransitionKernelFactory::create()
 {
   queso_require_msg(m_vectorSpace, "ERROR: must call set_vectorspace() before building tk!");
+  queso_require_msg(m_dr_scales, "ERROR: must call set_dr_scales() before building tk!");
+  queso_require_msg(m_pdf_synchronizer, "ERROR: must call set_pdf_synchronizer() before building tk!");
+  queso_require_msg(m_initial_cov_matrix, "ERROR: must call set_initial_cov_matrix() before building tk!");
 
   SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type new_tk = this->build_tk(*m_vectorSpace);
 

--- a/src/core/inc/TransitionKernelFactory.h
+++ b/src/core/inc/TransitionKernelFactory.h
@@ -84,13 +84,7 @@ public:
   }
 
 protected:
-  virtual SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type build_tk(
-      const MhOptionsValues & options,
-      const VectorSpace<GslVector, GslMatrix> & v,
-      const std::vector<double> & dr_scales,
-      const ScalarFunctionSynchronizer<GslVector, GslMatrix> & pdf_synchronizer,
-      GslMatrix & initial_cov_matrix,
-      const BaseJointPdf<GslVector, GslMatrix> & target_pdf);
+  virtual SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type build_tk() = 0;
 
   static const VectorSpace<GslVector, GslMatrix> * m_vectorSpace;
   static const std::vector<double> * m_dr_scales;
@@ -117,13 +111,7 @@ typename SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type TransitionKernelFac
   queso_require_msg(m_options, "ERROR: must call set_options() before building tk!");
   queso_require_msg(m_target_pdf, "ERROR: must call set_target_pdf() before building tk!");
 
-  SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type new_tk = this->build_tk(
-      *m_options,
-      *m_vectorSpace,
-      *m_dr_scales,
-      *m_pdf_synchronizer,
-      *m_initial_cov_matrix,
-      *m_target_pdf);
+  SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type new_tk = this->build_tk();
 
   queso_assert(new_tk);
 

--- a/src/core/inc/TransitionKernelFactory.h
+++ b/src/core/inc/TransitionKernelFactory.h
@@ -53,7 +53,7 @@ public:
 
 protected:
   virtual SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type build_tk(
-      const VectorSpace<GslVector, GslMatrix> & v) = 0;
+      const VectorSpace<GslVector, GslMatrix> & v);
 
 private:
   /**

--- a/src/core/inc/TransitionKernelFactory.h
+++ b/src/core/inc/TransitionKernelFactory.h
@@ -68,7 +68,10 @@ protected:
   }
 
   virtual SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type build_tk(
-      const VectorSpace<GslVector, GslMatrix> & v);
+      const VectorSpace<GslVector, GslMatrix> & v,
+      const std::vector<double> & dr_scales,
+      const ScalarFunctionSynchronizer<GslVector, GslMatrix> & pdf_synchronizer,
+      const GslMatrix & initial_cov_matrix);
 
   static const std::vector<double> * m_dr_scales;
   static const ScalarFunctionSynchronizer<GslVector, GslMatrix> * m_pdf_synchronizer;
@@ -90,7 +93,11 @@ typename SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type TransitionKernelFac
   queso_require_msg(m_pdf_synchronizer, "ERROR: must call set_pdf_synchronizer() before building tk!");
   queso_require_msg(m_initial_cov_matrix, "ERROR: must call set_initial_cov_matrix() before building tk!");
 
-  SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type new_tk = this->build_tk(*m_vectorSpace);
+  SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type new_tk = this->build_tk(
+      *m_vectorSpace,
+      *m_dr_scales,
+      *m_pdf_synchronizer,
+      *m_initial_cov_matrix);
 
   queso_assert(new_tk);
 

--- a/src/core/inc/TransitionKernelFactory.h
+++ b/src/core/inc/TransitionKernelFactory.h
@@ -25,7 +25,10 @@
 #ifndef QUESO_TK_FACTORY_H
 #define QUESO_TK_FACTORY_H
 
-#include <queso/Factory.h>
+#include <queso/FactoryWithVectorSpace.h>
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/TKGroup.h>
 
 namespace QUESO
 {
@@ -33,15 +36,14 @@ namespace QUESO
 /**
  * TransitionKernelFactory class defintion.
  */
-template <class Base>
-class TransitionKernelFactory : public Factory<Base>
+class TransitionKernelFactory : public FactoryWithVectorSpace<BaseTKGroup<GslVector, GslMatrix> >
 {
 public:
   /**
    * Constructor. Takes the name to be mapped.
    */
   TransitionKernelFactory(const std::string & name)
-    : Factory<Base>(name)
+    : FactoryWithVectorSpace<BaseTKGroup<GslVector, GslMatrix> >(name)
   {}
 
   /**
@@ -49,12 +51,29 @@ public:
    */
   virtual ~TransitionKernelFactory() {}
 
+protected:
+  virtual SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type build_tk(
+      const VectorSpace<GslVector, GslMatrix> & v) = 0;
+
+private:
   /**
    * Create a Base class.  Force this to be implemented
    * later.
    */
-  virtual typename SharedPtr<Base>::Type create() = 0;
+  virtual typename SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type create();
 };
+
+inline
+typename SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type TransitionKernelFactory::create()
+{
+  queso_require_msg(m_vectorSpace, "ERROR: must call set_vectorspace() before building tk!");
+
+  SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type new_tk = this->build_tk(*m_vectorSpace);
+
+  queso_assert(new_tk);
+
+  return new_tk;
+}
 
 } // namespace QUESO
 

--- a/src/core/src/AlgorithmFactory.C
+++ b/src/core/src/AlgorithmFactory.C
@@ -38,15 +38,21 @@ Factory<Algorithm<GslVector, GslMatrix> >::factory_map()
   return _factory_map;
 }
 
-// SharedPtr<Algorithm<GslVector, GslMatrix> >::Type
-// AlgorithmFactory::build_algorithm()
-// {
-//   SharedPtr<Algorithm<GslVector, GslMatrix> >::Type new_alg;
-//   new_alg.reset(new DerivedAlgorithm(*(this->m_env), *(this->m_tk)));
-//   return new_alg;
-// }
+// AlgorithmFactoryImp implementation
+template <class DerivedAlgorithm>
+SharedPtr<Algorithm<GslVector, GslMatrix> >::Type
+AlgorithmFactoryImp<DerivedAlgorithm>::build_algorithm()
+{
+  SharedPtr<Algorithm<GslVector, GslMatrix> >::Type new_alg;
+  new_alg.reset(new DerivedAlgorithm(*(this->m_env), *(this->m_tk)));
+  return new_alg;
+}
 
 const BaseEnvironment * AlgorithmFactory::m_env = NULL;
 const BaseTKGroup<GslVector, GslMatrix> * AlgorithmFactory::m_tk = NULL;
+
+// Register with the factory
+AlgorithmFactoryImp<Algorithm<GslVector, GslMatrix> > random_walk_alg("random_walk");
+AlgorithmFactoryImp<Algorithm<GslVector, GslMatrix> > logit_random_walk_alg("logit_random_walk");
 
 } // namespace QUESO

--- a/src/core/src/AlgorithmFactory.C
+++ b/src/core/src/AlgorithmFactory.C
@@ -22,31 +22,31 @@
 //
 //-----------------------------------------------------------------------el-
 
-#include <queso/MarkovChainPositionData.h>
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/AlgorithmFactory.h>
 
-namespace QUESO {
-
-class GslVector;
-class GslMatrix;
-class BaseEnvironment;
-template <class V, class M> class BaseTKGroup;
-
-template <class V = GslVector, class M = GslMatrix>
-class AcceptanceRatio
+namespace QUESO
 {
-public:
-  AcceptanceRatio(const BaseEnvironment & env, const BaseTKGroup<V, M> & tk);
-  ~AcceptanceRatio();
 
-  //! tk_pos_x is the position of the tk when evaluating for x
-  //! tk_pos_y is the position of the tk when evaluating for y
-  double operator()(MarkovChainPositionData<V> x,
-                    MarkovChainPositionData<V> y,
-                    const V & tk_pos_x,
-                    const V & tk_pos_y);
-private:
-  const BaseEnvironment & m_env;
-  const BaseTKGroup<V, M> & m_tk;
-};
+template <>
+std::map<std::string, Factory<Algorithm<GslVector, GslMatrix> > *> &
+Factory<Algorithm<GslVector, GslMatrix> >::factory_map()
+{
+  static std::map<std::string, Factory<Algorithm<GslVector, GslMatrix> > *> _factory_map;
 
-}  // End namespace QUESO
+  return _factory_map;
+}
+
+// SharedPtr<Algorithm<GslVector, GslMatrix> >::Type
+// AlgorithmFactory::build_algorithm()
+// {
+//   SharedPtr<Algorithm<GslVector, GslMatrix> >::Type new_alg;
+//   new_alg.reset(new DerivedAlgorithm(*(this->m_env), *(this->m_tk)));
+//   return new_alg;
+// }
+
+const BaseEnvironment * AlgorithmFactory::m_env = NULL;
+const BaseTKGroup<GslVector, GslMatrix> * AlgorithmFactory::m_tk = NULL;
+
+} // namespace QUESO

--- a/src/core/src/TKFactoryLogitRandomWalk.C
+++ b/src/core/src/TKFactoryLogitRandomWalk.C
@@ -22,38 +22,32 @@
 //
 //-----------------------------------------------------------------------el-
 
-#ifndef QUESO_TK_FACTORY_RANDOM_WALK_H
-#define QUESO_TK_FACTORY_RANDOM_WALK_H
-
-#include <queso/TransitionKernelFactory.h>
-#include <queso/TKGroup.h>
+#include <queso/TKFactoryLogitRandomWalk.h>
+#include <queso/TransformedScaledCovMatrixTKGroup.h>
 
 namespace QUESO
 {
 
-/**
- * TKFactoryRandomWalk class defintion.
- */
 template <class DerivedTK>
-class TKFactoryRandomWalk : public TransitionKernelFactory
+SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type
+TKFactoryLogitRandomWalk<DerivedTK>::build_tk()
 {
-public:
-  /**
-   * Constructor. Takes the name to be mapped.
-   */
-  TKFactoryRandomWalk(const std::string & name)
-    : TransitionKernelFactory(name)
-  {}
+  SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type new_tk;
 
-  /**
-   * Destructor. (Empty.)
-   */
-  virtual ~TKFactoryRandomWalk() {}
+  // Cast the domain to a box.  Might this cast fail?
+  const BoxSubset<GslVector, GslMatrix> & boxSubset =
+    dynamic_cast<const BoxSubset<GslVector, GslMatrix> & >(
+        this->m_target_pdf->domainSet());
 
-protected:
-  virtual SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type build_tk();
-};
+  new_tk.reset(new DerivedTK(this->m_options->m_prefix.c_str(),
+                             boxSubset,
+                             *(this->m_dr_scales),
+                             *(this->m_initial_cov_matrix)));
 
-} // namespace QUESO
+  return new_tk;
+}
 
-#endif  // QUESO_TK_FACTORY_RANDOM_WALK_H
+// Instantiate all the transition kernel factories
+TKFactoryLogitRandomWalk<TransformedScaledCovMatrixTKGroup<GslVector, GslMatrix> > tk_factory_logit_random_walk("logit_random_walk");
+
+}  // namespace QUESO

--- a/src/core/src/TKFactoryRandomWalk.C
+++ b/src/core/src/TKFactoryRandomWalk.C
@@ -22,38 +22,27 @@
 //
 //-----------------------------------------------------------------------el-
 
-#ifndef QUESO_FACTORYWITHVECTORSPACE_H
-#define QUESO_FACTORYWITHVECTORSPACE_H
-
-#include <queso/Factory.h>
-#include <queso/VectorSpace.h>
+#include <queso/TKFactoryRandomWalk.h>
+#include <queso/ScaledCovMatrixTKGroup.h>
 
 namespace QUESO
 {
 
-/**
- * FactoryWithVectorSpace class defintion.
- */
-template <class Base>
-class FactoryWithVectorSpace : public Factory<Base>
+template <class DerivedTK>
+SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type
+TKFactoryRandomWalk<DerivedTK>::build_tk()
 {
-public:
-  FactoryWithVectorSpace(const std::string & name)
-    : Factory<Base>(name)
-  {}
+  SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type new_tk;
 
-  virtual ~FactoryWithVectorSpace() {}
+  new_tk.reset(new DerivedTK(this->m_options->m_prefix.c_str(),
+                             *(this->m_vectorSpace),
+                             *(this->m_dr_scales),
+                             *(this->m_initial_cov_matrix)));
 
-  static void set_vectorspace(const VectorSpace<GslVector, GslMatrix> & v)
-  {
-    m_vectorSpace = &v;
-  }
+  return new_tk;
+}
 
-protected:
-  // We are not taking ownership of this, so we don't want it to be deleted.
-  static const VectorSpace<GslVector, GslMatrix> * m_vectorSpace;
-};
+// Instantiate all the transition kernel factories
+TKFactoryRandomWalk<ScaledCovMatrixTKGroup<GslVector, GslMatrix> > tk_factory_random_walk("random_walk");
 
 } // namespace QUESO
-
-#endif // QUESO_FACTORYWITHVECTORSPACE_H

--- a/src/core/src/TKFactoryRandomWalk.C
+++ b/src/core/src/TKFactoryRandomWalk.C
@@ -45,4 +45,4 @@ TKFactoryRandomWalk<DerivedTK>::build_tk()
 // Instantiate all the transition kernel factories
 TKFactoryRandomWalk<ScaledCovMatrixTKGroup<GslVector, GslMatrix> > tk_factory_random_walk("random_walk");
 
-} // namespace QUESO
+}  // namespace QUESO

--- a/src/core/src/TKFactoryStochasticNewton.C
+++ b/src/core/src/TKFactoryStochasticNewton.C
@@ -1,0 +1,48 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/TKFactoryStochasticNewton.h>
+#include <queso/HessianCovMatricesTKGroup.h>
+
+namespace QUESO
+{
+
+template <class DerivedTK>
+SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type
+TKFactoryStochasticNewton<DerivedTK>::build_tk()
+{
+  SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type new_tk;
+
+  new_tk.reset(new DerivedTK(this->m_options->m_prefix.c_str(),
+                             *(this->m_vectorSpace),
+                             *(this->m_dr_scales),
+                             *(this->m_pdf_synchronizer)));
+
+  return new_tk;
+}
+
+// Instantiate all the transition kernel factories
+TKFactoryStochasticNewton<HessianCovMatricesTKGroup<GslVector, GslMatrix> > tk_factory_stochastic_newton("stochastic_newton");
+
+} // namespace QUESO

--- a/src/core/src/TransitionKernelFactory.C
+++ b/src/core/src/TransitionKernelFactory.C
@@ -39,19 +39,12 @@ Factory<BaseTKGroup<GslVector, GslMatrix> >::factory_map()
   return _factory_map;
 }
 
-SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type build_tk(
-    const VectorSpace<GslVector, GslMatrix> & v)
+SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type
+TransitionKernelFactory::build_tk(const VectorSpace<GslVector, GslMatrix> & v)
 {
-  std::vector<double> scales(1, 1.0);
-
-  GslVector ones(v.zeroVector());
-  ones.cwSet(1.0);
-
-  GslMatrix covMatrix(ones);
-
   SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type new_tk(
       new ScaledCovMatrixTKGroup<GslVector, GslMatrix>(
-        "", v, scales, covMatrix));
+        "", v, *m_dr_scales, *m_initial_cov_matrix));
 
   return new_tk;
 }

--- a/src/core/src/TransitionKernelFactory.C
+++ b/src/core/src/TransitionKernelFactory.C
@@ -104,7 +104,7 @@ const MhOptionsValues * TransitionKernelFactory::m_options = NULL;
 const BaseJointPdf<GslVector, GslMatrix> * TransitionKernelFactory::m_target_pdf = NULL;
 
 // Instantiate all the transition kernel factories
-TransitionKernelFactory tk_factory_dram("dram");
+TransitionKernelFactory tk_factory_dram("random_walk");
 TransitionKernelFactory tk_factory_stochastic_newton("stochastic_newton");
 
 } // namespace QUESO

--- a/src/core/src/TransitionKernelFactory.C
+++ b/src/core/src/TransitionKernelFactory.C
@@ -59,4 +59,10 @@ SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type build_tk(
 template<>
 const VectorSpace<GslVector, GslMatrix> * FactoryWithVectorSpace<BaseTKGroup<GslVector, GslMatrix> >::m_vectorSpace = NULL;
 
+const std::vector<double> * TransitionKernelFactory::m_dr_scales = NULL;
+
+const ScalarFunctionSynchronizer<GslVector, GslMatrix> * TransitionKernelFactory::m_pdf_synchronizer = NULL;
+
+const GslMatrix * TransitionKernelFactory::m_initial_cov_matrix = NULL;
+
 } // namespace QUESO

--- a/src/core/src/TransitionKernelFactory.C
+++ b/src/core/src/TransitionKernelFactory.C
@@ -1,0 +1,44 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/TransitionKernelFactory.h>
+#include <queso/TKGroup.h>
+
+namespace QUESO
+{
+
+template <>
+std::map<std::string, Factory<BaseTKGroup<GslVector, GslMatrix> > *> &
+Factory<BaseTKGroup<GslVector, GslMatrix> >::factory_map()
+{
+  static std::map<std::string, Factory<BaseTKGroup<GslVector, GslMatrix> > *> _factory_map;
+
+  return _factory_map;
+}
+
+template class TransitionKernelFactory<BaseTKGroup<GslVector, GslMatrix> >;
+
+} // namespace QUESO

--- a/src/core/src/TransitionKernelFactory.C
+++ b/src/core/src/TransitionKernelFactory.C
@@ -90,8 +90,7 @@ TransitionKernelFactory::build_tk(
   return new_tk;
 }
 
-template<>
-const VectorSpace<GslVector, GslMatrix> * FactoryWithVectorSpace<BaseTKGroup<GslVector, GslMatrix> >::m_vectorSpace = NULL;
+const VectorSpace<GslVector, GslMatrix> * TransitionKernelFactory::m_vectorSpace = NULL;
 
 const std::vector<double> * TransitionKernelFactory::m_dr_scales = NULL;
 

--- a/src/core/src/TransitionKernelFactory.C
+++ b/src/core/src/TransitionKernelFactory.C
@@ -25,7 +25,7 @@
 #include <queso/GslVector.h>
 #include <queso/GslMatrix.h>
 #include <queso/TransitionKernelFactory.h>
-#include <queso/TKGroup.h>
+#include <queso/ScaledCovMatrixTKGroup.h>
 
 namespace QUESO
 {
@@ -37,6 +37,23 @@ Factory<BaseTKGroup<GslVector, GslMatrix> >::factory_map()
   static std::map<std::string, Factory<BaseTKGroup<GslVector, GslMatrix> > *> _factory_map;
 
   return _factory_map;
+}
+
+SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type build_tk(
+    const VectorSpace<GslVector, GslMatrix> & v)
+{
+  std::vector<double> scales(1, 1.0);
+
+  GslVector ones(v.zeroVector());
+  ones.cwSet(1.0);
+
+  GslMatrix covMatrix(ones);
+
+  SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type new_tk(
+      new ScaledCovMatrixTKGroup<GslVector, GslMatrix>(
+        "", v, scales, covMatrix));
+
+  return new_tk;
 }
 
 template<>

--- a/src/core/src/TransitionKernelFactory.C
+++ b/src/core/src/TransitionKernelFactory.C
@@ -26,6 +26,8 @@
 #include <queso/GslMatrix.h>
 #include <queso/TransitionKernelFactory.h>
 #include <queso/ScaledCovMatrixTKGroup.h>
+#include <queso/TransformedScaledCovMatrixTKGroup.h>
+#include <queso/HessianCovMatricesTKGroup.h>
 
 namespace QUESO
 {
@@ -45,11 +47,45 @@ TransitionKernelFactory::build_tk(
     const VectorSpace<GslVector, GslMatrix> & v,
     const std::vector<double> & dr_scales,
     const ScalarFunctionSynchronizer<GslVector, GslMatrix> & pdf_synchronizer,
-    const GslMatrix & initial_cov_matrix)
+    GslMatrix & initial_cov_matrix,
+    const BaseJointPdf<GslVector, GslMatrix> & target_pdf)
 {
-  SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type new_tk(
-      new ScaledCovMatrixTKGroup<GslVector, GslMatrix>(
-        "", v, dr_scales, initial_cov_matrix));
+  SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type new_tk;
+
+  if (options.m_tkUseLocalHessian) {
+    new_tk.reset(new HessianCovMatricesTKGroup<GslVector,GslMatrix>(
+          options.m_prefix.c_str(),
+          v,
+          dr_scales,
+          pdf_synchronizer));
+  }
+  else {
+    if (options.m_initialProposalCovMatrixDataInputFileName != ".") {
+      std::set<unsigned int> tmpSet;
+      tmpSet.insert(v.env().subId());
+      initial_cov_matrix.subReadContents((options.m_initialProposalCovMatrixDataInputFileName+"_sub"+v.env().subIdString()),
+                                          options.m_initialProposalCovMatrixDataInputFileType,
+                                          tmpSet);
+    }
+
+    // Decide whether or not to do logit transform
+    if (options.m_doLogitTransform) {
+      // Variable transform of initial proposal cov matrix has already been
+      // done
+
+      // We need this dynamic_cast to BoxSubset so that m_tk can inspect the
+      // domain bounds and do the necessary transform
+      new_tk.reset(new TransformedScaledCovMatrixTKGroup<GslVector, GslMatrix>(
+          options.m_prefix.c_str(),
+          dynamic_cast<const BoxSubset<GslVector, GslMatrix> & >(target_pdf.domainSet()),
+          dr_scales, initial_cov_matrix));
+    }
+    else {
+      new_tk.reset(new ScaledCovMatrixTKGroup<GslVector, GslMatrix>(
+          options.m_prefix.c_str(), v, dr_scales,
+          initial_cov_matrix));
+    }
+  }
 
   return new_tk;
 }
@@ -61,8 +97,14 @@ const std::vector<double> * TransitionKernelFactory::m_dr_scales = NULL;
 
 const ScalarFunctionSynchronizer<GslVector, GslMatrix> * TransitionKernelFactory::m_pdf_synchronizer = NULL;
 
-const GslMatrix * TransitionKernelFactory::m_initial_cov_matrix = NULL;
+GslMatrix * TransitionKernelFactory::m_initial_cov_matrix = NULL;
 
 const MhOptionsValues * TransitionKernelFactory::m_options = NULL;
+
+const BaseJointPdf<GslVector, GslMatrix> * TransitionKernelFactory::m_target_pdf = NULL;
+
+// Instantiate all the transition kernel factories
+TransitionKernelFactory tk_factory_dram("dram");
+TransitionKernelFactory tk_factory_stochastic_newton("stochastic_newton");
 
 } // namespace QUESO

--- a/src/core/src/TransitionKernelFactory.C
+++ b/src/core/src/TransitionKernelFactory.C
@@ -40,11 +40,14 @@ Factory<BaseTKGroup<GslVector, GslMatrix> >::factory_map()
 }
 
 SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type
-TransitionKernelFactory::build_tk(const VectorSpace<GslVector, GslMatrix> & v)
+TransitionKernelFactory::build_tk(const VectorSpace<GslVector, GslMatrix> & v,
+    const std::vector<double> & dr_scales,
+    const ScalarFunctionSynchronizer<GslVector, GslMatrix> & pdf_synchronizer,
+    const GslMatrix & initial_cov_matrix)
 {
   SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type new_tk(
       new ScaledCovMatrixTKGroup<GslVector, GslMatrix>(
-        "", v, *m_dr_scales, *m_initial_cov_matrix));
+        "", v, dr_scales, initial_cov_matrix));
 
   return new_tk;
 }

--- a/src/core/src/TransitionKernelFactory.C
+++ b/src/core/src/TransitionKernelFactory.C
@@ -39,6 +39,7 @@ Factory<BaseTKGroup<GslVector, GslMatrix> >::factory_map()
   return _factory_map;
 }
 
-template class TransitionKernelFactory<BaseTKGroup<GslVector, GslMatrix> >;
+template<>
+const VectorSpace<GslVector, GslMatrix> * FactoryWithVectorSpace<BaseTKGroup<GslVector, GslMatrix> >::m_vectorSpace = NULL;
 
 } // namespace QUESO

--- a/src/core/src/TransitionKernelFactory.C
+++ b/src/core/src/TransitionKernelFactory.C
@@ -41,54 +41,54 @@ Factory<BaseTKGroup<GslVector, GslMatrix> >::factory_map()
   return _factory_map;
 }
 
-SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type
-TransitionKernelFactory::build_tk(
-    const MhOptionsValues & options,
-    const VectorSpace<GslVector, GslMatrix> & v,
-    const std::vector<double> & dr_scales,
-    const ScalarFunctionSynchronizer<GslVector, GslMatrix> & pdf_synchronizer,
-    GslMatrix & initial_cov_matrix,
-    const BaseJointPdf<GslVector, GslMatrix> & target_pdf)
-{
-  SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type new_tk;
-
-  if (options.m_tkUseLocalHessian) {
-    new_tk.reset(new HessianCovMatricesTKGroup<GslVector,GslMatrix>(
-          options.m_prefix.c_str(),
-          v,
-          dr_scales,
-          pdf_synchronizer));
-  }
-  else {
-    if (options.m_initialProposalCovMatrixDataInputFileName != ".") {
-      std::set<unsigned int> tmpSet;
-      tmpSet.insert(v.env().subId());
-      initial_cov_matrix.subReadContents((options.m_initialProposalCovMatrixDataInputFileName+"_sub"+v.env().subIdString()),
-                                          options.m_initialProposalCovMatrixDataInputFileType,
-                                          tmpSet);
-    }
-
-    // Decide whether or not to do logit transform
-    if (options.m_doLogitTransform) {
-      // Variable transform of initial proposal cov matrix has already been
-      // done
-
-      // We need this dynamic_cast to BoxSubset so that m_tk can inspect the
-      // domain bounds and do the necessary transform
-      new_tk.reset(new TransformedScaledCovMatrixTKGroup<GslVector, GslMatrix>(
-          options.m_prefix.c_str(),
-          dynamic_cast<const BoxSubset<GslVector, GslMatrix> & >(target_pdf.domainSet()),
-          dr_scales, initial_cov_matrix));
-    }
-    else {
-      new_tk.reset(new ScaledCovMatrixTKGroup<GslVector, GslMatrix>(
-          options.m_prefix.c_str(), v, dr_scales,
-          initial_cov_matrix));
-    }
-  }
-
-  return new_tk;
-}
+// SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type
+// TransitionKernelFactory::build_tk(
+//     const MhOptionsValues & options,
+//     const VectorSpace<GslVector, GslMatrix> & v,
+//     const std::vector<double> & dr_scales,
+//     const ScalarFunctionSynchronizer<GslVector, GslMatrix> & pdf_synchronizer,
+//     GslMatrix & initial_cov_matrix,
+//     const BaseJointPdf<GslVector, GslMatrix> & target_pdf)
+// {
+//   SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type new_tk;
+//
+//   if (options.m_tkUseLocalHessian) {
+//     new_tk.reset(new HessianCovMatricesTKGroup<GslVector,GslMatrix>(
+//           options.m_prefix.c_str(),
+//           v,
+//           dr_scales,
+//           pdf_synchronizer));
+//   }
+//   else {
+//     if (options.m_initialProposalCovMatrixDataInputFileName != ".") {
+//       std::set<unsigned int> tmpSet;
+//       tmpSet.insert(v.env().subId());
+//       initial_cov_matrix.subReadContents((options.m_initialProposalCovMatrixDataInputFileName+"_sub"+v.env().subIdString()),
+//                                           options.m_initialProposalCovMatrixDataInputFileType,
+//                                           tmpSet);
+//     }
+//
+//     // Decide whether or not to do logit transform
+//     if (options.m_doLogitTransform) {
+//       // Variable transform of initial proposal cov matrix has already been
+//       // done
+//
+//       // We need this dynamic_cast to BoxSubset so that m_tk can inspect the
+//       // domain bounds and do the necessary transform
+//       new_tk.reset(new TransformedScaledCovMatrixTKGroup<GslVector, GslMatrix>(
+//           options.m_prefix.c_str(),
+//           dynamic_cast<const BoxSubset<GslVector, GslMatrix> & >(target_pdf.domainSet()),
+//           dr_scales, initial_cov_matrix));
+//     }
+//     else {
+//       new_tk.reset(new ScaledCovMatrixTKGroup<GslVector, GslMatrix>(
+//           options.m_prefix.c_str(), v, dr_scales,
+//           initial_cov_matrix));
+//     }
+//   }
+//
+//   return new_tk;
+// }
 
 const VectorSpace<GslVector, GslMatrix> * TransitionKernelFactory::m_vectorSpace = NULL;
 
@@ -101,9 +101,5 @@ GslMatrix * TransitionKernelFactory::m_initial_cov_matrix = NULL;
 const MhOptionsValues * TransitionKernelFactory::m_options = NULL;
 
 const BaseJointPdf<GslVector, GslMatrix> * TransitionKernelFactory::m_target_pdf = NULL;
-
-// Instantiate all the transition kernel factories
-TransitionKernelFactory tk_factory_dram("random_walk");
-TransitionKernelFactory tk_factory_stochastic_newton("stochastic_newton");
 
 } // namespace QUESO

--- a/src/core/src/TransitionKernelFactory.C
+++ b/src/core/src/TransitionKernelFactory.C
@@ -40,7 +40,9 @@ Factory<BaseTKGroup<GslVector, GslMatrix> >::factory_map()
 }
 
 SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type
-TransitionKernelFactory::build_tk(const VectorSpace<GslVector, GslMatrix> & v,
+TransitionKernelFactory::build_tk(
+    const MhOptionsValues & options,
+    const VectorSpace<GslVector, GslMatrix> & v,
     const std::vector<double> & dr_scales,
     const ScalarFunctionSynchronizer<GslVector, GslMatrix> & pdf_synchronizer,
     const GslMatrix & initial_cov_matrix)
@@ -60,5 +62,7 @@ const std::vector<double> * TransitionKernelFactory::m_dr_scales = NULL;
 const ScalarFunctionSynchronizer<GslVector, GslMatrix> * TransitionKernelFactory::m_pdf_synchronizer = NULL;
 
 const GslMatrix * TransitionKernelFactory::m_initial_cov_matrix = NULL;
+
+const MhOptionsValues * TransitionKernelFactory::m_options = NULL;
 
 } // namespace QUESO

--- a/src/stats/inc/AcceptanceRatio.h
+++ b/src/stats/inc/AcceptanceRatio.h
@@ -1,0 +1,52 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/MarkovChainPositionData.h>
+
+namespace QUESO {
+
+class GslVector;
+class GslMatrix;
+class BaseEnvironment;
+template <class V, class M> class BaseTKGroup;
+
+template <class V = GslVector, class M = GslMatrix>
+class AcceptanceRatio
+{
+public:
+  AcceptanceRatio(const BaseEnvironment & env, const BaseTKGroup<V, M> & tk);
+  ~AcceptanceRatio();
+
+  //! tk_pos_x is the position of the tk when evaluating for x
+  //! tk_pos_y is the position of the tk when evaluating for y
+  double operator()(MarkovChainPositionData<V> x,
+                    MarkovChainPositionData<V> y,
+                    const V & tk_pos_x,
+                    const V & tk_pos_y);
+private:
+  const BaseEnvironment & m_env;
+  const BaseTKGroup<V, M> & m_tk;
+};
+
+}  // End namespace QUESO

--- a/src/stats/inc/Algorithm.h
+++ b/src/stats/inc/Algorithm.h
@@ -1,0 +1,52 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/MarkovChainPositionData.h>
+
+namespace QUESO {
+
+class GslVector;
+class GslMatrix;
+class BaseEnvironment;
+template <class V, class M> class BaseTKGroup;
+
+template <class V = GslVector, class M = GslMatrix>
+class Algorithm
+{
+public:
+  Algorithm(const BaseEnvironment & env, const BaseTKGroup<V, M> & tk);
+  ~Algorithm();
+
+  //! tk_pos_x is the position of the tk when evaluating for x
+  //! tk_pos_y is the position of the tk when evaluating for y
+  double operator()(MarkovChainPositionData<V> x,
+                    MarkovChainPositionData<V> y,
+                    const V & tk_pos_x,
+                    const V & tk_pos_y);
+private:
+  const BaseEnvironment & m_env;
+  const BaseTKGroup<V, M> & m_tk;
+};
+
+}  // End namespace QUESO

--- a/src/stats/inc/Algorithm.h
+++ b/src/stats/inc/Algorithm.h
@@ -40,10 +40,10 @@ public:
 
   //! tk_pos_x is the position of the tk when evaluating for x
   //! tk_pos_y is the position of the tk when evaluating for y
-  double operator()(MarkovChainPositionData<V> x,
-                    MarkovChainPositionData<V> y,
-                    const V & tk_pos_x,
-                    const V & tk_pos_y);
+  double acceptance_ratio(MarkovChainPositionData<V> x,
+                          MarkovChainPositionData<V> y,
+                          const V & tk_pos_x,
+                          const V & tk_pos_y);
 private:
   const BaseEnvironment & m_env;
   const BaseTKGroup<V, M> & m_tk;

--- a/src/stats/inc/HessianCovMatricesTKGroup.h
+++ b/src/stats/inc/HessianCovMatricesTKGroup.h
@@ -67,7 +67,7 @@ public:
   //! Gaussian increment property to construct a transition kernel.
   const GaussianVectorRV<V,M>& rv                        (const std::vector<unsigned int>& stageIds);
 
-  virtual const GaussianVectorRV<V, M> & rv() const;
+  virtual const GaussianVectorRV<V, M> & rv(const V & position) const;
    //@}
 
   //! @name Misc methods

--- a/src/stats/inc/HessianCovMatricesTKGroup.h
+++ b/src/stats/inc/HessianCovMatricesTKGroup.h
@@ -66,6 +66,8 @@ public:
 
   //! Gaussian increment property to construct a transition kernel.
   const GaussianVectorRV<V,M>& rv                        (const std::vector<unsigned int>& stageIds);
+
+  virtual const GaussianVectorRV<V, M> & rv() const;
    //@}
 
   //! @name Misc methods

--- a/src/stats/inc/HessianCovMatricesTKGroup.h
+++ b/src/stats/inc/HessianCovMatricesTKGroup.h
@@ -75,6 +75,8 @@ public:
 
   //! Clears the pre-computing positions \c m_preComputingPositions[stageId]
   void                          clearPreComputingPositions();
+
+  virtual unsigned int set_dr_stage(unsigned int stageId);
   //@}
 
   //! @name I/O methods

--- a/src/stats/inc/MLSamplingLevelOptions.h
+++ b/src/stats/inc/MLSamplingLevelOptions.h
@@ -102,6 +102,7 @@
 #define UQ_ML_SAMPLING_L_AM_EPSILON_ODV                                       1.e-5
 #define UQ_ML_SAMPLING_L_DO_LOGIT_TRANSFORM                                   0
 #define UQ_ML_SAMPLING_L_ALGORITHM                                            "random_walk"
+#define UQ_ML_SAMPLING_L_TK                                                   "random_walk"
 
 namespace QUESO {
 
@@ -355,6 +356,9 @@ public:
   //! Which algorithm to use for sampling
   std::string m_algorithm;
 
+  //! Which transition kernel to use for sampling
+  std::string m_tk;
+
 private:
   //! Copies the option values from \c srcOptions to \c this.
   void   copyOptionsValues(const MLSamplingLevelOptions& srcOptions);
@@ -442,6 +446,7 @@ private:
   std::string                   m_option_am_epsilon;
   std::string                   m_option_doLogitTransform;
   std::string                   m_option_algorithm;
+  std::string                   m_option_tk;
 
   void checkOptions(const BaseEnvironment * env);
 

--- a/src/stats/inc/MLSamplingLevelOptions.h
+++ b/src/stats/inc/MLSamplingLevelOptions.h
@@ -101,6 +101,7 @@
 #define UQ_ML_SAMPLING_L_AM_ETA_ODV                                           1.
 #define UQ_ML_SAMPLING_L_AM_EPSILON_ODV                                       1.e-5
 #define UQ_ML_SAMPLING_L_DO_LOGIT_TRANSFORM                                   0
+#define UQ_ML_SAMPLING_L_ALGORITHM                                            "random_walk"
 
 namespace QUESO {
 
@@ -351,6 +352,9 @@ public:
   //! Whether or not a logit transform will be done for bounded domains
   bool m_doLogitTransform;
 
+  //! Which algorithm to use for sampling
+  std::string m_algorithm;
+
 private:
   //! Copies the option values from \c srcOptions to \c this.
   void   copyOptionsValues(const MLSamplingLevelOptions& srcOptions);
@@ -437,6 +441,7 @@ private:
   std::string                   m_option_am_eta;
   std::string                   m_option_am_epsilon;
   std::string                   m_option_doLogitTransform;
+  std::string                   m_option_algorithm;
 
   void checkOptions(const BaseEnvironment * env);
 

--- a/src/stats/inc/MetropolisHastingsSG.h
+++ b/src/stats/inc/MetropolisHastingsSG.h
@@ -43,7 +43,7 @@ class GslVector;
 class GslMatrix;
 
 template <class P_V, class P_M>
-class AcceptanceRatio;
+class Algorithm;
 
 //--------------------------------------------------
 // MHRawChainInfoStruct --------------------------
@@ -314,7 +314,7 @@ private:
   const ScalarFunctionSynchronizer<P_V,P_M> * m_targetPdfSynchronizer;
 
   typename SharedPtr<BaseTKGroup<P_V,P_M> >::Type m_tk;
-  typename SharedPtr<AcceptanceRatio<P_V, P_M>>::Type m_acceptanceRatio;
+  typename SharedPtr<Algorithm<P_V, P_M>>::Type m_algorithm;
   unsigned int m_positionIdForDebugging;
   unsigned int m_stageIdForDebugging;
   std::vector<unsigned int> m_idsOfUniquePositions;

--- a/src/stats/inc/MetropolisHastingsSG.h
+++ b/src/stats/inc/MetropolisHastingsSG.h
@@ -35,6 +35,7 @@
 #include <queso/ArrayOfSequences.h>
 #include <sys/time.h>
 #include <fstream>
+#include <queso/SharedPtr.h>
 
 namespace QUESO {
 
@@ -309,7 +310,7 @@ private:
   std::vector<bool> m_parameterEnabledStatus; // gpmsa2
   const ScalarFunctionSynchronizer<P_V,P_M> * m_targetPdfSynchronizer;
 
-  BaseTKGroup<P_V,P_M> * m_tk;
+  typename SharedPtr<BaseTKGroup<P_V,P_M> >::Type m_tk;
   unsigned int m_positionIdForDebugging;
   unsigned int m_stageIdForDebugging;
   std::vector<unsigned int> m_idsOfUniquePositions;

--- a/src/stats/inc/MetropolisHastingsSG.h
+++ b/src/stats/inc/MetropolisHastingsSG.h
@@ -42,6 +42,9 @@ namespace QUESO {
 class GslVector;
 class GslMatrix;
 
+template <class P_V, class P_M>
+class AcceptanceRatio;
+
 //--------------------------------------------------
 // MHRawChainInfoStruct --------------------------
 //--------------------------------------------------
@@ -311,6 +314,7 @@ private:
   const ScalarFunctionSynchronizer<P_V,P_M> * m_targetPdfSynchronizer;
 
   typename SharedPtr<BaseTKGroup<P_V,P_M> >::Type m_tk;
+  typename SharedPtr<AcceptanceRatio<P_V, P_M>>::Type m_acceptanceRatio;
   unsigned int m_positionIdForDebugging;
   unsigned int m_stageIdForDebugging;
   std::vector<unsigned int> m_idsOfUniquePositions;

--- a/src/stats/inc/MetropolisHastingsSGOptions.h
+++ b/src/stats/inc/MetropolisHastingsSGOptions.h
@@ -97,6 +97,7 @@
 #define UQ_MH_SG_OUTPUT_LOG_TARGET                                    1
 #define UQ_MH_SG_DO_LOGIT_TRANSFORM                                   1
 #define UQ_MH_SG_ALGORITHM                                            "logit_random_walk"
+#define UQ_MH_SG_TK                                                   "logit_random_walk"
 
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
 namespace boost {
@@ -608,6 +609,9 @@ public:
   //! Which algorithm to use for the MCMC.  Default is "random_walk"
   std::string m_algorithm;
 
+  //! Which transition kernel to use for MCMC.  Default is "random_walk"
+  std::string m_tk;
+
 private:
   // Cache a pointer to the environment.
   const BaseEnvironment * m_env;
@@ -731,6 +735,8 @@ private:
   std::string                   m_option_doLogitTransform;
   //! Option name for MhOptionsValues::m_algorithm.  Option name is m_prefix + "mh_algorithm"
   std::string                   m_option_algorithm;
+  //! Option name for MhOptionsValues::m_tk.  Option name is m_prefix + "mh_tk"
+  std::string                   m_option_tk;
 
   //! Copies the option values from \c src to \c this.
   void copy(const MhOptionsValues& src);
@@ -880,6 +886,7 @@ private:
   std::string                   m_option_outputLogTarget;
   std::string                   m_option_doLogitTransform;
   std::string                   m_option_algorithm;
+  std::string                   m_option_tk;
 };
 
 std::ostream& operator<<(std::ostream& os, const MetropolisHastingsSGOptions& obj);

--- a/src/stats/inc/MetropolisHastingsSGOptions.h
+++ b/src/stats/inc/MetropolisHastingsSGOptions.h
@@ -96,6 +96,7 @@
 #define UQ_MH_SG_OUTPUT_LOG_LIKELIHOOD                                1
 #define UQ_MH_SG_OUTPUT_LOG_TARGET                                    1
 #define UQ_MH_SG_DO_LOGIT_TRANSFORM                                   1
+#define UQ_MH_SG_ALGORITHM                                            "random_walk"
 
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
 namespace boost {
@@ -604,6 +605,9 @@ public:
   //! Flag for deciding whether or not to do logit transform of bounded domains Default is true.
   bool m_doLogitTransform;
 
+  //! Which algorithm to use for the MCMC.  Default is "random_walk"
+  std::string m_algorithm;
+
 private:
   // Cache a pointer to the environment.
   const BaseEnvironment * m_env;
@@ -725,6 +729,8 @@ private:
   std::string                   m_option_outputLogTarget;
   //! Option name for MhOptionsValues::m_doLogitTransform.  Option name is m_prefix + "mh_doLogitTransform"
   std::string                   m_option_doLogitTransform;
+  //! Option name for MhOptionsValues::m_algorithm.  Option name is m_prefix + "mh_algorithm"
+  std::string                   m_option_algorithm;
 
   //! Copies the option values from \c src to \c this.
   void copy(const MhOptionsValues& src);

--- a/src/stats/inc/MetropolisHastingsSGOptions.h
+++ b/src/stats/inc/MetropolisHastingsSGOptions.h
@@ -96,7 +96,7 @@
 #define UQ_MH_SG_OUTPUT_LOG_LIKELIHOOD                                1
 #define UQ_MH_SG_OUTPUT_LOG_TARGET                                    1
 #define UQ_MH_SG_DO_LOGIT_TRANSFORM                                   1
-#define UQ_MH_SG_ALGORITHM                                            "random_walk"
+#define UQ_MH_SG_ALGORITHM                                            "logit_random_walk"
 
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
 namespace boost {
@@ -879,6 +879,7 @@ private:
   std::string                   m_option_outputLogLikelihood;
   std::string                   m_option_outputLogTarget;
   std::string                   m_option_doLogitTransform;
+  std::string                   m_option_algorithm;
 };
 
 std::ostream& operator<<(std::ostream& os, const MetropolisHastingsSGOptions& obj);

--- a/src/stats/inc/ScaledCovMatrixTKGroup.h
+++ b/src/stats/inc/ScaledCovMatrixTKGroup.h
@@ -66,7 +66,7 @@ public:
   //! Gaussian increment property to construct a transition kernel.
   const GaussianVectorRV<V,M>& rv                        (const std::vector<unsigned int>& stageIds);
 
-  virtual const GaussianVectorRV<V, M> & rv() const;
+  virtual const GaussianVectorRV<V, M> & rv(const V & position) const;
 
   //! Scales the covariance matrix.
   /*! The covariance matrix is scaled by a factor of \f$ 1/scales^2 \f$.*/

--- a/src/stats/inc/ScaledCovMatrixTKGroup.h
+++ b/src/stats/inc/ScaledCovMatrixTKGroup.h
@@ -78,6 +78,9 @@ public:
 
   //! Clears the pre-computing positions \c m_preComputingPositions[stageId]
   void                          clearPreComputingPositions();
+
+  //! Sets the internal \c m_stageId varialbe to \c stageId
+  virtual unsigned int set_dr_stage(unsigned int stageId);
   //@}
 
   //! @name I/O methods

--- a/src/stats/inc/ScaledCovMatrixTKGroup.h
+++ b/src/stats/inc/ScaledCovMatrixTKGroup.h
@@ -66,6 +66,8 @@ public:
   //! Gaussian increment property to construct a transition kernel.
   const GaussianVectorRV<V,M>& rv                        (const std::vector<unsigned int>& stageIds);
 
+  virtual const GaussianVectorRV<V, M> & rv() const;
+
   //! Scales the covariance matrix.
   /*! The covariance matrix is scaled by a factor of \f$ 1/scales^2 \f$.*/
   void                          updateLawCovMatrix        (const M& covMatrix);

--- a/src/stats/inc/TKGroup.h
+++ b/src/stats/inc/TKGroup.h
@@ -87,6 +87,8 @@ public:
 
   //! Clears the pre-computing positions \c m_preComputingPositions[stageId]
   virtual       void                          clearPreComputingPositions();
+
+  virtual void set_dr_stage(unsigned int stageId);
   //@}
 
   //! @name I/O methods
@@ -96,13 +98,16 @@ public:
   virtual       void                          print                     (std::ostream& os) const;
   //@}
 protected:
-  const   EmptyEnvironment*                    m_emptyEnv;
-  const   BaseEnvironment&                     m_env;
-          std::string                                 m_prefix;
-  const   VectorSpace<V,M>*                    m_vectorSpace;
-          std::vector<double>                         m_scales;
-          std::vector<const V*>                       m_preComputingPositions;
-          std::vector<BaseVectorRV<V,M>* > m_rvs; // Gaussian, not Base... And nothing const...
+  const EmptyEnvironment*                m_emptyEnv;
+  const BaseEnvironment&                 m_env;
+        std::string                      m_prefix;
+  const VectorSpace<V,M>*                m_vectorSpace;
+        std::vector<double>              m_scales;
+        std::vector<const V*>            m_preComputingPositions;
+        std::vector<BaseVectorRV<V,M>* > m_rvs; // Gaussian, not Base... And nothing const...
+
+private:
+  unsigned int m_stageId;
 };
 
 }  // End namespace QUESO

--- a/src/stats/inc/TKGroup.h
+++ b/src/stats/inc/TKGroup.h
@@ -88,7 +88,8 @@ public:
   //! Clears the pre-computing positions \c m_preComputingPositions[stageId]
   virtual       void                          clearPreComputingPositions();
 
-  virtual void set_dr_stage(unsigned int stageId);
+  //! Does nothing.  Subclasses may re-implement.  Returns the current stage id.
+  virtual unsigned int set_dr_stage(unsigned int stageId);
   //@}
 
   //! @name I/O methods
@@ -105,8 +106,6 @@ protected:
         std::vector<double>              m_scales;
         std::vector<const V*>            m_preComputingPositions;
         std::vector<BaseVectorRV<V,M>* > m_rvs; // Gaussian, not Base... And nothing const...
-
-private:
   unsigned int m_stageId;
 };
 

--- a/src/stats/inc/TKGroup.h
+++ b/src/stats/inc/TKGroup.h
@@ -74,7 +74,7 @@ public:
   virtual const BaseVectorRV<V,M>& rv                        (const std::vector<unsigned int>& stageIds) = 0;
 
   //! Constructs transition kernel pdf based on internal \c m_stageId variable
-  virtual const BaseVectorRV<V, M> & rv() const = 0;
+  virtual const BaseVectorRV<V, M> & rv(const V & position) const = 0;
   //@}
 
   //! @name Misc methods

--- a/src/stats/inc/TKGroup.h
+++ b/src/stats/inc/TKGroup.h
@@ -72,6 +72,9 @@ public:
 
   //! Gaussian increment property to construct a transition kernel. See template specialization.
   virtual const BaseVectorRV<V,M>& rv                        (const std::vector<unsigned int>& stageIds) = 0;
+
+  //! Constructs transition kernel pdf based on internal \c m_stageId variable
+  virtual const BaseVectorRV<V, M> & rv() const = 0;
   //@}
 
   //! @name Misc methods

--- a/src/stats/inc/TransformedScaledCovMatrixTKGroup.h
+++ b/src/stats/inc/TransformedScaledCovMatrixTKGroup.h
@@ -70,7 +70,7 @@ public:
   const InvLogitGaussianVectorRV<V, M> & rv(
       const std::vector<unsigned int> & stageIds);
 
-  virtual const InvLogitGaussianVectorRV<V, M> & rv() const;
+  virtual const InvLogitGaussianVectorRV<V, M> & rv(const V & position) const;
 
   //! Scales the covariance matrix of the underlying Gaussian distribution.
   /*! The covariance matrix is scaled by a factor of \f$ 1/scales^2 \f$.*/

--- a/src/stats/inc/TransformedScaledCovMatrixTKGroup.h
+++ b/src/stats/inc/TransformedScaledCovMatrixTKGroup.h
@@ -70,6 +70,8 @@ public:
   const InvLogitGaussianVectorRV<V, M> & rv(
       const std::vector<unsigned int> & stageIds);
 
+  virtual const InvLogitGaussianVectorRV<V, M> & rv() const;
+
   //! Scales the covariance matrix of the underlying Gaussian distribution.
   /*! The covariance matrix is scaled by a factor of \f$ 1/scales^2 \f$.*/
   void updateLawCovMatrix(const M & covMatrix);

--- a/src/stats/inc/TransformedScaledCovMatrixTKGroup.h
+++ b/src/stats/inc/TransformedScaledCovMatrixTKGroup.h
@@ -87,6 +87,8 @@ public:
 
   //! Clears the pre-computing positions \c m_preComputingPositions[stageId]
   void clearPreComputingPositions();
+
+  virtual unsigned int set_dr_stage(unsigned int stageId);
   //@}
 
   //! @name I/O methods

--- a/src/stats/src/AcceptanceRatio.C
+++ b/src/stats/src/AcceptanceRatio.C
@@ -1,0 +1,168 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/Environment.h>
+#include <queso/math_macros.h>
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/AcceptanceRatio.h>
+#include <queso/TKGroup.h>
+
+namespace QUESO {
+
+template <class V, class M>
+AcceptanceRatio<V, M>::AcceptanceRatio(const BaseEnvironment & env,
+    const BaseTKGroup<V, M> & tk)
+  :
+    m_env(env),
+    m_tk(tk)
+{
+}
+
+template <class V, class M>
+AcceptanceRatio<V, M>::~AcceptanceRatio()
+{
+}
+
+template <class V, class M>
+double
+AcceptanceRatio<V, M>::operator()(
+    MarkovChainPositionData<V> x,
+    MarkovChainPositionData<V> y,
+    const V & tk_pos_x,
+    const V & tk_pos_y)
+{
+  double alphaQuotient = 0.;
+  if ((x.outOfTargetSupport() == false) &&
+      (y.outOfTargetSupport() == false)) {
+    if ((x.logTarget() == -INFINITY) ||
+        (x.logTarget() ==  INFINITY) ||
+        ( queso_isnan(x.logTarget())      )) {
+      std::cerr << "WARNING In MetropolisHastingsSG<P_V,P_M>::alpha(x,y)"
+                << ", worldRank "       << m_env.worldRank()
+                << ", fullRank "        << m_env.fullRank()
+                << ", subEnvironment "  << m_env.subId()
+                << ", subRank "         << m_env.subRank()
+                << ", inter0Rank "      << m_env.inter0Rank()
+                << ": x.logTarget() = " << x.logTarget()
+                << ", x.values() = "    << x.vecValues()
+                << ", y.values() = "    << y.vecValues()
+                << std::endl;
+    }
+    else if ((y.logTarget() == -INFINITY           ) ||
+             (y.logTarget() ==  INFINITY           ) ||
+             ( queso_isnan(y.logTarget()) )) {
+      std::cerr << "WARNING In MetropolisHastingsSG<P_V,P_M>::alpha(x,y)"
+                << ", worldRank "       << m_env.worldRank()
+                << ", fullRank "        << m_env.fullRank()
+                << ", subEnvironment "  << m_env.subId()
+                << ", subRank "         << m_env.subRank()
+                << ", inter0Rank "      << m_env.inter0Rank()
+                << ": y.logTarget() = " << y.logTarget()
+                << ", x.values() = "    << x.vecValues()
+                << ", y.values() = "    << y.vecValues()
+                << std::endl;
+    }
+    else {
+      double yLogTargetToUse = y.logTarget();
+
+      if (m_tk.symmetric()) {
+        alphaQuotient = std::exp(yLogTargetToUse - x.logTarget());
+
+        // if ((m_env.subDisplayFile()                   ) &&
+        //     (m_env.displayVerbosity() >= 3            ) &&
+        //     (m_optionsObj->m_totallyMute == false)) {
+        //   *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::alpha(x,y)"
+        //                          << ": symmetric proposal case"
+        //                          << ", x = "               << x.vecValues()
+        //                          << ", y = "               << y.vecValues()
+        //                          << ", yLogTargetToUse = " << yLogTargetToUse
+        //                          << ", x.logTarget() = "   << x.logTarget()
+        //                          << ", alpha = "           << alphaQuotient
+        //                          << std::endl;
+        // }
+      }
+      else {
+        double qyx = m_tk.rv(tk_pos_x).pdf().lnValue(x.vecValues(),NULL,NULL,NULL,NULL);
+        // if ((m_env.subDisplayFile()                   ) &&
+        //     (m_env.displayVerbosity() >= 10           ) &&
+        //     (m_optionsObj->m_totallyMute == false)) {
+        //   const InvLogitGaussianJointPdf<P_V,P_M>* pdfYX = dynamic_cast< const InvLogitGaussianJointPdf<P_V,P_M>* >(&(m_tk->rv(yStageId).pdf()));
+        //   *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::alpha(x,y)"
+        //                          << ", rvYX.lawExpVector = " << pdfYX->lawExpVector()
+        //                          << ", rvYX.lawVarVector = " << pdfYX->lawVarVector()
+        //                          << ", rvYX.lawCovMatrix = " << pdfYX->lawCovMatrix()
+        //                          << std::endl;
+        // }
+        double qxy = m_tk.rv(tk_pos_y).pdf().lnValue(y.vecValues(),NULL,NULL,NULL,NULL);
+        // if ((m_env.subDisplayFile()                   ) &&
+        //     (m_env.displayVerbosity() >= 10           ) &&
+        //     (m_optionsObj->m_totallyMute == false)) {
+        //   const InvLogitGaussianJointPdf<P_V,P_M>* pdfXY = dynamic_cast< const InvLogitGaussianJointPdf<P_V,P_M>* >(&(m_tk->rv(xStageId).pdf()));
+        //   *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::alpha(x,y)"
+        //                          << ", rvXY.lawExpVector = " << pdfXY->lawExpVector()
+        //                          << ", rvXY.lawVarVector = " << pdfXY->lawVarVector()
+        //                          << ", rvXY.lawCovMatrix = " << pdfXY->lawCovMatrix()
+        //                          << std::endl;
+        // }
+        alphaQuotient = std::exp(yLogTargetToUse +
+                                 qyx -
+                                 x.logTarget() -
+                                 qxy);
+        // if ((m_env.subDisplayFile()                   ) &&
+        //     (m_env.displayVerbosity() >= 3            ) &&
+        //     (m_optionsObj->m_totallyMute == false)) {
+        //   *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::alpha(x,y)"
+        //                          << ": asymmetric proposal case"
+        //                          << ", xStageId = "        << xStageId
+        //                          << ", yStageId = "        << yStageId
+        //                          << ", x = "               << x.vecValues()
+        //                          << ", y = "               << y.vecValues()
+        //                          << ", yLogTargetToUse = " << yLogTargetToUse
+        //                          << ", q(y,x) = "          << qyx
+        //                          << ", x.logTarget() = "   << x.logTarget()
+        //                          << ", q(x,y) = "          << qxy
+        //                          << ", alpha = "           << alphaQuotient
+        //                          << std::endl;
+        // }
+      }
+    } // protection logic against logTarget values
+  }
+  else {
+    // if ((m_env.subDisplayFile()                   ) &&
+    //     (m_env.displayVerbosity() >= 10           ) &&
+    //     (m_optionsObj->m_totallyMute == false)) {
+    //   *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::alpha(x,y)"
+    //                          << ": x.outOfTargetSupport = " << x.outOfTargetSupport()
+    //                          << ", y.outOfTargetSupport = " << y.outOfTargetSupport()
+    //                          << std::endl;
+    // }
+  }
+
+  return std::min(1.,alphaQuotient);
+}
+
+template class AcceptanceRatio<GslVector, GslMatrix>;
+
+}  // End namespace QUESO

--- a/src/stats/src/Algorithm.C
+++ b/src/stats/src/Algorithm.C
@@ -26,13 +26,13 @@
 #include <queso/math_macros.h>
 #include <queso/GslVector.h>
 #include <queso/GslMatrix.h>
-#include <queso/AcceptanceRatio.h>
+#include <queso/Algorithm.h>
 #include <queso/TKGroup.h>
 
 namespace QUESO {
 
 template <class V, class M>
-AcceptanceRatio<V, M>::AcceptanceRatio(const BaseEnvironment & env,
+Algorithm<V, M>::Algorithm(const BaseEnvironment & env,
     const BaseTKGroup<V, M> & tk)
   :
     m_env(env),
@@ -41,13 +41,13 @@ AcceptanceRatio<V, M>::AcceptanceRatio(const BaseEnvironment & env,
 }
 
 template <class V, class M>
-AcceptanceRatio<V, M>::~AcceptanceRatio()
+Algorithm<V, M>::~Algorithm()
 {
 }
 
 template <class V, class M>
 double
-AcceptanceRatio<V, M>::operator()(
+Algorithm<V, M>::operator()(
     MarkovChainPositionData<V> x,
     MarkovChainPositionData<V> y,
     const V & tk_pos_x,
@@ -163,6 +163,6 @@ AcceptanceRatio<V, M>::operator()(
   return std::min(1.,alphaQuotient);
 }
 
-template class AcceptanceRatio<GslVector, GslMatrix>;
+template class Algorithm<GslVector, GslMatrix>;
 
 }  // End namespace QUESO

--- a/src/stats/src/Algorithm.C
+++ b/src/stats/src/Algorithm.C
@@ -47,7 +47,7 @@ Algorithm<V, M>::~Algorithm()
 
 template <class V, class M>
 double
-Algorithm<V, M>::operator()(
+Algorithm<V, M>::acceptance_ratio(
     MarkovChainPositionData<V> x,
     MarkovChainPositionData<V> y,
     const V & tk_pos_x,

--- a/src/stats/src/HessianCovMatricesTKGroup.C
+++ b/src/stats/src/HessianCovMatricesTKGroup.C
@@ -351,6 +351,17 @@ HessianCovMatricesTKGroup<V,M>::clearPreComputingPositions()
 
   return;
 }
+
+template <class V, class M>
+unsigned int
+HessianCovMatricesTKGroup<V, M>::set_dr_stage(unsigned int stageId)
+{
+  unsigned int old_stageId = this->m_stageId;
+  this->m_stageId = stageId;
+  return old_stageId;
+}
+
+
 // I/O methods---------------------------------------
 template<class V, class M>
 void

--- a/src/stats/src/HessianCovMatricesTKGroup.C
+++ b/src/stats/src/HessianCovMatricesTKGroup.C
@@ -143,17 +143,17 @@ HessianCovMatricesTKGroup<V,M>::rv(const std::vector<unsigned int>& stageIds)
 
 template <class V, class M>
 const GaussianVectorRV<V, M> &
-HessianCovMatricesTKGroup<V, M>::rv() const
+HessianCovMatricesTKGroup<V, M>::rv(const V & position) const
 {
   queso_require_greater_msg(m_rvs.size(), this->m_stageId, "m_rvs.size() <= stageId");
   queso_require_msg(m_rvs[this->m_stageId], "m_rvs[stageId] == NULL");
-  queso_require_greater_msg(m_preComputingPositions.size(), this->m_stageId, "m_preComputingPositions.size() <= stageId");
-  queso_require_msg(m_preComputingPositions[this->m_stageId], "m_preComputingPositions[stageId] == NULL");
+  // queso_require_greater_msg(m_preComputingPositions.size(), this->m_stageId, "m_preComputingPositions.size() <= stageId");
+  // queso_require_msg(m_preComputingPositions[this->m_stageId], "m_preComputingPositions[stageId] == NULL");
 
   GaussianVectorRV<V, M> * gaussian_rv =
     dynamic_cast<GaussianVectorRV<V, M> * >(m_rvs[this->m_stageId]);
 
-  gaussian_rv->updateLawExpVector(*m_preComputingPositions[this->m_stageId] + *m_originalNewtonSteps[this->m_stageId]);
+  gaussian_rv->updateLawExpVector(position + *m_originalNewtonSteps[this->m_stageId]);
 
   gaussian_rv->updateLawCovMatrix(*m_originalCovMatrices[this->m_stageId]);
 

--- a/src/stats/src/HessianCovMatricesTKGroup.C
+++ b/src/stats/src/HessianCovMatricesTKGroup.C
@@ -140,6 +140,26 @@ HessianCovMatricesTKGroup<V,M>::rv(const std::vector<unsigned int>& stageIds)
 
   return *gaussian_rv;
 }
+
+template <class V, class M>
+const GaussianVectorRV<V, M> &
+HessianCovMatricesTKGroup<V, M>::rv() const
+{
+  queso_require_greater_msg(m_rvs.size(), this->m_stageId, "m_rvs.size() <= stageId");
+  queso_require_msg(m_rvs[this->m_stageId], "m_rvs[stageId] == NULL");
+  queso_require_greater_msg(m_preComputingPositions.size(), this->m_stageId, "m_preComputingPositions.size() <= stageId");
+  queso_require_msg(m_preComputingPositions[this->m_stageId], "m_preComputingPositions[stageId] == NULL");
+
+  GaussianVectorRV<V, M> * gaussian_rv =
+    dynamic_cast<GaussianVectorRV<V, M> * >(m_rvs[this->m_stageId]);
+
+  gaussian_rv->updateLawExpVector(*m_preComputingPositions[this->m_stageId] + *m_originalNewtonSteps[this->m_stageId]);
+
+  gaussian_rv->updateLawCovMatrix(*m_originalCovMatrices[this->m_stageId]);
+
+  return *gaussian_rv;
+}
+
 // Misc methods--------------------------------------
 template<class V, class M>
 bool

--- a/src/stats/src/MLSamplingLevelOptions.C
+++ b/src/stats/src/MLSamplingLevelOptions.C
@@ -182,7 +182,8 @@ MLSamplingLevelOptions::MLSamplingLevelOptions(
     m_option_am_eta                                    (m_prefix + "am_eta"                                    ),
     m_option_am_epsilon                                (m_prefix + "am_epsilon"                                ),
     m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          ),
-    m_option_algorithm                                 (m_prefix + "algorithm"                                 )
+    m_option_algorithm                                 (m_prefix + "algorithm"                                 ),
+    m_option_tk                                        (m_prefix + "tk"                                        )
 {
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
   this->defineAllOptions();
@@ -266,6 +267,7 @@ MLSamplingLevelOptions::defineAllOptions()
   m_parser->registerOption<double      >(m_option_am_epsilon,                                 m_amEpsilon                                , "'am' epsilon"                                                    );
   m_parser->registerOption<bool        >(m_option_doLogitTransform,                           UQ_ML_SAMPLING_L_DO_LOGIT_TRANSFORM        , "flag for doing logit transform for bounded domains"              );
   m_parser->registerOption<std::string >(m_option_algorithm,                                  UQ_ML_SAMPLING_L_ALGORITHM                 , "which algorithm to use for sampling"                             );
+  m_parser->registerOption<std::string >(m_option_tk,                                         UQ_ML_SAMPLING_L_TK                        , "which transition kernel to use for sampling"                     );
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 }
 
@@ -342,6 +344,7 @@ MLSamplingLevelOptions::getAllOptions()
   m_parser->getOption<double      >(m_option_am_epsilon,                                 m_amEpsilon                                );
   m_parser->getOption<bool        >(m_option_doLogitTransform,                           m_doLogitTransform);
   m_parser->getOption<std::string >(m_option_algorithm,                                  m_algorithm);
+  m_parser->getOption<std::string >(m_option_tk,                                         m_tk);
 #else
   m_help = m_env.input()(m_option_help,                                       UQ_ML_SAMPLING_L_HELP                      );
 #ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY
@@ -473,6 +476,7 @@ MLSamplingLevelOptions::getAllOptions()
   m_amEpsilon                                 = m_env.input()(m_option_am_epsilon,                                 m_amEpsilon                                );
   m_doLogitTransform                          = m_env.input()(m_option_doLogitTransform,                           UQ_ML_SAMPLING_L_DO_LOGIT_TRANSFORM        );
   m_algorithm                                 = m_env.input()(m_option_algorithm,                                  UQ_ML_SAMPLING_L_ALGORITHM                 );
+  m_tk                                        = m_env.input()(m_option_tk,                                         UQ_ML_SAMPLING_L_TK                        );
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 }
 
@@ -559,6 +563,7 @@ MLSamplingLevelOptions::copyOptionsValues(const MLSamplingLevelOptions& srcOptio
   m_amEpsilon                                 = srcOptions.m_amEpsilon;
   m_doLogitTransform                          = srcOptions.m_doLogitTransform;
   m_algorithm                                 = srcOptions.m_algorithm;
+  m_tk                                        = srcOptions.m_tk;
 
   return;
 }
@@ -815,6 +820,7 @@ MLSamplingLevelOptions::print(std::ostream& os) const
      << "\n" << m_option_am_epsilon                                 << " = " << m_amEpsilon
      << "\n" << m_option_doLogitTransform                           << " = " << m_doLogitTransform
      << "\n" << m_option_algorithm                                  << " = " << m_algorithm
+     << "\n" << m_option_tk                                         << " = " << m_tk
      << std::endl;
 
   return;

--- a/src/stats/src/MLSamplingLevelOptions.C
+++ b/src/stats/src/MLSamplingLevelOptions.C
@@ -181,7 +181,8 @@ MLSamplingLevelOptions::MLSamplingLevelOptions(
     m_option_am_adaptedMatrices_dataOutputAllowedSet   (m_prefix + "amAdaptedMatrices_dataOutputAllowedSet"    ),
     m_option_am_eta                                    (m_prefix + "am_eta"                                    ),
     m_option_am_epsilon                                (m_prefix + "am_epsilon"                                ),
-    m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          )
+    m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          ),
+    m_option_algorithm                                 (m_prefix + "algorithm"                                 )
 {
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
   this->defineAllOptions();
@@ -264,6 +265,7 @@ MLSamplingLevelOptions::defineAllOptions()
   m_parser->registerOption<double      >(m_option_am_eta,                                     m_amEta                                    , "'am' eta"                                                        );
   m_parser->registerOption<double      >(m_option_am_epsilon,                                 m_amEpsilon                                , "'am' epsilon"                                                    );
   m_parser->registerOption<bool        >(m_option_doLogitTransform,                           UQ_ML_SAMPLING_L_DO_LOGIT_TRANSFORM        , "flag for doing logit transform for bounded domains"              );
+  m_parser->registerOption<std::string >(m_option_algorithm,                                  UQ_ML_SAMPLING_L_ALGORITHM                 , "which algorithm to use for sampling"                             );
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 }
 
@@ -339,6 +341,7 @@ MLSamplingLevelOptions::getAllOptions()
   m_parser->getOption<double      >(m_option_am_eta,                                     m_amEta                                    );
   m_parser->getOption<double      >(m_option_am_epsilon,                                 m_amEpsilon                                );
   m_parser->getOption<bool        >(m_option_doLogitTransform,                           m_doLogitTransform);
+  m_parser->getOption<std::string >(m_option_algorithm,                                  m_algorithm);
 #else
   m_help = m_env.input()(m_option_help,                                       UQ_ML_SAMPLING_L_HELP                      );
 #ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY
@@ -469,6 +472,7 @@ MLSamplingLevelOptions::getAllOptions()
   m_amEta                                     = m_env.input()(m_option_am_eta,                                     m_amEta                                    );
   m_amEpsilon                                 = m_env.input()(m_option_am_epsilon,                                 m_amEpsilon                                );
   m_doLogitTransform                          = m_env.input()(m_option_doLogitTransform,                           UQ_ML_SAMPLING_L_DO_LOGIT_TRANSFORM        );
+  m_algorithm                                 = m_env.input()(m_option_algorithm,                                  UQ_ML_SAMPLING_L_ALGORITHM                 );
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 }
 
@@ -554,6 +558,7 @@ MLSamplingLevelOptions::copyOptionsValues(const MLSamplingLevelOptions& srcOptio
   m_amEta                                     = srcOptions.m_amEta;
   m_amEpsilon                                 = srcOptions.m_amEpsilon;
   m_doLogitTransform                          = srcOptions.m_doLogitTransform;
+  m_algorithm                                 = srcOptions.m_algorithm;
 
   return;
 }
@@ -809,6 +814,7 @@ MLSamplingLevelOptions::print(std::ostream& os) const
   os << "\n" << m_option_am_eta                                     << " = " << m_amEta
      << "\n" << m_option_am_epsilon                                 << " = " << m_amEpsilon
      << "\n" << m_option_doLogitTransform                           << " = " << m_doLogitTransform
+     << "\n" << m_option_algorithm                                  << " = " << m_algorithm
      << std::endl;
 
   return;

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -36,7 +36,7 @@
 #include <queso/GaussianJointPdf.h>
 
 #include <queso/TransitionKernelFactory.h>
-#include <queso/AcceptanceRatio.h>
+#include <queso/AlgorithmFactory.h>
 
 namespace QUESO {
 
@@ -153,7 +153,7 @@ MetropolisHastingsSG<P_V,P_M>::MetropolisHastingsSG(
   m_parameterEnabledStatus    (m_vectorSpace.dimLocal(),true), // gpmsa2
   m_targetPdfSynchronizer     (new ScalarFunctionSynchronizer<P_V,P_M>(m_targetPdf,m_initialPosition)),
   m_tk                        (),
-  m_acceptanceRatio           (),
+  m_algorithm                 (),
   m_positionIdForDebugging    (0),
   m_stageIdForDebugging       (0),
   m_idsOfUniquePositions      (0),//0.),
@@ -235,7 +235,7 @@ MetropolisHastingsSG<P_V,P_M>::MetropolisHastingsSG(
   m_parameterEnabledStatus    (m_vectorSpace.dimLocal(),true), // gpmsa2
   m_targetPdfSynchronizer     (new ScalarFunctionSynchronizer<P_V,P_M>(m_targetPdf,m_initialPosition)),
   m_tk                        (),
-  m_acceptanceRatio           (),
+  m_algorithm                 (),
   m_positionIdForDebugging    (0),
   m_stageIdForDebugging       (0),
   m_idsOfUniquePositions      (0),//0.),
@@ -315,7 +315,7 @@ MetropolisHastingsSG<P_V,P_M>::MetropolisHastingsSG(
   m_parameterEnabledStatus    (m_vectorSpace.dimLocal(),true), // gpmsa2
   m_targetPdfSynchronizer     (new ScalarFunctionSynchronizer<P_V,P_M>(m_targetPdf,m_initialPosition)),
   m_tk                        (),
-  m_acceptanceRatio           (),
+  m_algorithm                 (),
   m_positionIdForDebugging    (0),
   m_stageIdForDebugging       (0),
   m_idsOfUniquePositions      (0),//0.),
@@ -382,7 +382,7 @@ MetropolisHastingsSG<P_V,P_M>::MetropolisHastingsSG(
   m_parameterEnabledStatus    (m_vectorSpace.dimLocal(),true), // gpmsa2
   m_targetPdfSynchronizer     (new ScalarFunctionSynchronizer<P_V,P_M>(m_targetPdf,m_initialPosition)),
   m_tk                        (),
-  m_acceptanceRatio           (),
+  m_algorithm                 (),
   m_positionIdForDebugging    (0),
   m_stageIdForDebugging       (0),
   m_idsOfUniquePositions      (0),//0.),
@@ -551,7 +551,8 @@ MetropolisHastingsSG<P_V,P_M>::commonConstructor()
 
   m_tk = TransitionKernelFactory::build(m_optionsObj->m_algorithm);
 
-  m_acceptanceRatio.reset(new AcceptanceRatio<>(m_env, *m_tk));
+  m_algorithm.reset(new Algorithm<>(m_env, *m_tk));
+  // m_algorithm = AlgorithmFactory::build(m_optionsObj->m_algorithm);
 }
 //--------------------------------------------------
 template<class P_V,class P_M>
@@ -755,10 +756,10 @@ MetropolisHastingsSG<P_V,P_M>::alpha(
   if (inputSize == 2) {
     const P_V & tk_pos_x = m_tk->preComputingPosition(inputTKStageIds[inputSize-1]);
     const P_V & tk_pos_y = m_tk->preComputingPosition(inputTKStageIds[0]);
-    return (*(this->m_acceptanceRatio))(*(inputPositionsData[0]),
-                                        *(inputPositionsData[inputSize - 1]),
-                                        tk_pos_x,
-                                        tk_pos_y);
+    return (*(this->m_algorithm))(*(inputPositionsData[0]),
+                                  *(inputPositionsData[inputSize - 1]),
+                                  tk_pos_x,
+                                  tk_pos_y);
   }
 
   // Prepare two vectors of positions
@@ -1838,13 +1839,13 @@ MetropolisHastingsSG<P_V,P_M>::generateFullChain(
         queso_require_equal_to_msg(iRC, 0, "gettimeofday called failed");
       }
       if (m_optionsObj->m_rawChainGenerateExtra) {
-        alphaFirstCandidate = (*m_acceptanceRatio)(currentPositionData,
+        alphaFirstCandidate = (*m_algorithm)(currentPositionData,
             currentCandidateData,
             currentCandidateData.vecValues(),
             currentPositionData.vecValues());
       }
       else {
-        alphaFirstCandidate = (*m_acceptanceRatio)(currentPositionData,
+        alphaFirstCandidate = (*m_algorithm)(currentPositionData,
             currentCandidateData,
             currentCandidateData.vecValues(),
             currentPositionData.vecValues());

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -2123,7 +2123,7 @@ MetropolisHastingsSG<P_V, P_M>::adapt(unsigned int positionId,
 
     // Transform to the space without boundaries.  This is the space
     // where the proposal distribution is Gaussian
-    if (this->m_optionsObj->m_doLogitTransform == true) {
+    if (this->m_optionsObj->m_algorithm == "logit_random_walk") {
       // Only do this when we don't use the Hessian (this may change in
       // future, but transformToGaussianSpace() is only implemented in
       // TransformedScaledCovMatrixTKGroup

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -548,8 +548,7 @@ MetropolisHastingsSG<P_V,P_M>::commonConstructor()
   TransitionKernelFactory::set_initial_cov_matrix(m_initialProposalCovMatrix);
   TransitionKernelFactory::set_dr_scales(drScalesAll);
   TransitionKernelFactory::set_target_pdf(m_targetPdf);
-
-  m_tk = TransitionKernelFactory::build(m_optionsObj->m_algorithm);
+  m_tk = TransitionKernelFactory::build(m_optionsObj->m_tk);
 
   AlgorithmFactory::set_environment(m_env);
   AlgorithmFactory::set_tk(*m_tk);

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -684,8 +684,14 @@ template<class P_V,class P_M>
 double
 MetropolisHastingsSG<P_V,P_M>::alpha(
   const std::vector<MarkovChainPositionData<P_V>*>& inputPositionsData,
-  const std::vector<unsigned int                        >& inputTKStageIds)
+  const std::vector<unsigned int                 >& inputTKStageIds)
 {
+  // inputPositionsData is all the DR position data, except for the first
+  // two elements.  The first element is the current state, and the second
+  // element is the would-be candidate before DR.
+  //
+  // inputTKStageIds is a vector containing 0, 1, 2, ..., n
+
   unsigned int inputSize = inputPositionsData.size();
   if ((m_env.subDisplayFile()                   ) &&
       (m_env.displayVerbosity() >= 10           ) &&
@@ -695,6 +701,7 @@ MetropolisHastingsSG<P_V,P_M>::alpha(
                            << std::endl;
   }
   queso_require_greater_equal_msg(inputSize, 2, "inputPositionsData has size < 2");
+  queso_require_equal_to_msg(inputSize, inputPositionsData.size(), "inputPositionsData and inputTKStageIds have different lengths");
 
   // If necessary, return 0. right away
   if (inputPositionsData[0          ]->outOfTargetSupport()) return 0.;
@@ -2502,6 +2509,8 @@ MetropolisHastingsSG<P_V, P_M>::delayedRejection(unsigned int positionId,
         logLikelihood,
         logTarget);
 
+    // Ok, so we almost don't need setPreComputingPosition.  All the DR
+    // position information we needed was generated in this while loop.
     drPositionsData.push_back(new MarkovChainPositionData<P_V>(currentCandidateData));
     tkStageIds.push_back     (stageId+1);
 
@@ -2650,6 +2659,6 @@ MetropolisHastingsSG<P_V, P_M>::transformInitialCovMatrixToGaussianSpace(
   }
 }
 
-}  // End namespace QUESO
+template class MetropolisHastingsSG<GslVector, GslMatrix>;
 
-template class QUESO::MetropolisHastingsSG<QUESO::GslVector, QUESO::GslMatrix>;
+}  // End namespace QUESO

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -504,6 +504,12 @@ MetropolisHastingsSG<P_V,P_M>::commonConstructor()
     drScalesAll[i] = m_optionsObj->m_drScalesForExtraStages[i-1];
   }
 
+  if (m_optionsObj->m_doLogitTransform) {
+    // Variable transform initial proposal cov matrix
+    transformInitialCovMatrixToGaussianSpace(
+        dynamic_cast<const BoxSubset<P_V, P_M> & >(m_targetPdf.domainSet()));
+  }
+
   TransitionKernelFactory::set_vectorspace(m_vectorSpace);
   TransitionKernelFactory::set_options(*m_optionsObj);
   TransitionKernelFactory::set_pdf_synchronizer(*m_targetPdfSynchronizer);
@@ -544,10 +550,6 @@ MetropolisHastingsSG<P_V,P_M>::commonConstructor()
 
     // Decide whether or not to do logit transform
     if (m_optionsObj->m_doLogitTransform) {
-      // Variable transform initial proposal cov matrix
-      transformInitialCovMatrixToGaussianSpace(
-          dynamic_cast<const BoxSubset<P_V, P_M> & >(m_targetPdf.domainSet()));
-
       // We need this dynamic_cast to BoxSubset so that m_tk can inspect the
       // domain bounds and do the necessary transform
       m_tk = new TransformedScaledCovMatrixTKGroup<P_V, P_M>(

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -572,21 +572,6 @@ MetropolisHastingsSG<P_V,P_M>::commonConstructor()
       queso_require_msg(!(m_nullInputProposalCovMatrix), "proposal cov matrix should have been passed by user, since, according to the input algorithm options, local Hessians will not be used in the proposal");
     }
 
-    // Decide whether or not to do logit transform
-    if (m_optionsObj->m_doLogitTransform) {
-      // We need this dynamic_cast to BoxSubset so that m_tk can inspect the
-      // domain bounds and do the necessary transform
-      m_tk.reset(new TransformedScaledCovMatrixTKGroup<P_V, P_M>(
-          m_optionsObj->m_prefix.c_str(),
-          dynamic_cast<const BoxSubset<P_V, P_M> & >(m_targetPdf.domainSet()),
-          drScalesAll, m_initialProposalCovMatrix));
-    }
-    else {
-      m_tk.reset(new ScaledCovMatrixTKGroup<P_V, P_M>(
-          m_optionsObj->m_prefix.c_str(), m_vectorSpace, drScalesAll,
-          m_initialProposalCovMatrix));
-    }
-
     if ((m_env.subDisplayFile()                   ) &&
         (m_optionsObj->m_totallyMute == false)) {
       *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::commonConstructor()"

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -527,42 +527,28 @@ MetropolisHastingsSG<P_V,P_M>::commonConstructor()
 
   m_tk = TransitionKernelFactory::build(m_optionsObj->m_algorithm);
 
-  if (m_optionsObj->m_tkUseLocalHessian) { // sep2011
-    m_tk.reset(new HessianCovMatricesTKGroup<P_V,P_M>(m_optionsObj->m_prefix.c_str(),
-                                                      m_vectorSpace,
-                                                      drScalesAll,
-                                                      *m_targetPdfSynchronizer));
+  if (m_optionsObj->m_initialProposalCovMatrixDataInputFileName != ".") { // palms
+    std::set<unsigned int> tmpSet;
+    tmpSet.insert(m_env.subId());
+    m_initialProposalCovMatrix.subReadContents((m_optionsObj->m_initialProposalCovMatrixDataInputFileName+"_sub"+m_env.subIdString()),
+                                               m_optionsObj->m_initialProposalCovMatrixDataInputFileType,
+                                               tmpSet);
     if ((m_env.subDisplayFile()                   ) &&
         (m_optionsObj->m_totallyMute == false)) {
       *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::commonConstructor()"
-                              << ": just instantiated a 'HessianCovMatrices' TK class"
+                              << ": just read initial proposal cov matrix contents = " << m_initialProposalCovMatrix
                               << std::endl;
     }
   }
   else {
-    if (m_optionsObj->m_initialProposalCovMatrixDataInputFileName != ".") { // palms
-      std::set<unsigned int> tmpSet;
-      tmpSet.insert(m_env.subId());
-      m_initialProposalCovMatrix.subReadContents((m_optionsObj->m_initialProposalCovMatrixDataInputFileName+"_sub"+m_env.subIdString()),
-                                                 m_optionsObj->m_initialProposalCovMatrixDataInputFileType,
-                                                 tmpSet);
-      if ((m_env.subDisplayFile()                   ) &&
-          (m_optionsObj->m_totallyMute == false)) {
-        *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::commonConstructor()"
-                                << ": just read initial proposal cov matrix contents = " << m_initialProposalCovMatrix
-                                << std::endl;
-      }
-    }
-    else {
-      queso_require_msg(!(m_nullInputProposalCovMatrix), "proposal cov matrix should have been passed by user, since, according to the input algorithm options, local Hessians will not be used in the proposal");
-    }
+    queso_require_msg(!(m_nullInputProposalCovMatrix), "proposal cov matrix should have been passed by user, since, according to the input algorithm options, local Hessians will not be used in the proposal");
+  }
 
-    if ((m_env.subDisplayFile()                   ) &&
-        (m_optionsObj->m_totallyMute == false)) {
-      *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::commonConstructor()"
-                              << ": just instantiated a 'ScaledCovMatrix' TK class"
-                              << std::endl;
-    }
+  if ((m_env.subDisplayFile()                   ) &&
+      (m_optionsObj->m_totallyMute == false)) {
+    *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::commonConstructor()"
+                            << ": just instantiated a 'ScaledCovMatrix' TK class"
+                            << std::endl;
   }
 
   if ((m_env.subDisplayFile()                   ) &&

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -619,11 +619,11 @@ MetropolisHastingsSG<P_V,P_M>::alpha(
       }
       else {
         m_tk->set_dr_stage(yStageId);
-        double qyx = m_tk->rv(yStageId).pdf().lnValue(x.vecValues(),NULL,NULL,NULL,NULL);
+        double qyx = m_tk->rv().pdf().lnValue(x.vecValues(),NULL,NULL,NULL,NULL);
         if ((m_env.subDisplayFile()                   ) &&
             (m_env.displayVerbosity() >= 10           ) &&
             (m_optionsObj->m_totallyMute == false)) {
-          const InvLogitGaussianJointPdf<P_V,P_M>* pdfYX = dynamic_cast< const InvLogitGaussianJointPdf<P_V,P_M>* >(&(m_tk->rv(yStageId).pdf()));
+          const InvLogitGaussianJointPdf<P_V,P_M>* pdfYX = dynamic_cast< const InvLogitGaussianJointPdf<P_V,P_M>* >(&(m_tk->rv().pdf()));
           *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::alpha(x,y)"
                                  << ", rvYX.lawExpVector = " << pdfYX->lawExpVector()
                                  << ", rvYX.lawVarVector = " << pdfYX->lawVarVector()
@@ -631,11 +631,11 @@ MetropolisHastingsSG<P_V,P_M>::alpha(
                                  << std::endl;
         }
         m_tk->set_dr_stage(xStageId);
-        double qxy = m_tk->rv(xStageId).pdf().lnValue(y.vecValues(),NULL,NULL,NULL,NULL);
+        double qxy = m_tk->rv().pdf().lnValue(y.vecValues(),NULL,NULL,NULL,NULL);
         if ((m_env.subDisplayFile()                   ) &&
             (m_env.displayVerbosity() >= 10           ) &&
             (m_optionsObj->m_totallyMute == false)) {
-          const InvLogitGaussianJointPdf<P_V,P_M>* pdfXY = dynamic_cast< const InvLogitGaussianJointPdf<P_V,P_M>* >(&(m_tk->rv(xStageId).pdf()));
+          const InvLogitGaussianJointPdf<P_V,P_M>* pdfXY = dynamic_cast< const InvLogitGaussianJointPdf<P_V,P_M>* >(&(m_tk->rv().pdf()));
           *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::alpha(x,y)"
                                  << ", rvXY.lawExpVector = " << pdfXY->lawExpVector()
                                  << ", rvXY.lawVarVector = " << pdfXY->lawVarVector()
@@ -675,6 +675,9 @@ MetropolisHastingsSG<P_V,P_M>::alpha(
                              << std::endl;
     }
   }
+
+  m_tk->set_dr_stage(old_stageId);
+
   if (alphaQuotientPtr != NULL) *alphaQuotientPtr = alphaQuotient;
 
   return std::min(1.,alphaQuotient);

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -2308,11 +2308,11 @@ MetropolisHastingsSG<P_V, P_M>::adapt(unsigned int positionId,
 
     // Transform the proposal covariance matrix if we have Logit transforms
     // turned on
-    if (this->m_optionsObj->m_doLogitTransform) {
+    if (this->m_optionsObj->m_algorithm == "logit_random_walk") {
       (dynamic_cast<TransformedScaledCovMatrixTKGroup<P_V,P_M>* >(m_tk.get()))
         ->updateLawCovMatrix(tmpMatrix);
     }
-    else{
+    else if (this->m_optionsObj->m_algorithm == "random_walk") {
       (dynamic_cast<ScaledCovMatrixTKGroup<P_V,P_M>* >(m_tk.get()))
         ->updateLawCovMatrix(tmpMatrix);
     }

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -516,7 +516,8 @@ MetropolisHastingsSG<P_V,P_M>::commonConstructor()
   TransitionKernelFactory::set_initial_cov_matrix(m_initialProposalCovMatrix);
   TransitionKernelFactory::set_dr_scales(drScalesAll);
   TransitionKernelFactory::set_target_pdf(m_targetPdf);
-  TransitionKernelFactory::build("dram");
+
+  TransitionKernelFactory::build(m_optionsObj->m_algorithm);
 
   if (m_optionsObj->m_tkUseLocalHessian) { // sep2011
     m_tk = new HessianCovMatricesTKGroup<P_V,P_M>(m_optionsObj->m_prefix.c_str(),

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -756,10 +756,11 @@ MetropolisHastingsSG<P_V,P_M>::alpha(
   if (inputSize == 2) {
     const P_V & tk_pos_x = m_tk->preComputingPosition(inputTKStageIds[inputSize-1]);
     const P_V & tk_pos_y = m_tk->preComputingPosition(inputTKStageIds[0]);
-    return (*(this->m_algorithm))(*(inputPositionsData[0]),
-                                  *(inputPositionsData[inputSize - 1]),
-                                  tk_pos_x,
-                                  tk_pos_y);
+    return this->m_algorithm->acceptance_ratio(
+        *(inputPositionsData[0]),
+        *(inputPositionsData[inputSize - 1]),
+        tk_pos_x,
+        tk_pos_y);
   }
 
   // Prepare two vectors of positions
@@ -1839,13 +1840,15 @@ MetropolisHastingsSG<P_V,P_M>::generateFullChain(
         queso_require_equal_to_msg(iRC, 0, "gettimeofday called failed");
       }
       if (m_optionsObj->m_rawChainGenerateExtra) {
-        alphaFirstCandidate = (*m_algorithm)(currentPositionData,
+        alphaFirstCandidate = m_algorithm->acceptance_ratio(
+            currentPositionData,
             currentCandidateData,
             currentCandidateData.vecValues(),
             currentPositionData.vecValues());
       }
       else {
-        alphaFirstCandidate = (*m_algorithm)(currentPositionData,
+        alphaFirstCandidate = m_algorithm->acceptance_ratio(
+            currentPositionData,
             currentCandidateData,
             currentCandidateData.vecValues(),
             currentPositionData.vecValues());

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -503,7 +503,8 @@ MetropolisHastingsSG<P_V,P_M>::commonConstructor()
     drScalesAll[i] = m_optionsObj->m_drScalesForExtraStages[i-1];
   }
 
-  if (m_optionsObj->m_doLogitTransform) {
+  // Only transform prop cov matrix if we're doing a logit random walk
+  if ((m_optionsObj->m_algorithm == "logit_random_walk") || m_optionsObj->m_doLogitTransform) {
     // Variable transform initial proposal cov matrix
     transformInitialCovMatrixToGaussianSpace(
         dynamic_cast<const BoxSubset<P_V, P_M> & >(m_targetPdf.domainSet()));

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -518,22 +518,6 @@ MetropolisHastingsSG<P_V,P_M>::commonConstructor()
     queso_warning(msg.c_str());
   }
 
-  // Check the user didn't ask for a logit transform and a non-logit algorithm
-  // or vice-versa
-  if (m_optionsObj->m_algorithm == "random_walk") {
-    queso_require_equal_to_msg(
-        m_optionsObj->m_doLogitTransform,
-        0,
-        "ERROR: Chosen algorithm `" << m_optionsObj->m_algorithm << "`.  Chosen logit transform? " << m_optionsObj->m_doLogitTransform << ". These two options are incompatible.");
-  }
-
-  if (m_optionsObj->m_algorithm == "logit_random_walk") {
-    queso_require_equal_to_msg(
-        m_optionsObj->m_doLogitTransform,
-        1,
-        "ERROR: Chosen algorithm `" << m_optionsObj->m_algorithm << "`.  Chosen logit transform? " << m_optionsObj->m_doLogitTransform << ". These two options are incompatible.");
-  }
-
   TransitionKernelFactory::set_vectorspace(m_vectorSpace);
   TransitionKernelFactory::set_options(*m_optionsObj);
   TransitionKernelFactory::set_pdf_synchronizer(*m_targetPdfSynchronizer);

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -543,20 +543,6 @@ MetropolisHastingsSG<P_V,P_M>::commonConstructor()
   else {
     queso_require_msg(!(m_nullInputProposalCovMatrix), "proposal cov matrix should have been passed by user, since, according to the input algorithm options, local Hessians will not be used in the proposal");
   }
-
-  if ((m_env.subDisplayFile()                   ) &&
-      (m_optionsObj->m_totallyMute == false)) {
-    *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::commonConstructor()"
-                            << ": just instantiated a 'ScaledCovMatrix' TK class"
-                            << std::endl;
-  }
-
-  if ((m_env.subDisplayFile()                   ) &&
-      (m_optionsObj->m_totallyMute == false)) {
-    *m_env.subDisplayFile() << "Leaving MetropolisHastingsSG<P_V,P_M>::commonConstructor()"
-                            << std::endl;
-  }
-  return;
 }
 //--------------------------------------------------
 template<class P_V,class P_M>

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -556,6 +556,13 @@ MetropolisHastingsSG<P_V,P_M>::alpha(
   unsigned int                               yStageId,
   double*                                    alphaQuotientPtr)
 {
+  unsigned int old_stageId;
+
+  // Get the current (old) stageId.  We'll set the tk back to this stage id
+  // at the end to preserve the state of the tk
+  old_stageId = m_tk->set_dr_stage(0);
+  m_tk->set_dr_stage(old_stageId);
+
   double alphaQuotient = 0.;
   if ((x.outOfTargetSupport() == false) &&
       (y.outOfTargetSupport() == false)) {
@@ -611,6 +618,7 @@ MetropolisHastingsSG<P_V,P_M>::alpha(
         }
       }
       else {
+        m_tk->set_dr_stage(yStageId);
         double qyx = m_tk->rv(yStageId).pdf().lnValue(x.vecValues(),NULL,NULL,NULL,NULL);
         if ((m_env.subDisplayFile()                   ) &&
             (m_env.displayVerbosity() >= 10           ) &&
@@ -622,6 +630,7 @@ MetropolisHastingsSG<P_V,P_M>::alpha(
                                  << ", rvYX.lawCovMatrix = " << pdfYX->lawCovMatrix()
                                  << std::endl;
         }
+        m_tk->set_dr_stage(xStageId);
         double qxy = m_tk->rv(xStageId).pdf().lnValue(y.vecValues(),NULL,NULL,NULL,NULL);
         if ((m_env.subDisplayFile()                   ) &&
             (m_env.displayVerbosity() >= 10           ) &&

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -531,7 +531,7 @@ MetropolisHastingsSG<P_V,P_M>::commonConstructor()
   // Only transform prop cov matrix if we're doing a logit random walk.
   // Also note we're transforming *after* we potentially read it from the input
   // file.
-  if ((m_optionsObj->m_algorithm == "logit_random_walk") || m_optionsObj->m_doLogitTransform) {
+  if ((m_optionsObj->m_algorithm == "logit_random_walk") && m_optionsObj->m_doLogitTransform) {
     // Variable transform initial proposal cov matrix
     transformInitialCovMatrixToGaussianSpace(
         dynamic_cast<const BoxSubset<P_V, P_M> & >(m_targetPdf.domainSet()));

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -503,6 +503,15 @@ MetropolisHastingsSG<P_V,P_M>::commonConstructor()
   for (unsigned int i = 1; i < (m_optionsObj->m_drScalesForExtraStages.size()+1); ++i) {
     drScalesAll[i] = m_optionsObj->m_drScalesForExtraStages[i-1];
   }
+
+  TransitionKernelFactory::set_vectorspace(m_vectorSpace);
+  TransitionKernelFactory::set_options(*m_optionsObj);
+  TransitionKernelFactory::set_pdf_synchronizer(*m_targetPdfSynchronizer);
+  TransitionKernelFactory::set_initial_cov_matrix(m_initialProposalCovMatrix);
+  TransitionKernelFactory::set_dr_scales(drScalesAll);
+  TransitionKernelFactory::set_target_pdf(m_targetPdf);
+  TransitionKernelFactory::build("dram");
+
   if (m_optionsObj->m_tkUseLocalHessian) { // sep2011
     m_tk = new HessianCovMatricesTKGroup<P_V,P_M>(m_optionsObj->m_prefix.c_str(),
                                                          m_vectorSpace,

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -797,11 +797,8 @@ MetropolisHastingsSG<P_V,P_M>::alpha(
   const P_V& _lastTKPosition         = m_tk->preComputingPosition(        tkStageIds[inputSize-1]);
   const P_V& _lastBackwardTKPosition = m_tk->preComputingPosition(backwardTKStageIds[inputSize-1]);
 
-  // unsigned int old_stageId = m_tk->set_dr_stage();
   double numContrib = m_tk->rv(backwardTKStageIdsLess1).pdf().lnValue(_lastBackwardTKPosition,NULL,NULL,NULL,NULL);
-  // m_tk->set_dr_stage(old_stageId);
 
-  // old_stageId = m_tk->set_dr_stage(tkStageIdsLess1);
   double denContrib = m_tk->rv(tkStageIdsLess1).pdf().lnValue(_lastTKPosition,NULL,NULL,NULL,NULL);
   if ((m_env.subDisplayFile()                   ) &&
       (m_env.displayVerbosity() >= 10           ) &&
@@ -813,7 +810,6 @@ MetropolisHastingsSG<P_V,P_M>::alpha(
                            << ", denContrib = " << denContrib
                            << std::endl;
   }
-  // m_tk->set_dr_stage(old_stageId);
 
   logNumerator   += numContrib;
   logDenominator += denContrib;
@@ -831,11 +827,8 @@ MetropolisHastingsSG<P_V,P_M>::alpha(
             tkStageIdsLess1.pop_back();
     backwardTKStageIdsLess1.pop_back();
 
-    // old_stageId = m_tk->set_dr_stage(backwardTKStageIdsLess1);
     numContrib = m_tk->rv(backwardTKStageIdsLess1).pdf().lnValue(lastBackwardTKPosition,NULL,NULL,NULL,NULL);
-    // m_tk->set_dr_stage(old_stageId);
 
-    // m_tk->set_dr_stage(tkStageIdsLess1);
     denContrib = m_tk->rv(tkStageIdsLess1).pdf().lnValue(lastTKPosition,NULL,NULL,NULL,NULL);
     if ((m_env.subDisplayFile()                   ) &&
         (m_env.displayVerbosity() >= 10           ) &&
@@ -847,7 +840,6 @@ MetropolisHastingsSG<P_V,P_M>::alpha(
                              << ", denContrib = " << denContrib
                              << std::endl;
     }
-    // m_tk->set_dr_stage(old_stageId);
 
     logNumerator   += numContrib;
     logDenominator += denContrib;

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -551,8 +551,9 @@ MetropolisHastingsSG<P_V,P_M>::commonConstructor()
 
   m_tk = TransitionKernelFactory::build(m_optionsObj->m_algorithm);
 
-  m_algorithm.reset(new Algorithm<>(m_env, *m_tk));
-  // m_algorithm = AlgorithmFactory::build(m_optionsObj->m_algorithm);
+  AlgorithmFactory::set_environment(m_env);
+  AlgorithmFactory::set_tk(*m_tk);
+  m_algorithm = AlgorithmFactory::build(m_optionsObj->m_algorithm);
 }
 //--------------------------------------------------
 template<class P_V,class P_M>

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -517,7 +517,7 @@ MetropolisHastingsSG<P_V,P_M>::commonConstructor()
   TransitionKernelFactory::set_dr_scales(drScalesAll);
   TransitionKernelFactory::set_target_pdf(m_targetPdf);
 
-  TransitionKernelFactory::build(m_optionsObj->m_algorithm);
+  SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type tk_ptr = TransitionKernelFactory::build(m_optionsObj->m_algorithm);
 
   if (m_optionsObj->m_tkUseLocalHessian) { // sep2011
     m_tk = new HessianCovMatricesTKGroup<P_V,P_M>(m_optionsObj->m_prefix.c_str(),

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -35,6 +35,8 @@
 
 #include <queso/GaussianJointPdf.h>
 
+#include <queso/TransitionKernelFactory.h>
+
 namespace QUESO {
 
 // Default constructor -----------------------------

--- a/src/stats/src/MetropolisHastingsSGOptions.C
+++ b/src/stats/src/MetropolisHastingsSGOptions.C
@@ -102,6 +102,7 @@ MhOptionsValues::MhOptionsValues(
     m_outputLogTarget                          (UQ_MH_SG_OUTPUT_LOG_TARGET),
     m_doLogitTransform                         (UQ_MH_SG_DO_LOGIT_TRANSFORM),
     m_algorithm                                (UQ_MH_SG_ALGORITHM),
+    m_tk                                       (UQ_MH_SG_TK),
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
     m_alternativeRawSsOptionsValues            (),
     m_alternativeFilteredSsOptionsValues       (),
@@ -166,7 +167,8 @@ MhOptionsValues::MhOptionsValues(
     m_option_outputLogLikelihood                       (m_prefix + "outputLogLikelihood"                       ),
     m_option_outputLogTarget                           (m_prefix + "outputLogTarget"                           ),
     m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          ),
-    m_option_algorithm                                 (m_prefix + "algorithm"                                 )
+    m_option_algorithm                                 (m_prefix + "algorithm"                                 ),
+    m_option_tk                                        (m_prefix + "tk"                                        )
 {
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
   if (alternativeRawSsOptionsValues     ) m_alternativeRawSsOptionsValues      = *alternativeRawSsOptionsValues;
@@ -241,6 +243,7 @@ MhOptionsValues::MhOptionsValues(
     m_outputLogTarget                          (UQ_MH_SG_OUTPUT_LOG_TARGET),
     m_doLogitTransform                         (UQ_MH_SG_DO_LOGIT_TRANSFORM),
     m_algorithm                                (UQ_MH_SG_ALGORITHM),
+    m_tk                                       (UQ_MH_SG_TK),
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
     m_alternativeRawSsOptionsValues            (),
     m_alternativeFilteredSsOptionsValues       (),
@@ -305,7 +308,8 @@ MhOptionsValues::MhOptionsValues(
     m_option_outputLogLikelihood                       (m_prefix + "outputLogLikelihood"                       ),
     m_option_outputLogTarget                           (m_prefix + "outputLogTarget"                           ),
     m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          ),
-    m_option_algorithm                                 (m_prefix + "algorithm"                                 )
+    m_option_algorithm                                 (m_prefix + "algorithm"                                 ),
+    m_option_tk                                        (m_prefix + "tk"                                        )
 {
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
   if (alternativeRawSsOptionsValues     ) m_alternativeRawSsOptionsValues      = *alternativeRawSsOptionsValues;
@@ -370,6 +374,7 @@ MhOptionsValues::MhOptionsValues(
   m_parser->registerOption<bool        >(m_option_outputLogTarget,                            UQ_MH_SG_OUTPUT_LOG_TARGET                                   , "flag to toggle output of log target values"                 );
   m_parser->registerOption<bool        >(m_option_doLogitTransform,                           UQ_MH_SG_DO_LOGIT_TRANSFORM                                  , "flag to toggle logit transform for bounded domains"         );
   m_parser->registerOption<std::string >(m_option_algorithm,                                  UQ_MH_SG_ALGORITHM                                           , "which MCMC algorithm to use"                                );
+  m_parser->registerOption<std::string >(m_option_tk,                                         UQ_MH_SG_TK                                                  , "which MCMC transition kernel to use"                        );
 
   m_parser->scanInputFile();
 
@@ -430,6 +435,7 @@ MhOptionsValues::MhOptionsValues(
   m_parser->getOption<bool        >(m_option_outputLogTarget,                            m_outputLogTarget);
   m_parser->getOption<bool        >(m_option_doLogitTransform,                           m_doLogitTransform);
   m_parser->getOption<std::string >(m_option_algorithm,                                  m_algorithm);
+  m_parser->getOption<std::string >(m_option_tk,                                         m_tk);
 #else
   m_help = m_env->input()(m_option_help, UQ_MH_SG_HELP);
   m_dataOutputFileName = m_env->input()(m_option_dataOutputFileName, UQ_MH_SG_DATA_OUTPUT_FILE_NAME_ODV);
@@ -543,6 +549,7 @@ MhOptionsValues::MhOptionsValues(
   m_outputLogTarget = m_env->input()(m_option_outputLogTarget, UQ_MH_SG_OUTPUT_LOG_TARGET);
   m_doLogitTransform = m_env->input()(m_option_doLogitTransform, UQ_MH_SG_DO_LOGIT_TRANSFORM);
   m_algorithm = m_env->input()(m_option_algorithm, UQ_MH_SG_ALGORITHM);
+  m_tk = m_env->input()(m_option_tk, UQ_MH_SG_TK);
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 
   checkOptions(env);
@@ -705,6 +712,7 @@ MhOptionsValues::copy(const MhOptionsValues& src)
   m_outputLogTarget                           = src.m_outputLogTarget;
   m_doLogitTransform                          = src.m_doLogitTransform;
   m_algorithm                                 = src.m_algorithm;
+  m_tk                                        = src.m_tk;
 
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
   m_alternativeRawSsOptionsValues             = src.m_alternativeRawSsOptionsValues;
@@ -795,6 +803,7 @@ std::ostream & operator<<(std::ostream & os, const MhOptionsValues & obj)
      << "\n" << obj.m_option_outputLogTarget                            << " = " << obj.m_outputLogTarget
      << "\n" << obj.m_option_doLogitTransform                           << " = " << obj.m_doLogitTransform
      << "\n" << obj.m_option_algorithm                                  << " = " << obj.m_algorithm
+     << "\n" << obj.m_option_tk                                         << " = " << obj.m_tk
      << std::endl;
 
   return os;
@@ -879,7 +888,8 @@ MetropolisHastingsSGOptions::MetropolisHastingsSGOptions(
   m_option_outputLogLikelihood                       (m_prefix + "outputLogLikelihood"                       ),
   m_option_outputLogTarget                           (m_prefix + "outputLogTarget"                           ),
   m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          ),
-  m_option_algorithm                                 (m_prefix + "algorithm"                                 )
+  m_option_algorithm                                 (m_prefix + "algorithm"                                 ),
+  m_option_tk                                        (m_prefix + "tk"                                        )
 {
   queso_deprecated();
 
@@ -959,7 +969,8 @@ MetropolisHastingsSGOptions::MetropolisHastingsSGOptions(
   m_option_outputLogLikelihood                       (m_prefix + "outputLogLikelihood"                       ),
   m_option_outputLogTarget                           (m_prefix + "outputLogTarget"                           ),
   m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          ),
-  m_option_algorithm                                 (m_prefix + "algorithm"                                 )
+  m_option_algorithm                                 (m_prefix + "algorithm"                                 ),
+  m_option_tk                                        (m_prefix + "tk"                                        )
 {
   queso_deprecated();
 
@@ -1059,7 +1070,8 @@ MetropolisHastingsSGOptions::MetropolisHastingsSGOptions(
   m_option_outputLogLikelihood                       (m_prefix + "outputLogLikelihood"                       ),
   m_option_outputLogTarget                           (m_prefix + "outputLogTarget"                           ),
   m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          ),
-  m_option_algorithm                                 (m_prefix + "algorithm"                                 )
+  m_option_algorithm                                 (m_prefix + "algorithm"                                 ),
+  m_option_tk                                        (m_prefix + "tk"                                        )
 {
   queso_deprecated();
 
@@ -1119,6 +1131,7 @@ MetropolisHastingsSGOptions::MetropolisHastingsSGOptions(
   m_ov.m_outputLogTarget                           = UQ_MH_SG_OUTPUT_LOG_TARGET;
   m_ov.m_doLogitTransform                          = mlOptions.m_doLogitTransform;
   m_ov.m_algorithm                                 = mlOptions.m_algorithm;
+  m_ov.m_tk                                        = mlOptions.m_tk;
 
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
 //m_ov.m_alternativeRawSsOptionsValues             = mlOptions.; // dakota
@@ -1272,6 +1285,7 @@ MetropolisHastingsSGOptions::print(std::ostream& os) const
      << "\n" << m_option_outputLogTarget                            << " = " << m_ov.m_outputLogTarget
      << "\n" << m_option_doLogitTransform                           << " = " << m_ov.m_doLogitTransform
      << "\n" << m_option_algorithm                                  << " = " << m_ov.m_algorithm
+     << "\n" << m_option_tk                                         << " = " << m_ov.m_tk
      << std::endl;
 
   return;
@@ -1342,6 +1356,7 @@ MetropolisHastingsSGOptions::defineMyOptions(boost::program_options::options_des
     (m_option_outputLogTarget.c_str(),                            boost::program_options::value<bool        >()->default_value(UQ_MH_SG_OUTPUT_LOG_TARGET                                   ), "flag to toggle output of log target values"                 )
     (m_option_doLogitTransform.c_str(),                           boost::program_options::value<bool        >()->default_value(UQ_MH_SG_DO_LOGIT_TRANSFORM                                  ), "flag to toggle logit transform for bounded domains"         )
     (m_option_algorithm.c_str(),                                  boost::program_options::value<std::string >()->default_value(UQ_MH_SG_ALGORITHM                                           ), "which mcmc algorithm to use"                                )
+    (m_option_tk.c_str(),                                         boost::program_options::value<std::string >()->default_value(UQ_MH_SG_TK                                                  ), "which mcmc tk to use"                                       )
   ;
 
   return;
@@ -1663,6 +1678,10 @@ MetropolisHastingsSGOptions::getMyOptionValues(boost::program_options::options_d
 
   if (m_env.allOptionsMap().count(m_option_algorithm)) {
     m_ov.m_algorithm = ((const boost::program_options::variable_value&) m_env.allOptionsMap()[m_option_algorithm]).as<std::string>();
+  }
+
+  if (m_env.allOptionsMap().count(m_option_tk)) {
+    m_ov.m_tk = ((const boost::program_options::variable_value&) m_env.allOptionsMap()[m_option_tk]).as<std::string>();
   }
 }
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS

--- a/src/stats/src/MetropolisHastingsSGOptions.C
+++ b/src/stats/src/MetropolisHastingsSGOptions.C
@@ -101,6 +101,7 @@ MhOptionsValues::MhOptionsValues(
     m_outputLogLikelihood                      (UQ_MH_SG_OUTPUT_LOG_LIKELIHOOD),
     m_outputLogTarget                          (UQ_MH_SG_OUTPUT_LOG_TARGET),
     m_doLogitTransform                         (UQ_MH_SG_DO_LOGIT_TRANSFORM),
+    m_algorithm                                (UQ_MH_SG_ALGORITHM),
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
     m_alternativeRawSsOptionsValues            (),
     m_alternativeFilteredSsOptionsValues       (),
@@ -164,7 +165,8 @@ MhOptionsValues::MhOptionsValues(
     m_option_BrooksGelmanLag                           (m_prefix + "BrooksGelmanLag"                           ),
     m_option_outputLogLikelihood                       (m_prefix + "outputLogLikelihood"                       ),
     m_option_outputLogTarget                           (m_prefix + "outputLogTarget"                           ),
-    m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          )
+    m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          ),
+    m_option_algorithm                                 (m_prefix + "algorithm"                                 )
 {
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
   if (alternativeRawSsOptionsValues     ) m_alternativeRawSsOptionsValues      = *alternativeRawSsOptionsValues;
@@ -238,6 +240,7 @@ MhOptionsValues::MhOptionsValues(
     m_outputLogLikelihood                      (UQ_MH_SG_OUTPUT_LOG_LIKELIHOOD),
     m_outputLogTarget                          (UQ_MH_SG_OUTPUT_LOG_TARGET),
     m_doLogitTransform                         (UQ_MH_SG_DO_LOGIT_TRANSFORM),
+    m_algorithm                                (UQ_MH_SG_ALGORITHM),
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
     m_alternativeRawSsOptionsValues            (),
     m_alternativeFilteredSsOptionsValues       (),
@@ -301,7 +304,8 @@ MhOptionsValues::MhOptionsValues(
     m_option_BrooksGelmanLag                           (m_prefix + "BrooksGelmanLag"                           ),
     m_option_outputLogLikelihood                       (m_prefix + "outputLogLikelihood"                       ),
     m_option_outputLogTarget                           (m_prefix + "outputLogTarget"                           ),
-    m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          )
+    m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          ),
+    m_option_algorithm                                 (m_prefix + "algorithm"                                 )
 {
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
   if (alternativeRawSsOptionsValues     ) m_alternativeRawSsOptionsValues      = *alternativeRawSsOptionsValues;
@@ -365,6 +369,7 @@ MhOptionsValues::MhOptionsValues(
   m_parser->registerOption<bool        >(m_option_outputLogLikelihood,                        UQ_MH_SG_OUTPUT_LOG_LIKELIHOOD                               , "flag to toggle output of log likelihood values"             );
   m_parser->registerOption<bool        >(m_option_outputLogTarget,                            UQ_MH_SG_OUTPUT_LOG_TARGET                                   , "flag to toggle output of log target values"                 );
   m_parser->registerOption<bool        >(m_option_doLogitTransform,                           UQ_MH_SG_DO_LOGIT_TRANSFORM                                  , "flag to toggle logit transform for bounded domains"         );
+  m_parser->registerOption<std::string >(m_option_algorithm,                                  UQ_MH_SG_ALGORITHM                                           , "which MCMC algorithm to use"                                );
 
   m_parser->scanInputFile();
 
@@ -424,6 +429,7 @@ MhOptionsValues::MhOptionsValues(
   m_parser->getOption<bool        >(m_option_outputLogLikelihood,                        m_outputLogLikelihood);
   m_parser->getOption<bool        >(m_option_outputLogTarget,                            m_outputLogTarget);
   m_parser->getOption<bool        >(m_option_doLogitTransform,                           m_doLogitTransform);
+  m_parser->getOption<std::string >(m_option_algorithm,                                  m_algorithm);
 #else
   m_help = m_env->input()(m_option_help, UQ_MH_SG_HELP);
   m_dataOutputFileName = m_env->input()(m_option_dataOutputFileName, UQ_MH_SG_DATA_OUTPUT_FILE_NAME_ODV);
@@ -536,6 +542,7 @@ MhOptionsValues::MhOptionsValues(
   m_outputLogLikelihood = m_env->input()(m_option_outputLogLikelihood, UQ_MH_SG_OUTPUT_LOG_LIKELIHOOD);
   m_outputLogTarget = m_env->input()(m_option_outputLogTarget, UQ_MH_SG_OUTPUT_LOG_TARGET);
   m_doLogitTransform = m_env->input()(m_option_doLogitTransform, UQ_MH_SG_DO_LOGIT_TRANSFORM);
+  m_algorithm = m_env->input()(m_option_algorithm, UQ_MH_SG_ALGORITHM);
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 
   checkOptions(env);
@@ -663,6 +670,7 @@ MhOptionsValues::copy(const MhOptionsValues& src)
   m_outputLogLikelihood                       = src.m_outputLogLikelihood;
   m_outputLogTarget                           = src.m_outputLogTarget;
   m_doLogitTransform                          = src.m_doLogitTransform;
+  m_algorithm                                 = src.m_algorithm;
 
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
   m_alternativeRawSsOptionsValues             = src.m_alternativeRawSsOptionsValues;
@@ -752,6 +760,7 @@ std::ostream & operator<<(std::ostream & os, const MhOptionsValues & obj)
      << "\n" << obj.m_option_outputLogLikelihood                        << " = " << obj.m_outputLogLikelihood
      << "\n" << obj.m_option_outputLogTarget                            << " = " << obj.m_outputLogTarget
      << "\n" << obj.m_option_doLogitTransform                           << " = " << obj.m_doLogitTransform
+     << "\n" << obj.m_option_algorithm                                  << " = " << obj.m_algorithm
      << std::endl;
 
   return os;

--- a/src/stats/src/MetropolisHastingsSGOptions.C
+++ b/src/stats/src/MetropolisHastingsSGOptions.C
@@ -606,6 +606,40 @@ MhOptionsValues::checkOptions(const BaseEnvironment * env)
     m_amAdaptedMatricesDataOutputAllowedSet.clear();
     m_amAdaptedMatricesDataOutputAllowedSet.insert(env->subId());
   }
+
+  if (m_algorithm == "random_walk") {
+    queso_require_equal_to_msg(
+        m_doLogitTransform,
+        0,
+        "logit transform must be off to use random_walk");
+    queso_require_equal_to_msg(
+        m_tkUseLocalHessian,
+        0,
+        "local Hessian must be off to use random_walk");
+  }
+
+  if (m_algorithm == "logit_random_walk") {
+    queso_require_equal_to_msg(
+        m_doLogitTransform,
+        1,
+        "logit transform must be on to use logit_random_walk");
+    queso_require_equal_to_msg(
+        m_tkUseLocalHessian,
+        0,
+        "local Hessian must be off to use logit_random_walk");
+  }
+
+  if (m_algorithm == "stochastic_newton") {
+    queso_require_equal_to_msg(
+        m_doLogitTransform,
+        0,
+        "logit transform must be off to use stochastic_newton");
+    queso_require_equal_to_msg(
+        m_tkUseLocalHessian,
+        1,
+        "local Hessian must be on to use stochastic_newton");
+  }
+
 }
 
 void

--- a/src/stats/src/MetropolisHastingsSGOptions.C
+++ b/src/stats/src/MetropolisHastingsSGOptions.C
@@ -844,7 +844,8 @@ MetropolisHastingsSGOptions::MetropolisHastingsSGOptions(
   m_option_BrooksGelmanLag                           (m_prefix + "BrooksGelmanLag"                           ),
   m_option_outputLogLikelihood                       (m_prefix + "outputLogLikelihood"                       ),
   m_option_outputLogTarget                           (m_prefix + "outputLogTarget"                           ),
-  m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          )
+  m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          ),
+  m_option_algorithm                                 (m_prefix + "algorithm"                                 )
 {
   queso_deprecated();
 
@@ -923,7 +924,8 @@ MetropolisHastingsSGOptions::MetropolisHastingsSGOptions(
   m_option_BrooksGelmanLag                           (m_prefix + "BrooksGelmanLag"                           ),
   m_option_outputLogLikelihood                       (m_prefix + "outputLogLikelihood"                       ),
   m_option_outputLogTarget                           (m_prefix + "outputLogTarget"                           ),
-  m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          )
+  m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          ),
+  m_option_algorithm                                 (m_prefix + "algorithm"                                 )
 {
   queso_deprecated();
 
@@ -1022,7 +1024,8 @@ MetropolisHastingsSGOptions::MetropolisHastingsSGOptions(
   m_option_BrooksGelmanLag                           (m_prefix + "BrooksGelmanLag"                           ),
   m_option_outputLogLikelihood                       (m_prefix + "outputLogLikelihood"                       ),
   m_option_outputLogTarget                           (m_prefix + "outputLogTarget"                           ),
-  m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          )
+  m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          ),
+  m_option_algorithm                                 (m_prefix + "algorithm"                                 )
 {
   queso_deprecated();
 
@@ -1081,6 +1084,7 @@ MetropolisHastingsSGOptions::MetropolisHastingsSGOptions(
   m_ov.m_outputLogLikelihood                       = UQ_MH_SG_OUTPUT_LOG_LIKELIHOOD;
   m_ov.m_outputLogTarget                           = UQ_MH_SG_OUTPUT_LOG_TARGET;
   m_ov.m_doLogitTransform                          = mlOptions.m_doLogitTransform;
+  m_ov.m_algorithm                                 = mlOptions.m_algorithm;
 
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
 //m_ov.m_alternativeRawSsOptionsValues             = mlOptions.; // dakota
@@ -1233,6 +1237,7 @@ MetropolisHastingsSGOptions::print(std::ostream& os) const
      << "\n" << m_option_outputLogLikelihood                        << " = " << m_ov.m_outputLogLikelihood
      << "\n" << m_option_outputLogTarget                            << " = " << m_ov.m_outputLogTarget
      << "\n" << m_option_doLogitTransform                           << " = " << m_ov.m_doLogitTransform
+     << "\n" << m_option_algorithm                                  << " = " << m_ov.m_algorithm
      << std::endl;
 
   return;
@@ -1302,6 +1307,7 @@ MetropolisHastingsSGOptions::defineMyOptions(boost::program_options::options_des
     (m_option_outputLogLikelihood.c_str(),                        boost::program_options::value<bool        >()->default_value(UQ_MH_SG_OUTPUT_LOG_LIKELIHOOD                               ), "flag to toggle output of log likelihood values"             )
     (m_option_outputLogTarget.c_str(),                            boost::program_options::value<bool        >()->default_value(UQ_MH_SG_OUTPUT_LOG_TARGET                                   ), "flag to toggle output of log target values"                 )
     (m_option_doLogitTransform.c_str(),                           boost::program_options::value<bool        >()->default_value(UQ_MH_SG_DO_LOGIT_TRANSFORM                                  ), "flag to toggle logit transform for bounded domains"         )
+    (m_option_algorithm.c_str(),                                  boost::program_options::value<std::string >()->default_value(UQ_MH_SG_ALGORITHM                                           ), "which mcmc algorithm to use"                                )
   ;
 
   return;
@@ -1619,6 +1625,10 @@ MetropolisHastingsSGOptions::getMyOptionValues(boost::program_options::options_d
 
   if (m_env.allOptionsMap().count(m_option_doLogitTransform)) {
     m_ov.m_doLogitTransform = ((const boost::program_options::variable_value&) m_env.allOptionsMap()[m_option_doLogitTransform]).as<bool>();
+  }
+
+  if (m_env.allOptionsMap().count(m_option_algorithm)) {
+    m_ov.m_algorithm = ((const boost::program_options::variable_value&) m_env.allOptionsMap()[m_option_algorithm]).as<std::string>();
   }
 }
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS

--- a/src/stats/src/ScaledCovMatrixTKGroup.C
+++ b/src/stats/src/ScaledCovMatrixTKGroup.C
@@ -133,16 +133,16 @@ ScaledCovMatrixTKGroup<V,M>::rv(const std::vector<unsigned int>& stageIds)
 
 template <class V, class M>
 const GaussianVectorRV<V, M> &
-ScaledCovMatrixTKGroup<V, M>::rv() const
+ScaledCovMatrixTKGroup<V, M>::rv(const V & position) const
 {
   queso_require_not_equal_to_msg(m_rvs.size(), 0, "m_rvs.size() = 0");
   queso_require_msg(m_rvs[0], "m_rvs[0] == NULL");
-  queso_require_greater_msg(m_preComputingPositions.size(), this->m_stageId, "m_preComputingPositions.size() <= stageId");
-  queso_require_msg(m_preComputingPositions[this->m_stageId], "m_preComputingPositions[stageId] == NULL");
+  //queso_require_greater_msg(m_preComputingPositions.size(), this->m_stageId, "m_preComputingPositions.size() <= stageId");
+  //queso_require_msg(m_preComputingPositions[this->m_stageId], "m_preComputingPositions[stageId] == NULL");
 
-  GaussianVectorRV<V, M> * gaussian_rv = dynamic_cast<GaussianVectorRV<V, M> * >(m_rvs[0]);
+  GaussianVectorRV<V, M> * gaussian_rv = dynamic_cast<GaussianVectorRV<V, M> * >(m_rvs[this->m_stageId]);
 
-  gaussian_rv->updateLawExpVector(*m_preComputingPositions[this->m_stageId]);
+  gaussian_rv->updateLawExpVector(position);
 
   return (*gaussian_rv);
 }

--- a/src/stats/src/ScaledCovMatrixTKGroup.C
+++ b/src/stats/src/ScaledCovMatrixTKGroup.C
@@ -130,6 +130,23 @@ ScaledCovMatrixTKGroup<V,M>::rv(const std::vector<unsigned int>& stageIds)
 
   return (*gaussian_rv);
 }
+
+template <class V, class M>
+const GaussianVectorRV<V, M> &
+ScaledCovMatrixTKGroup<V, M>::rv() const
+{
+  queso_require_not_equal_to_msg(m_rvs.size(), 0, "m_rvs.size() = 0");
+  queso_require_msg(m_rvs[0], "m_rvs[0] == NULL");
+  queso_require_greater_msg(m_preComputingPositions.size(), this->m_stageId, "m_preComputingPositions.size() <= stageId");
+  queso_require_msg(m_preComputingPositions[this->m_stageId], "m_preComputingPositions[stageId] == NULL");
+
+  GaussianVectorRV<V, M> * gaussian_rv = dynamic_cast<GaussianVectorRV<V, M> * >(m_rvs[0]);
+
+  gaussian_rv->updateLawExpVector(*m_preComputingPositions[this->m_stageId]);
+
+  return (*gaussian_rv);
+}
+
 //---------------------------------------------------
 template<class V, class M>
 void

--- a/src/stats/src/ScaledCovMatrixTKGroup.C
+++ b/src/stats/src/ScaledCovMatrixTKGroup.C
@@ -150,8 +150,6 @@ ScaledCovMatrixTKGroup<V,M>::updateLawCovMatrix(const M& covMatrix)
     }
     dynamic_cast<GaussianVectorRV<V, M> * >(m_rvs[i])->updateLawCovMatrix(factor*covMatrix);
   }
-
-  return;
 }
 
 // Misc methods -------------------------------------
@@ -199,9 +197,7 @@ void
 ScaledCovMatrixTKGroup<V,M>::clearPreComputingPositions()
 {
   BaseTKGroup<V,M>::clearPreComputingPositions();
-  return;
 }
-
 
 // Private methods------------------------------------
 template<class V, class M>
@@ -216,12 +212,10 @@ ScaledCovMatrixTKGroup<V,M>::setRVsWithZeroMean()
     double factor = 1./m_scales[i]/m_scales[i];
     queso_require_msg(!(m_rvs[i]), "m_rvs[i] != NULL");
     m_rvs[i] = new GaussianVectorRV<V,M>(m_prefix.c_str(),
-                                                *m_vectorSpace,
-                                                m_vectorSpace->zeroVector(),
-                                                factor*m_originalCovMatrix);
+                                         *m_vectorSpace,
+                                         m_vectorSpace->zeroVector(),
+                                         factor*m_originalCovMatrix);
   }
-
-  return;
 }
 // I/O methods---------------------------------------
 template<class V, class M>
@@ -229,7 +223,6 @@ void
 ScaledCovMatrixTKGroup<V,M>::print(std::ostream& os) const
 {
   BaseTKGroup<V,M>::print(os);
-  return;
 }
 
 }  // End namespace QUESO

--- a/src/stats/src/ScaledCovMatrixTKGroup.C
+++ b/src/stats/src/ScaledCovMatrixTKGroup.C
@@ -199,6 +199,15 @@ ScaledCovMatrixTKGroup<V,M>::clearPreComputingPositions()
   BaseTKGroup<V,M>::clearPreComputingPositions();
 }
 
+template <class V, class M>
+unsigned int
+ScaledCovMatrixTKGroup<V, M>::set_dr_stage(unsigned int stageId)
+{
+  unsigned int old_stageId = this->m_stageId;
+  this->m_stageId = stageId;
+  return old_stageId;
+}
+
 // Private methods------------------------------------
 template<class V, class M>
 void

--- a/src/stats/src/TKGroup.C
+++ b/src/stats/src/TKGroup.C
@@ -121,10 +121,10 @@ BaseTKGroup<V,M>::clearPreComputingPositions()
 }
 
 template <class V, class M>
-void
+unsigned int
 BaseTKGroup<V, M>::set_dr_stage(unsigned int stageId)
 {
-  m_stageId = stageId;
+  return this->m_stageId;
 }
 
 // I/O methods---------------------------------------

--- a/src/stats/src/TKGroup.C
+++ b/src/stats/src/TKGroup.C
@@ -38,7 +38,8 @@ BaseTKGroup<V,M>::BaseTKGroup()
   m_vectorSpace          (NULL),
   m_scales               (),
   m_preComputingPositions(),
-  m_rvs                  ()
+  m_rvs                  (),
+  m_stageId              (0)
 {
 }
 // Constructor with values---------------------------
@@ -54,7 +55,8 @@ BaseTKGroup<V,M>::BaseTKGroup(
   m_vectorSpace          (&vectorSpace),
   m_scales               (scales.size(),1.),
   m_preComputingPositions(scales.size()+1,NULL), // Yes, +1
-  m_rvs                  (scales.size(),NULL) // IMPORTANT: it stays like this for scaledTK, but it will be overwritten to '+1' by hessianTK constructor
+  m_rvs                  (scales.size(),NULL), // IMPORTANT: it stays like this for scaledTK, but it will be overwritten to '+1' by hessianTK constructor
+  m_stageId              (0)
 {
   for (unsigned int i = 0; i < m_scales.size(); ++i) {
     m_scales[i] = scales[i];
@@ -117,6 +119,14 @@ BaseTKGroup<V,M>::clearPreComputingPositions()
 
   return;
 }
+
+template <class V, class M>
+void
+BaseTKGroup<V, M>::set_dr_stage(unsigned int stageId)
+{
+  m_stageId = stageId;
+}
+
 // I/O methods---------------------------------------
 template<class V, class M>
 void

--- a/src/stats/src/TransformedScaledCovMatrixTKGroup.C
+++ b/src/stats/src/TransformedScaledCovMatrixTKGroup.C
@@ -143,20 +143,18 @@ TransformedScaledCovMatrixTKGroup<V,M>::rv(const std::vector<unsigned int>& stag
 
 template <class V, class M>
 const InvLogitGaussianVectorRV<V, M> &
-TransformedScaledCovMatrixTKGroup<V, M>::rv() const
+TransformedScaledCovMatrixTKGroup<V, M>::rv(const V & position) const
 {
   queso_require_not_equal_to_msg(m_rvs.size(), 0, "m_rvs.size() = 0");
   queso_require_msg(m_rvs[0], "m_rvs[0] == NULL");
-  queso_require_greater_msg(m_preComputingPositions.size(), this->m_stageId, "m_preComputingPositions.size() <= stageId");
-  queso_require_msg(m_preComputingPositions[this->m_stageId], "m_preComputingPositions[stageId] == NULL");
+  // queso_require_greater_msg(m_preComputingPositions.size(), this->m_stageId, "m_preComputingPositions.size() <= stageId");
+  // queso_require_msg(m_preComputingPositions[this->m_stageId], "m_preComputingPositions[stageId] == NULL");
 
   InvLogitGaussianVectorRV<V, M> * invlogit_gaussian =
-    dynamic_cast<InvLogitGaussianVectorRV<V, M> * >(m_rvs[0]);
+    dynamic_cast<InvLogitGaussianVectorRV<V, M> * >(m_rvs[this->m_stageId]);
 
-  V transformedPreComputingPositions(*m_preComputingPositions[this->m_stageId]);
-  transformToGaussianSpace(*m_preComputingPositions[this->m_stageId],
-      transformedPreComputingPositions);
-
+  V transformedPreComputingPositions(position);
+  transformToGaussianSpace(position, transformedPreComputingPositions);
   invlogit_gaussian->updateLawExpVector(transformedPreComputingPositions);
 
   return (*invlogit_gaussian);

--- a/src/stats/src/TransformedScaledCovMatrixTKGroup.C
+++ b/src/stats/src/TransformedScaledCovMatrixTKGroup.C
@@ -216,6 +216,14 @@ TransformedScaledCovMatrixTKGroup<V,M>::clearPreComputingPositions()
   return;
 }
 
+template <class V, class M>
+unsigned int
+TransformedScaledCovMatrixTKGroup<V, M>::set_dr_stage(unsigned int stageId)
+{
+  unsigned int old_stageId = this->m_stageId;
+  this->m_stageId = stageId;
+  return old_stageId;
+}
 
 // Private methods------------------------------------
 template<class V, class M>

--- a/src/stats/src/TransformedScaledCovMatrixTKGroup.C
+++ b/src/stats/src/TransformedScaledCovMatrixTKGroup.C
@@ -140,6 +140,28 @@ TransformedScaledCovMatrixTKGroup<V,M>::rv(const std::vector<unsigned int>& stag
 
   return (*invlogit_gaussian);
 }
+
+template <class V, class M>
+const InvLogitGaussianVectorRV<V, M> &
+TransformedScaledCovMatrixTKGroup<V, M>::rv() const
+{
+  queso_require_not_equal_to_msg(m_rvs.size(), 0, "m_rvs.size() = 0");
+  queso_require_msg(m_rvs[0], "m_rvs[0] == NULL");
+  queso_require_greater_msg(m_preComputingPositions.size(), this->m_stageId, "m_preComputingPositions.size() <= stageId");
+  queso_require_msg(m_preComputingPositions[this->m_stageId], "m_preComputingPositions[stageId] == NULL");
+
+  InvLogitGaussianVectorRV<V, M> * invlogit_gaussian =
+    dynamic_cast<InvLogitGaussianVectorRV<V, M> * >(m_rvs[0]);
+
+  V transformedPreComputingPositions(*m_preComputingPositions[this->m_stageId]);
+  transformToGaussianSpace(*m_preComputingPositions[this->m_stageId],
+      transformedPreComputingPositions);
+
+  invlogit_gaussian->updateLawExpVector(transformedPreComputingPositions);
+
+  return (*invlogit_gaussian);
+}
+
 //---------------------------------------------------
 template<class V, class M>
 void

--- a/test/t04_bimodal/example_1chain.inp
+++ b/test/t04_bimodal/example_1chain.inp
@@ -43,7 +43,7 @@ ip_ml_default_maxRejectionRate      = 0.4
 ip_ml_default_putOutOfBoundsInChain = 0
 
 ip_ml_6_putOutOfBoundsInChain = 0
- 
+
 ###############################################
 # Level 3
 ###############################################

--- a/test/test_StatisticalInverseProblem/test_NoInputFile.C
+++ b/test/test_StatisticalInverseProblem/test_NoInputFile.C
@@ -121,6 +121,7 @@ int main(int argc, char ** argv) {
   mhOptions.m_amEpsilon = 1.e-8;
   mhOptions.m_doLogitTransform = false;
   mhOptions.m_algorithm = "random_walk";
+  mhOptions.m_tk = "random_walk";
 
   ip.solveWithBayesMetropolisHastings(&mhOptions, paramInitials,
       &proposalCovMatrix);

--- a/test/test_StatisticalInverseProblem/test_NoInputFile.C
+++ b/test/test_StatisticalInverseProblem/test_NoInputFile.C
@@ -120,6 +120,7 @@ int main(int argc, char ** argv) {
   mhOptions.m_amEta = (double) 2.4 * 2.4 / dim;  // From Gelman 95
   mhOptions.m_amEpsilon = 1.e-8;
   mhOptions.m_doLogitTransform = false;
+  mhOptions.m_algorithm = "random_walk";
 
   ip.solveWithBayesMetropolisHastings(&mhOptions, paramInitials,
       &proposalCovMatrix);


### PR DESCRIPTION
Allows the user to implement a custom transition kernel and register with the factory so QUESO can instantiate the custom kernel at run-time.

All commits pass `make check` locally, the changelog has been updated and documentation included.

This should replace #404 and #408.