### PR TITLE
Implement MALA

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -17,6 +17,7 @@ Version 0.56.0 (in progress)
   * Make boost program options optional (and use getpot when disabled)
   * Implement a transition kernel factory pattern so users may implement custom
     samplers
+  * Implement MALA, a derivative-informed MCMC sampler
 
 Version 0.55.0 (Jun 17, 2016)
   * Fix bug in JeffreysJointPdf

--- a/inc/queso/Makefile.am
+++ b/inc/queso/Makefile.am
@@ -66,6 +66,7 @@ BUILT_SOURCES += RngGsl.h
 BUILT_SOURCES += ScopedPtr.h
 BUILT_SOURCES += SharedPtr.h
 BUILT_SOURCES += TKFactoryLogitRandomWalk.h
+BUILT_SOURCES += TKFactoryMALA.h
 BUILT_SOURCES += TKFactoryRandomWalk.h
 BUILT_SOURCES += TKFactoryStochasticNewton.h
 BUILT_SOURCES += TeuchosMatrix.h
@@ -329,6 +330,8 @@ ScopedPtr.h: $(top_srcdir)/src/core/inc/ScopedPtr.h
 SharedPtr.h: $(top_srcdir)/src/core/inc/SharedPtr.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 TKFactoryLogitRandomWalk.h: $(top_srcdir)/src/core/inc/TKFactoryLogitRandomWalk.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+TKFactoryMALA.h: $(top_srcdir)/src/core/inc/TKFactoryMALA.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 TKFactoryRandomWalk.h: $(top_srcdir)/src/core/inc/TKFactoryRandomWalk.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@

--- a/inc/queso/Makefile.am
+++ b/inc/queso/Makefile.am
@@ -159,6 +159,7 @@ BUILT_SOURCES += MLSamplingLevelOptions.h
 BUILT_SOURCES += MLSamplingOptions.h
 BUILT_SOURCES += MarkovChainPositionData.h
 BUILT_SOURCES += MatrixCovarianceFunction.h
+BUILT_SOURCES += MetropolisAdjustedLangevinTK.h
 BUILT_SOURCES += MetropolisHastingsSG.h
 BUILT_SOURCES += MetropolisHastingsSGOptions.h
 BUILT_SOURCES += ModelValidation.h
@@ -514,6 +515,8 @@ MLSamplingOptions.h: $(top_srcdir)/src/stats/inc/MLSamplingOptions.h
 MarkovChainPositionData.h: $(top_srcdir)/src/stats/inc/MarkovChainPositionData.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 MatrixCovarianceFunction.h: $(top_srcdir)/src/stats/inc/MatrixCovarianceFunction.h
+	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
+MetropolisAdjustedLangevinTK.h: $(top_srcdir)/src/stats/inc/MetropolisAdjustedLangevinTK.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@
 MetropolisHastingsSG.h: $(top_srcdir)/src/stats/inc/MetropolisHastingsSG.h
 	$(AM_V_GEN)rm -f $@ && $(LN_S) $< $@

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -86,6 +86,7 @@ libqueso_la_SOURCES += core/src/TKFactoryStochasticNewton.C
 libqueso_la_SOURCES += core/src/TKFactoryRandomWalk.C
 libqueso_la_SOURCES += core/src/TKFactoryLogitRandomWalk.C
 libqueso_la_SOURCES += core/src/AlgorithmFactory.C
+libqueso_la_SOURCES += core/src/TKFactoryMALA.C
 
 
 # Sources that need libmesh
@@ -323,6 +324,7 @@ libqueso_include_HEADERS += core/inc/TKFactoryStochasticNewton.h
 libqueso_include_HEADERS += core/inc/TKFactoryRandomWalk.h
 libqueso_include_HEADERS += core/inc/TKFactoryLogitRandomWalk.h
 libqueso_include_HEADERS += core/inc/AlgorithmFactory.h
+libqueso_include_HEADERS += core/inc/TKFactoryMALA.h
 
 # Headers that need libmesh
 libqueso_include_HEADERS += core/inc/FunctionBase.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -254,6 +254,7 @@ libqueso_la_SOURCES += stats/src/GaussianLikelihoodFullCovarianceRandomCoefficie
 libqueso_la_SOURCES += stats/src/GaussianLikelihoodBlockDiagonalCovariance.C
 libqueso_la_SOURCES += stats/src/GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.C
 libqueso_la_SOURCES += stats/src/Algorithm.C
+libqueso_la_SOURCES += stats/src/MetropolisAdjustedLangevinTK.C
 
 # Sources from surrogates/src
 libqueso_la_SOURCES += surrogates/src/InterpolationSurrogateData.C
@@ -468,6 +469,7 @@ libqueso_include_HEADERS += stats/inc/GaussianLikelihoodFullCovarianceRandomCoef
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodBlockDiagonalCovariance.h
 libqueso_include_HEADERS += stats/inc/GaussianLikelihoodBlockDiagonalCovarianceRandomCoefficients.h
 libqueso_include_HEADERS += stats/inc/Algorithm.h
+libqueso_include_HEADERS += stats/inc/MetropolisAdjustedLangevinTK.h
 
 # Headers to install from surrogates/inc
 libqueso_include_HEADERS += surrogates/inc/SurrogateBase.h

--- a/src/core/inc/AlgorithmFactory.h
+++ b/src/core/inc/AlgorithmFactory.h
@@ -35,7 +35,9 @@ namespace QUESO
 {
 
 /**
- * AlgorithmFactory class defintion.
+ * AlgorithmFactory class defintion.  Clients subclassing this for their own
+ * algorithm (aka Metropolis-Hastings acceptance ratio) should implement
+ * build_algorithm.
  */
 class AlgorithmFactory : public Factory<Algorithm<GslVector, GslMatrix> >
 {
@@ -91,7 +93,9 @@ AlgorithmFactory::create()
 }
 
 /**
- * AlgorithmFactoryImp implementation of AlgorithmFactory
+ * AlgorithmFactoryImp implementation of AlgorithmFactory.  Implements an
+ * algorithm factory for the standard Metropolis-Hastings algorithm (aka
+ * acceptance ratio).
  */
 template <class DerivedAlgorithm>
 class AlgorithmFactoryImp : public AlgorithmFactory

--- a/src/core/inc/TKFactoryMALA.h
+++ b/src/core/inc/TKFactoryMALA.h
@@ -32,7 +32,8 @@ namespace QUESO
 {
 
 /**
- * TKFactoryMALA class defintion.
+ * TKFactoryMALA class defintion.  Implements the factory for the MALA
+ * transition kernel.
  */
 template <class DerivedTK>
 class TKFactoryMALA : public TransitionKernelFactory

--- a/src/core/inc/TKFactoryMALA.h
+++ b/src/core/inc/TKFactoryMALA.h
@@ -1,0 +1,59 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef QUESO_TK_FACTORY_MALA_H
+#define QUESO_TK_FACTORY_MALA_H
+
+#include <queso/TransitionKernelFactory.h>
+#include <queso/TKGroup.h>
+
+namespace QUESO
+{
+
+/**
+ * TKFactoryMALA class defintion.
+ */
+template <class DerivedTK>
+class TKFactoryMALA : public TransitionKernelFactory
+{
+public:
+  /**
+   * Constructor. Takes the name to be mapped.
+   */
+  TKFactoryMALA(const std::string & name)
+    : TransitionKernelFactory(name)
+  {}
+
+  /**
+   * Destructor. (Empty.)
+   */
+  virtual ~TKFactoryMALA() {}
+
+protected:
+  virtual SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type build_tk();
+};
+
+} // namespace QUESO
+
+#endif // QUESO_TK_FACTORY_MALA_H

--- a/src/core/src/TKFactoryMALA.C
+++ b/src/core/src/TKFactoryMALA.C
@@ -1,0 +1,53 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/TKFactoryMALA.h>
+#include <queso/MetropolisAdjustedLangevinTK.h>
+#include <queso/BayesianJointPdf.h>
+
+namespace QUESO
+{
+
+template <class DerivedTK>
+SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type
+TKFactoryMALA<DerivedTK>::build_tk()
+{
+  SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type new_tk;
+
+  const BayesianJointPdf<GslVector, GslMatrix> * target_bayesian_pdf =
+    dynamic_cast<const BayesianJointPdf<GslVector, GslMatrix> *>(
+        this->m_target_pdf);
+
+  new_tk.reset(new DerivedTK(this->m_options->m_prefix.c_str(),
+                             *target_bayesian_pdf,
+                             *(this->m_dr_scales),
+                             *(this->m_initial_cov_matrix)));
+
+  return new_tk;
+}
+
+// Instantiate all the transition kernel factories
+TKFactoryMALA<MetropolisAdjustedLangevinTK<GslVector, GslMatrix> > tk_factory_mala("mala");
+
+} // namespace QUESO

--- a/src/core/src/TKFactoryMALA.C
+++ b/src/core/src/TKFactoryMALA.C
@@ -35,6 +35,7 @@ TKFactoryMALA<DerivedTK>::build_tk()
 {
   SharedPtr<BaseTKGroup<GslVector, GslMatrix> >::Type new_tk;
 
+  // Assume the problem is Bayesian
   const BayesianJointPdf<GslVector, GslMatrix> * target_bayesian_pdf =
     dynamic_cast<const BayesianJointPdf<GslVector, GslMatrix> *>(
         this->m_target_pdf);

--- a/src/stats/inc/MetropolisAdjustedLangevinTK.h
+++ b/src/stats/inc/MetropolisAdjustedLangevinTK.h
@@ -71,6 +71,9 @@ public:
    */
   const GaussianVectorRV<V, M> & rv(const std::vector<unsigned int> & stageIds);
 
+  //! Constructs transition kernel pdf based on internal \c m_stageId variable
+  virtual const GaussianVectorRV<V, M> & rv(const V & position) const;
+
   //! Scales the covariance matrix.
   /*! The covariance matrix is scaled by a factor of \f$ 1/scales^2 \f$.*/
   void updateLawCovMatrix(const M & covMatrix);

--- a/src/stats/inc/MetropolisAdjustedLangevinTK.h
+++ b/src/stats/inc/MetropolisAdjustedLangevinTK.h
@@ -1,0 +1,113 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef UQ_MALA_TK_H
+#define UQ_MALA_TK_H
+
+#include <queso/TKGroup.h>
+
+namespace QUESO {
+
+class GslVector;
+class GslMatrix;
+template <class V, class M> class BayseianJointPdf;
+
+/*!
+ * \class MetropolisAdjustedLangevinTK
+ *
+ * \brief This class allows the representation of a transition kernel with a
+ * scaled covariance matrix.
+ */
+template <class V = GslVector, class M = GslMatrix>
+class MetropolisAdjustedLangevinTK : public BaseTKGroup<V, M> {
+public:
+  //! @name Constructor/Destructor methods
+  //@{
+  //! Default constructor.
+  MetropolisAdjustedLangevinTK(const char * prefix,
+                                const BayesianJointPdf<V, M> & targetPdf,
+                                const std::vector<double> & scales,
+                                const M & covMatrix);
+  //! Destructor.
+  ~MetropolisAdjustedLangevinTK();
+  //@}
+
+  //! @name Statistical/Mathematical methods
+  //@{
+  //! Whether or not the matrix is symmetric. Always 'true'.
+  /*! \todo: It only returns 'true', thus a test for its symmetricity must be included.*/
+  bool symmetric() const;
+
+  //! Gaussian increment property to construct a transition kernel.
+  /*
+   * Not implemented for MALA
+   */
+  const GaussianVectorRV<V, M> & rv(unsigned int stageId) const;
+
+  //! Gaussian increment property to construct a transition kernel.
+  /*
+   * Not implemented for MALA
+   */
+  const GaussianVectorRV<V, M> & rv(const std::vector<unsigned int> & stageIds);
+
+  //! Scales the covariance matrix.
+  /*! The covariance matrix is scaled by a factor of \f$ 1/scales^2 \f$.*/
+  void updateLawCovMatrix(const M & covMatrix);
+  //@}
+
+  //! @name Misc methods
+  //@{
+  //! Sets the pre-computing positions \c m_preComputingPositions[stageId] with a new vector of size \c position.
+  bool setPreComputingPosition(const V & position, unsigned int stageId);
+
+  //! Clears the pre-computing positions \c m_preComputingPositions[stageId]
+  void clearPreComputingPositions();
+  //@}
+
+  //! @name I/O methods
+  //@{
+  //! TODO: Prints the transition kernel.
+  /*! \todo: implement me!*/
+  void print(std::ostream & os) const;
+  //@}
+private:
+  //! Sets the mean of the RVs to zero.
+  void setRVsWithZeroMean();
+  using BaseTKGroup<V,M>::m_env;
+  using BaseTKGroup<V,M>::m_prefix;
+  using BaseTKGroup<V,M>::m_vectorSpace;
+  using BaseTKGroup<V,M>::m_scales;
+  using BaseTKGroup<V,M>::m_preComputingPositions;
+  using BaseTKGroup<V,M>::m_rvs;
+
+  M m_originalCovMatrix;
+
+  const BayesianJointPdf<V, M> & m_targetPdf;
+
+  double m_time_step;
+};
+
+}  // End namespace QUESO
+
+#endif  // UQ_MALA_TK_H

--- a/src/stats/inc/MetropolisAdjustedLangevinTK.h
+++ b/src/stats/inc/MetropolisAdjustedLangevinTK.h
@@ -36,8 +36,8 @@ template <class V, class M> class BayseianJointPdf;
 /*!
  * \class MetropolisAdjustedLangevinTK
  *
- * \brief This class allows the representation of a transition kernel with a
- * scaled covariance matrix.
+ * \brief This class allows the representation of the MALA transition kernel
+ * with a scaled covariance matrix for the purposes of delayed rejection.
  */
 template <class V = GslVector, class M = GslMatrix>
 class MetropolisAdjustedLangevinTK : public BaseTKGroup<V, M> {
@@ -60,15 +60,9 @@ public:
   bool symmetric() const;
 
   //! Gaussian increment property to construct a transition kernel.
-  /*
-   * Not implemented for MALA
-   */
   const GaussianVectorRV<V, M> & rv(unsigned int stageId) const;
 
   //! Gaussian increment property to construct a transition kernel.
-  /*
-   * Not implemented for MALA
-   */
   const GaussianVectorRV<V, M> & rv(const std::vector<unsigned int> & stageIds);
 
   //! Constructs transition kernel pdf based on internal \c m_stageId variable

--- a/src/stats/inc/MetropolisAdjustedLangevinTK.h
+++ b/src/stats/inc/MetropolisAdjustedLangevinTK.h
@@ -72,6 +72,11 @@ public:
   const GaussianVectorRV<V, M> & rv(const std::vector<unsigned int> & stageIds);
 
   //! Constructs transition kernel pdf based on internal \c m_stageId variable
+  /*
+   * This uses the formula for the transition kernel in Roberts & Tweedie 2001.
+   *
+   * http://projecteuclid.org/download/pdf_1/euclid.bj/1178291835
+   */
   virtual const GaussianVectorRV<V, M> & rv(const V & position) const;
 
   //! Scales the covariance matrix.

--- a/src/stats/src/Algorithm.C
+++ b/src/stats/src/Algorithm.C
@@ -28,6 +28,7 @@
 #include <queso/GslMatrix.h>
 #include <queso/Algorithm.h>
 #include <queso/TKGroup.h>
+#include <queso/InvLogitGaussianJointPdf.h>
 
 namespace QUESO {
 
@@ -59,7 +60,7 @@ Algorithm<V, M>::acceptance_ratio(
     if ((x.logTarget() == -INFINITY) ||
         (x.logTarget() ==  INFINITY) ||
         ( queso_isnan(x.logTarget())      )) {
-      std::cerr << "WARNING In MetropolisHastingsSG<P_V,P_M>::alpha(x,y)"
+      std::cerr << "WARNING In Algorithm<V,M>::alpha(x,y)"
                 << ", worldRank "       << m_env.worldRank()
                 << ", fullRank "        << m_env.fullRank()
                 << ", subEnvironment "  << m_env.subId()
@@ -73,7 +74,7 @@ Algorithm<V, M>::acceptance_ratio(
     else if ((y.logTarget() == -INFINITY           ) ||
              (y.logTarget() ==  INFINITY           ) ||
              ( queso_isnan(y.logTarget()) )) {
-      std::cerr << "WARNING In MetropolisHastingsSG<P_V,P_M>::alpha(x,y)"
+      std::cerr << "WARNING In Algorithm<V,M>::alpha(x,y)"
                 << ", worldRank "       << m_env.worldRank()
                 << ", fullRank "        << m_env.fullRank()
                 << ", subEnvironment "  << m_env.subId()
@@ -90,74 +91,67 @@ Algorithm<V, M>::acceptance_ratio(
       if (m_tk.symmetric()) {
         alphaQuotient = std::exp(yLogTargetToUse - x.logTarget());
 
-        // if ((m_env.subDisplayFile()                   ) &&
-        //     (m_env.displayVerbosity() >= 3            ) &&
-        //     (m_optionsObj->m_totallyMute == false)) {
-        //   *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::alpha(x,y)"
-        //                          << ": symmetric proposal case"
-        //                          << ", x = "               << x.vecValues()
-        //                          << ", y = "               << y.vecValues()
-        //                          << ", yLogTargetToUse = " << yLogTargetToUse
-        //                          << ", x.logTarget() = "   << x.logTarget()
-        //                          << ", alpha = "           << alphaQuotient
-        //                          << std::endl;
-        // }
+        if ((m_env.subDisplayFile()                   ) &&
+            (m_env.displayVerbosity() >= 3            )) {
+          *m_env.subDisplayFile() << "In Algorithm<V,M>::alpha(x,y)"
+                                 << ": symmetric proposal case"
+                                 << ", x = "               << x.vecValues()
+                                 << ", y = "               << y.vecValues()
+                                 << ", yLogTargetToUse = " << yLogTargetToUse
+                                 << ", x.logTarget() = "   << x.logTarget()
+                                 << ", alpha = "           << alphaQuotient
+                                 << std::endl;
+        }
       }
       else {
         double qyx = m_tk.rv(tk_pos_x).pdf().lnValue(x.vecValues(),NULL,NULL,NULL,NULL);
-        // if ((m_env.subDisplayFile()                   ) &&
-        //     (m_env.displayVerbosity() >= 10           ) &&
-        //     (m_optionsObj->m_totallyMute == false)) {
-        //   const InvLogitGaussianJointPdf<P_V,P_M>* pdfYX = dynamic_cast< const InvLogitGaussianJointPdf<P_V,P_M>* >(&(m_tk->rv(yStageId).pdf()));
-        //   *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::alpha(x,y)"
-        //                          << ", rvYX.lawExpVector = " << pdfYX->lawExpVector()
-        //                          << ", rvYX.lawVarVector = " << pdfYX->lawVarVector()
-        //                          << ", rvYX.lawCovMatrix = " << pdfYX->lawCovMatrix()
-        //                          << std::endl;
-        // }
+        if ((m_env.subDisplayFile()                   ) &&
+            (m_env.displayVerbosity() >= 10           )) {
+          const InvLogitGaussianJointPdf<V,M>* pdfYX = dynamic_cast< const InvLogitGaussianJointPdf<V,M>* >(&(m_tk.rv(tk_pos_x).pdf()));
+          *m_env.subDisplayFile() << "In Algorithm<V,M>::alpha(x,y)"
+                                 << ", rvYX.lawExpVector = " << pdfYX->lawExpVector()
+                                 << ", rvYX.lawVarVector = " << pdfYX->lawVarVector()
+                                 << ", rvYX.lawCovMatrix = " << pdfYX->lawCovMatrix()
+                                 << std::endl;
+        }
         double qxy = m_tk.rv(tk_pos_y).pdf().lnValue(y.vecValues(),NULL,NULL,NULL,NULL);
-        // if ((m_env.subDisplayFile()                   ) &&
-        //     (m_env.displayVerbosity() >= 10           ) &&
-        //     (m_optionsObj->m_totallyMute == false)) {
-        //   const InvLogitGaussianJointPdf<P_V,P_M>* pdfXY = dynamic_cast< const InvLogitGaussianJointPdf<P_V,P_M>* >(&(m_tk->rv(xStageId).pdf()));
-        //   *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::alpha(x,y)"
-        //                          << ", rvXY.lawExpVector = " << pdfXY->lawExpVector()
-        //                          << ", rvXY.lawVarVector = " << pdfXY->lawVarVector()
-        //                          << ", rvXY.lawCovMatrix = " << pdfXY->lawCovMatrix()
-        //                          << std::endl;
-        // }
+        if ((m_env.subDisplayFile()                   ) &&
+            (m_env.displayVerbosity() >= 10           )) {
+          const InvLogitGaussianJointPdf<V,M>* pdfXY = dynamic_cast< const InvLogitGaussianJointPdf<V,M>* >(&(m_tk.rv(tk_pos_y).pdf()));
+          *m_env.subDisplayFile() << "In Algorithm<V,M>::alpha(x,y)"
+                                 << ", rvXY.lawExpVector = " << pdfXY->lawExpVector()
+                                 << ", rvXY.lawVarVector = " << pdfXY->lawVarVector()
+                                 << ", rvXY.lawCovMatrix = " << pdfXY->lawCovMatrix()
+                                 << std::endl;
+        }
         alphaQuotient = std::exp(yLogTargetToUse +
                                  qyx -
                                  x.logTarget() -
                                  qxy);
-        // if ((m_env.subDisplayFile()                   ) &&
-        //     (m_env.displayVerbosity() >= 3            ) &&
-        //     (m_optionsObj->m_totallyMute == false)) {
-        //   *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::alpha(x,y)"
-        //                          << ": asymmetric proposal case"
-        //                          << ", xStageId = "        << xStageId
-        //                          << ", yStageId = "        << yStageId
-        //                          << ", x = "               << x.vecValues()
-        //                          << ", y = "               << y.vecValues()
-        //                          << ", yLogTargetToUse = " << yLogTargetToUse
-        //                          << ", q(y,x) = "          << qyx
-        //                          << ", x.logTarget() = "   << x.logTarget()
-        //                          << ", q(x,y) = "          << qxy
-        //                          << ", alpha = "           << alphaQuotient
-        //                          << std::endl;
-        // }
+        if ((m_env.subDisplayFile()                   ) &&
+            (m_env.displayVerbosity() >= 3            )) {
+          *m_env.subDisplayFile() << "In Algorithm<V,M>::alpha(x,y)"
+                                 << ": asymmetric proposal case"
+                                 << ", x = "               << x.vecValues()
+                                 << ", y = "               << y.vecValues()
+                                 << ", yLogTargetToUse = " << yLogTargetToUse
+                                 << ", q(y,x) = "          << qyx
+                                 << ", x.logTarget() = "   << x.logTarget()
+                                 << ", q(x,y) = "          << qxy
+                                 << ", alpha = "           << alphaQuotient
+                                 << std::endl;
+        }
       }
     } // protection logic against logTarget values
   }
   else {
-    // if ((m_env.subDisplayFile()                   ) &&
-    //     (m_env.displayVerbosity() >= 10           ) &&
-    //     (m_optionsObj->m_totallyMute == false)) {
-    //   *m_env.subDisplayFile() << "In MetropolisHastingsSG<P_V,P_M>::alpha(x,y)"
-    //                          << ": x.outOfTargetSupport = " << x.outOfTargetSupport()
-    //                          << ", y.outOfTargetSupport = " << y.outOfTargetSupport()
-    //                          << std::endl;
-    // }
+    if ((m_env.subDisplayFile()                   ) &&
+        (m_env.displayVerbosity() >= 10           )) {
+      *m_env.subDisplayFile() << "In Algorithm<V,M>::alpha(x,y)"
+                             << ": x.outOfTargetSupport = " << x.outOfTargetSupport()
+                             << ", y.outOfTargetSupport = " << y.outOfTargetSupport()
+                             << std::endl;
+    }
   }
 
   return std::min(1.,alphaQuotient);

--- a/src/stats/src/MetropolisAdjustedLangevinTK.C
+++ b/src/stats/src/MetropolisAdjustedLangevinTK.C
@@ -80,10 +80,10 @@ template <class V, class M>
 const GaussianVectorRV<V, M> &
 MetropolisAdjustedLangevinTK<V, M>::rv(unsigned int stageId) const
 {
-  queso_require_not_equal_to_msg(m_rvs.size(), 0, "m_rvs.size() = 0");
-  queso_require_msg(m_rvs[0], "m_rvs[0] == NULL");
-  queso_require_greater_msg(m_preComputingPositions.size(), stageId, "m_preComputingPositions.size() <= stageId");
-  queso_require_msg(m_preComputingPositions[stageId], "m_preComputingPositions[stageId] == NULL");
+  queso_require_not_equal_to(m_rvs.size(), 0);
+  queso_require(m_rvs[0]);
+  queso_require_greater(m_preComputingPositions.size(), stageId);
+  queso_require(m_preComputingPositions[stageId]);
 
   if ((m_env.subDisplayFile()        ) &&
       (m_env.displayVerbosity() >= 10)) {
@@ -105,10 +105,10 @@ template <class V, class M>
 const GaussianVectorRV<V, M> &
 MetropolisAdjustedLangevinTK<V, M>::rv(const std::vector<unsigned int> & stageIds)
 {
-  queso_require_greater_equal_msg(m_rvs.size(), stageIds.size(), "m_rvs.size() < stageIds.size()");
-  queso_require_msg(m_rvs[stageIds.size()-1], "m_rvs[stageIds.size()-1] == NULL");
-  queso_require_greater_msg(m_preComputingPositions.size(), stageIds[0], "m_preComputingPositions.size() <= stageIds[0]");
-  queso_require_msg(m_preComputingPositions[stageIds[0]], "m_preComputingPositions[stageIds[0]] == NULL");
+  queso_require_greater_equal(m_rvs.size(), stageIds.size());
+  queso_require(m_rvs[stageIds.size()-1]);
+  queso_require_greater(m_preComputingPositions.size(), stageIds[0]);
+  queso_require(m_preComputingPositions[stageIds[0]]);
 
   if ((m_env.subDisplayFile()        ) &&
       (m_env.displayVerbosity() >= 10)) {
@@ -131,8 +131,8 @@ template <class V, class M>
 const GaussianVectorRV<V, M> &
 MetropolisAdjustedLangevinTK<V, M>::rv(const V & position) const
 {
-  queso_require_not_equal_to_msg(m_rvs.size(), 0, "m_rvs.size() = 0");
-  queso_require_msg(m_rvs[0], "m_rvs[0] == NULL");
+  queso_require_not_equal_to(m_rvs.size(), 0);
+  queso_require(m_rvs[0]);
 
   GaussianVectorRV<V, M> * gaussian_rv = dynamic_cast<GaussianVectorRV<V, M> * >(m_rvs[this->m_stageId]);
 
@@ -229,13 +229,12 @@ template <class V, class M>
 void
 MetropolisAdjustedLangevinTK<V, M>::setRVsWithZeroMean()
 {
-  queso_require_not_equal_to_msg(m_rvs.size(), 0, "m_rvs.size() = 0");
-
-  queso_require_equal_to_msg(m_rvs.size(), m_scales.size(), "m_rvs.size() != m_scales.size()");
+  queso_require_not_equal_to(m_rvs.size(), 0);
+  queso_require_equal_to(m_rvs.size(), m_scales.size());
 
   for (unsigned int i = 0; i < m_scales.size(); ++i) {
     double factor = 1./m_scales[i]/m_scales[i];
-    queso_require_msg(!(m_rvs[i]), "m_rvs[i] != NULL");
+    queso_require(!(m_rvs[i]));
     m_rvs[i] = new GaussianVectorRV<V, M>(m_prefix.c_str(),
                                          *m_vectorSpace,
                                          m_vectorSpace->zeroVector(),

--- a/src/stats/src/MetropolisAdjustedLangevinTK.C
+++ b/src/stats/src/MetropolisAdjustedLangevinTK.C
@@ -128,6 +128,13 @@ MetropolisAdjustedLangevinTK<V, M>::rv(const std::vector<unsigned int> & stageId
 }
 
 template <class V, class M>
+const GaussianVectorRV<V, M> &
+MetropolisAdjustedLangevinTK<V, M>::rv(const V & position) const
+{
+  std::cout << "asdf" << std::endl;
+}
+
+template <class V, class M>
 void
 MetropolisAdjustedLangevinTK<V, M>::updateLawCovMatrix(const M & covMatrix)
 {

--- a/src/stats/src/MetropolisAdjustedLangevinTK.C
+++ b/src/stats/src/MetropolisAdjustedLangevinTK.C
@@ -1,0 +1,223 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/MetropolisAdjustedLangevinTK.h>
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/GaussianJointPdf.h>
+#include <queso/BayesianJointPdf.h>
+
+namespace QUESO {
+
+template <class V, class M>
+MetropolisAdjustedLangevinTK<V, M>::MetropolisAdjustedLangevinTK(
+  const char * prefix,
+  const BayesianJointPdf<V, M> & targetPdf,
+  const std::vector<double> & scales,
+  const M & covMatrix)
+  :
+  BaseTKGroup<V, M>(prefix, targetPdf.domainSet().vectorSpace(), scales),
+  m_originalCovMatrix(covMatrix),
+  m_targetPdf(targetPdf),
+  m_time_step(0.1)
+{
+  if ((m_env.subDisplayFile()) && (m_env.displayVerbosity() >= 5)) {
+    *m_env.subDisplayFile() << "Entering MetropolisAdjustedLangevinTK<V, M>::constructor()"
+                           << std::endl;
+  }
+
+  if ((m_env.subDisplayFile()) && (m_env.displayVerbosity() >= 5)) {
+    *m_env.subDisplayFile() << "In MetropolisAdjustedLangevinTK<V, M>::constructor()"
+                           << ": m_scales.size() = "                << m_scales.size()
+                           << ", m_preComputingPositions.size() = " << m_preComputingPositions.size()
+                           << ", m_rvs.size() = "                   << m_rvs.size()
+                           << ", m_originalCovMatrix = "            << m_originalCovMatrix
+                           << std::endl;
+  }
+
+  setRVsWithZeroMean();
+
+  if ((m_env.subDisplayFile()) && (m_env.displayVerbosity() >= 5)) {
+    *m_env.subDisplayFile() << "Leaving MetropolisAdjustedLangevinTK<V, M>::constructor()"
+                           << std::endl;
+  }
+}
+
+template <class V, class M>
+MetropolisAdjustedLangevinTK<V, M>::~MetropolisAdjustedLangevinTK()
+{
+}
+
+template <class V, class M>
+bool
+MetropolisAdjustedLangevinTK<V, M>::symmetric() const
+{
+  return false;
+}
+
+template <class V, class M>
+const GaussianVectorRV<V, M> &
+MetropolisAdjustedLangevinTK<V, M>::rv(unsigned int stageId) const
+{
+  queso_require_not_equal_to_msg(m_rvs.size(), 0, "m_rvs.size() = 0");
+  queso_require_msg(m_rvs[0], "m_rvs[0] == NULL");
+  queso_require_greater_msg(m_preComputingPositions.size(), stageId, "m_preComputingPositions.size() <= stageId");
+  queso_require_msg(m_preComputingPositions[stageId], "m_preComputingPositions[stageId] == NULL");
+
+  if ((m_env.subDisplayFile()        ) &&
+      (m_env.displayVerbosity() >= 10)) {
+    *m_env.subDisplayFile() << "In MetropolisAdjustedLangevinTK<V, M>::rv1()"
+                            << ", stageId = " << stageId
+                            << ": about to call m_rvs[0]->updateLawExpVector()"
+                            << ", vector = " << *m_preComputingPositions[stageId] // FIX ME: might demand parallelism
+                            << std::endl;
+  }
+
+  GaussianVectorRV<V, M> * gaussian_rv = dynamic_cast<GaussianVectorRV<V, M> * >(m_rvs[0]);
+
+  gaussian_rv->updateLawExpVector(*m_preComputingPositions[stageId]);
+
+  return (*gaussian_rv);
+}
+
+template <class V, class M>
+const GaussianVectorRV<V, M> &
+MetropolisAdjustedLangevinTK<V, M>::rv(const std::vector<unsigned int> & stageIds)
+{
+  queso_require_greater_equal_msg(m_rvs.size(), stageIds.size(), "m_rvs.size() < stageIds.size()");
+  queso_require_msg(m_rvs[stageIds.size()-1], "m_rvs[stageIds.size()-1] == NULL");
+  queso_require_greater_msg(m_preComputingPositions.size(), stageIds[0], "m_preComputingPositions.size() <= stageIds[0]");
+  queso_require_msg(m_preComputingPositions[stageIds[0]], "m_preComputingPositions[stageIds[0]] == NULL");
+
+  if ((m_env.subDisplayFile()        ) &&
+      (m_env.displayVerbosity() >= 10)) {
+    *m_env.subDisplayFile() << "In MetropolisAdjustedLangevinTK<V, M>::rv2()"
+                            << ", stageIds.size() = " << stageIds.size()
+                            << ", stageIds[0] = "     << stageIds[0]
+                            << ": about to call m_rvs[stageIds.size()-1]->updateLawExpVector()"
+                            << ", vector = " << *m_preComputingPositions[stageIds[0]] // FIX ME: might demand parallelism
+                            << std::endl;
+  }
+
+  GaussianVectorRV<V, M> * gaussian_rv = dynamic_cast<GaussianVectorRV<V, M> * >(m_rvs[stageIds.size()-1]);
+
+  gaussian_rv->updateLawExpVector(*m_preComputingPositions[stageIds[0]]);
+
+  return (*gaussian_rv);
+}
+
+template <class V, class M>
+void
+MetropolisAdjustedLangevinTK<V, M>::updateLawCovMatrix(const M & covMatrix)
+{
+  for (unsigned int i = 0; i < m_scales.size(); ++i) {
+    double factor = 1./m_scales[i]/m_scales[i];
+    if ((m_env.subDisplayFile()        ) &&
+        (m_env.displayVerbosity() >= 10)) {
+      *m_env.subDisplayFile() << "In MetropolisAdjustedLangevinTK<V, M>::updateLawCovMatrix()"
+                              << ", m_scales.size() = " << m_scales.size()
+                              << ", i = "               << i
+                              << ", m_scales[i] = "     << m_scales[i]
+                              << ", factor = "          << factor
+                              << ": about to call m_rvs[i]->updateLawCovMatrix()"
+                              << ", covMatrix = \n" << factor*covMatrix // FIX ME: might demand parallelism
+                              << std::endl;
+    }
+    dynamic_cast<GaussianVectorRV<V, M> * >(m_rvs[i])->updateLawCovMatrix(factor*m_time_step*covMatrix);
+  }
+}
+
+template <class V, class M>
+bool
+MetropolisAdjustedLangevinTK<V, M>::setPreComputingPosition(const V & position, unsigned int stageId)
+{
+  if ((m_env.subDisplayFile()) && (m_env.displayVerbosity() >= 5)) {
+    *m_env.subDisplayFile() << "Entering MetropolisAdjustedLangevinTK<V, M>::setPreComputingPosition()"
+                           << ": position = " << position
+                           << ", stageId = "  << stageId
+                           << std::endl;
+  }
+
+  BaseTKGroup<V, M>::setPreComputingPosition(position, stageId);
+
+  if ((m_env.subDisplayFile()) && (m_env.displayVerbosity() >= 5)) {
+    *m_env.subDisplayFile() << "In MetropolisAdjustedLangevinTK<V, M>::setPreComputingPosition()"
+                           << ", position = "        << position
+                           << ", stageId = "         << stageId
+                           << ": preComputingPos = " << *m_preComputingPositions[stageId];
+    if (stageId < m_scales.size()) {
+      *m_env.subDisplayFile() << ", factor = " << 1./m_scales[stageId]/m_scales[stageId];
+    }
+    if (stageId < m_rvs.size()) {
+      const GaussianJointPdf<V, M>* pdfPtr = dynamic_cast< const GaussianJointPdf<V, M>* >(&(m_rvs[stageId]->pdf()));
+      *m_env.subDisplayFile() << ", rvCov = " << pdfPtr->lawCovMatrix(); // FIX ME: might demand parallelism
+    }
+    *m_env.subDisplayFile() << std::endl;
+  }
+
+  if ((m_env.subDisplayFile()) && (m_env.displayVerbosity() >= 5)) {
+    *m_env.subDisplayFile() << "Leaving MetropolisAdjustedLangevinTK<V, M>::setPreComputingPosition()"
+                           << ": position = " << position
+                           << ", stageId = "  << stageId
+                           << std::endl;
+  }
+
+  return true;
+}
+
+template <class V, class M>
+void
+MetropolisAdjustedLangevinTK<V, M>::clearPreComputingPositions()
+{
+  BaseTKGroup<V, M>::clearPreComputingPositions();
+}
+
+template <class V, class M>
+void
+MetropolisAdjustedLangevinTK<V, M>::setRVsWithZeroMean()
+{
+  queso_require_not_equal_to_msg(m_rvs.size(), 0, "m_rvs.size() = 0");
+
+  queso_require_equal_to_msg(m_rvs.size(), m_scales.size(), "m_rvs.size() != m_scales.size()");
+
+  for (unsigned int i = 0; i < m_scales.size(); ++i) {
+    double factor = 1./m_scales[i]/m_scales[i];
+    queso_require_msg(!(m_rvs[i]), "m_rvs[i] != NULL");
+    m_rvs[i] = new GaussianVectorRV<V, M>(m_prefix.c_str(),
+                                         *m_vectorSpace,
+                                         m_vectorSpace->zeroVector(),
+                                         factor*m_time_step*m_originalCovMatrix);
+  }
+}
+
+template <class V, class M>
+void
+MetropolisAdjustedLangevinTK<V, M>::print(std::ostream & os) const
+{
+  BaseTKGroup<V, M>::print(os);
+}
+
+template class MetropolisAdjustedLangevinTK<GslVector, GslMatrix>;
+
+}  // End namespace QUESO

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -1733,7 +1733,7 @@ MetropolisHastingsSG<P_V,P_M>::generateFullChain(
         queso_require_equal_to_msg(iRC, 0, "gettimeofday called failed");
       }
 
-      m_tk->rv(0).realizer().realization(tmpVecValues);
+      m_tk->rv(currentPositionData.vecValues()).realizer().realization(tmpVecValues);
 
       if (m_numDisabledParameters > 0) { // gpmsa2
         for (unsigned int paramId = 0; paramId < m_vectorSpace.dimLocal(); ++paramId) {

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -63,6 +63,7 @@ check_PROGRAMS += test_intercomm0_gravity
 check_PROGRAMS += test_seq_of_vec_hdf5_write
 check_PROGRAMS += test_optimizer_input_parameters
 check_PROGRAMS += test_sip_gslopt_options
+check_PROGRAMS += test_mala
 
 LDADD       = $(top_builddir)/src/libqueso.la
 
@@ -158,6 +159,7 @@ test_intercomm0_gravity_CPPFLAGS = -I$(srcdir)/test_intercomm0 $(AM_CPPFLAGS)
 test_seq_of_vec_hdf5_write_SOURCES = test_SequenceOfVectors/test_HDF5Write.C
 test_optimizer_input_parameters_SOURCES = test_optimizer/test_optimizer_input_parameters.C
 test_sip_gslopt_options_SOURCES = test_optimizer/test_sip_gslopt_options.C
+test_mala_SOURCES = test_algorithms/test_mala.C
 
 # Files to freedom stamp
 srcstamp =
@@ -218,6 +220,7 @@ srcstamp += $(test_intercomm0_gravity_SOURCES)
 srcstamp += $(test_seq_of_vec_hdf5_write_SOURCES)
 srcstamp += $(test_optimizer_input_parameters_SOURCES)
 srcstamp += $(test_sip_gslopt_options_SOURCES)
+srcstamp += $(test_mala_SOURCES)
 
 TESTS =
 TESTS += test_uqEnvironmentNonFatal
@@ -278,6 +281,7 @@ TESTS += test_intercomm0/test_intercomm0_gravity_run.sh
 TESTS += test_optimizer_input_parameters
 TESTS += test_sip_gslopt_options
 TESTS += test_SequenceOfVectors/test_seq_of_vec_hdf5_write_run.sh
+TESTS += test_mala
 
 XFAIL_TESTS = test_SequenceOfVectorsErase
 if ! MPI_ENABLED
@@ -321,6 +325,7 @@ EXTRA_DIST += test_intercomm0/gravity_2proc.txt
 EXTRA_DIST += test_intercomm0/test_intercomm0_gravity_run.sh
 EXTRA_DIST += test_optimizer/input_test_optimizer_input_parameters
 EXTRA_DIST += test_SequenceOfVectors/test_seq_of_vec_hdf5_write_run.sh
+EXTRA_DIST += test_algorithms/input_test_mala.txt
 
 CLEANFILES =
 CLEANFILES += test_Environment/debug_output_sub0.txt
@@ -341,6 +346,7 @@ clean-local:
 	rm -rf $(top_builddir)/test/output_test_serialEnv
 	rm -rf $(top_builddir)/test/output_test_intercomm0_gravity_1
 	rm -rf $(top_builddir)/test/output_test_intercomm0_gravity_2
+	rm -rf $(top_builddir)/test/output_test_mala
 
 if CODE_COVERAGE_ENABLED
   CLEANFILES += *.gcda *.gcno

--- a/test/test_algorithms/input_test_mala.txt
+++ b/test/test_algorithms/input_test_mala.txt
@@ -1,0 +1,53 @@
+###############################################
+# UQ Environment
+###############################################
+#env_help                = anything
+env_numSubEnvironments   = 1
+env_subDisplayFileName   = output_test_mala/display
+env_subDisplayAllowAll   = 0
+env_subDisplayAllowedSet = 0
+env_displayVerbosity     = 100000000
+env_syncVerbosity        = 0
+env_seed                 = 0
+
+###############################################
+# Statistical inverse problem (ip)
+###############################################
+#ip_help                 = anything
+ip_computeSolution      = 1
+ip_dataOutputFileName   = output_test_mala/sipOutput
+ip_dataOutputAllowedSet = 0
+
+###############################################
+# 'ip_': information for Metropolis-Hastings algorithm
+###############################################
+#ip_mh_help                 = anything
+ip_mh_dataOutputFileName   = output_test_mala/sipOutput
+ip_mh_dataOutputAllowedSet = 0
+
+ip_mh_rawChain_dataInputFileName    = .
+ip_mh_rawChain_size                 = 10000
+ip_mh_rawChain_generateExtra        = 0
+ip_mh_rawChain_displayPeriod        = 50000
+ip_mh_rawChain_measureRunTimes      = 1
+ip_mh_rawChain_dataOutputFileName   = output_test_mala/ip_raw_chain
+ip_mh_rawChain_dataOutputFileType   = txt
+ip_mh_rawChain_dataOutputAllowedSet = 0
+ip_mh_rawChain_computeStats         = 0
+
+ip_mh_algorithm                     = random_walk
+ip_mh_tk                            = mala
+
+ip_mh_displayCandidates             = 0
+ip_mh_putOutOfBoundsInChain         = 0
+ip_mh_tk_useLocalHessian            = 0
+ip_mh_tk_useNewtonComponent         = 1
+ip_mh_dr_maxNumExtraStages          = 3
+ip_mh_dr_listOfScalesForExtraStages = 5. 10. 20.
+ip_mh_am_initialNonAdaptInterval    = 0
+ip_mh_am_adaptInterval              = 0
+ip_mh_am_eta                        = 1.92
+ip_mh_am_epsilon                    = 1.e-5
+ip_mh_doLogitTransform              = 0
+
+ip_mh_filteredChain_generate             = 0

--- a/test/test_algorithms/input_test_mala.txt
+++ b/test/test_algorithms/input_test_mala.txt
@@ -6,7 +6,7 @@ env_numSubEnvironments   = 1
 env_subDisplayFileName   = output_test_mala/display
 env_subDisplayAllowAll   = 0
 env_subDisplayAllowedSet = 0
-env_displayVerbosity     = 100000000
+env_displayVerbosity     = 0
 env_syncVerbosity        = 0
 env_seed                 = 0
 

--- a/test/test_algorithms/test_mala.C
+++ b/test/test_algorithms/test_mala.C
@@ -1,0 +1,104 @@
+#include <queso/GenericScalarFunction.h>
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/UniformVectorRV.h>
+#include <queso/StatisticalInverseProblem.h>
+#include <queso/ScalarFunction.h>
+#include <queso/VectorSet.h>
+
+template<class V, class M>
+class Likelihood : public QUESO::BaseScalarFunction<V, M>
+{
+public:
+
+  Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domain)
+    : QUESO::BaseScalarFunction<V, M>(prefix, domain)
+  {
+    // Setup here
+  }
+
+  virtual ~Likelihood()
+  {
+    // Deconstruct here
+  }
+
+  virtual double lnValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const
+  {
+    if (gradVector != NULL) {
+      (*gradVector)[0] = -domainVector[0];
+    }
+
+    return -0.5 * domainVector[0] * domainVector[0];
+  }
+
+  virtual double actualValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const
+  {
+    return std::exp(this->lnValue(domainVector, domainDirection, gradVector,
+          hessianMatrix, hessianEffect));
+  }
+
+private:
+  // Maybe store the observed data, y, here.
+};
+
+int main(int argc, char ** argv) {
+  MPI_Init(&argc, &argv);
+
+  // Step 0 of 5: Set up environment
+  QUESO::FullEnvironment env(MPI_COMM_WORLD, argv[1], "", NULL);
+
+  unsigned int dim = 1;
+
+  // Step 1 of 5: Instantiate the parameter space
+  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
+      "param_", dim, NULL);
+
+  double min_val = -10000.0;
+  double max_val =  10000.0;
+
+  // Step 2 of 5: Set up the prior
+  QUESO::GslVector paramMins(paramSpace.zeroVector());
+  paramMins.cwSet(min_val);
+  QUESO::GslVector paramMaxs(paramSpace.zeroVector());
+  paramMaxs.cwSet(max_val);
+
+  QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix> paramDomain("param_",
+      paramSpace, paramMins, paramMaxs);
+
+  // Uniform prior here.  Could be a different prior.
+  QUESO::UniformVectorRV<QUESO::GslVector, QUESO::GslMatrix> priorRv("prior_",
+      paramDomain);
+
+  // Step 3 of 5: Set up the likelihood using the class above
+  Likelihood<QUESO::GslVector, QUESO::GslMatrix> lhood("llhd_", paramDomain);
+
+  // Step 4 of 5: Instantiate the inverse problem
+  QUESO::GenericVectorRV<QUESO::GslVector, QUESO::GslMatrix>
+    postRv("post_", paramSpace);
+
+  QUESO::StatisticalInverseProblem<QUESO::GslVector, QUESO::GslMatrix>
+    ip("", NULL, priorRv, lhood, postRv);
+
+  // Step 5 of 5: Solve the inverse problem
+  QUESO::GslVector paramInitials(paramSpace.zeroVector());
+
+  // Initial condition of the chain
+  for (unsigned int i = 0; i < dim; i++) {
+    paramInitials[i] = 0.0;
+  }
+
+  QUESO::GslMatrix proposalCovMatrix(paramSpace.zeroVector());
+
+  for (unsigned int i = 0; i < dim; i++) {
+    // Might need to tweak this
+    proposalCovMatrix(i, i) = atof(argv[2]);
+  }
+
+  ip.solveWithBayesMetropolisHastings(NULL, paramInitials, &proposalCovMatrix);
+
+  MPI_Finalize();
+
+  return 0;
+}


### PR DESCRIPTION
Depends on #466.

Replaces #404 and #408.

Implements the MALA algorithm (Roberts and Tweedie 1996).  The user can utilise it merely by passing `ip_mh_tk = mala` and `ip_mh_algorithm = random_walk` in the input file.

Each commit passes `make check` for me locally, documentation is there (though I could probably do a better job of documenting the input file options, since I haven't documented those).  I've also added a test for output of MALA when sampling an N(0, 1) Gaussian distribution.  This test could also be extended to include other Gaussians to show robustness.

This PR also implements a factory pattern for the acceptance ratio, it's technically not needed for this flavour of MALA but I envisage it being useful for incarnations of MALA that exhibit robust convergence with respect to increasing parameter dimension.