### PR TITLE
Make transition kernels user-updatable

### DIFF
--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -515,6 +515,25 @@ example_SharedPtr_CPPFLAGS = $(AM_CPPFLAGS)
 dist_pointers_DATA =
 dist_pointers_DATA += ${example_SharedPtr_SOURCES}
 
+####################################
+# Custom Transition Kernel Example #
+####################################
+custom_tkdir = $(prefix)/examples/custom_tk
+
+custom_tk_PROGRAMS = hessian_eg
+
+hessian_eg_SOURCES =
+hessian_eg_SOURCES += custom_tk/hessian_eg.C
+hessian_eg_SOURCES += custom_tk/hessian_eg_main.C
+custom_tk_HEADERS = custom_tk/hessian_eg.h
+hessian_eg_LDADD = $(top_builddir)/src/libqueso.la
+hessian_eg_CPPFLAGS = $(AM_CPPFLAGS)
+
+dist_custom_tk_DATA =
+dist_custom_tk_DATA += ${hessian_eg_SOURCES}
+dist_custom_tk_DATA += ${hessian_eg_HEADERS}
+
+
 if CODE_COVERAGE_ENABLED
   CLEANFILES = *.gcda *.gcno
 endif

--- a/examples/custom_tk/hessian_eg.C
+++ b/examples/custom_tk/hessian_eg.C
@@ -4,7 +4,7 @@
 // QUESO - a library to support the Quantification of Uncertainty
 // for Estimation, Simulation and Optimization
 //
-// Copyright (C) 2008-2015 The PECOS Development Team
+// Copyright (C) 2008-2017 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the Version 2.1 GNU Lesser General

--- a/examples/custom_tk/hessian_eg.C
+++ b/examples/custom_tk/hessian_eg.C
@@ -59,9 +59,6 @@ MyTransitionKernel<V, M>::updateTK()
 
     new_matrix(0, 0) = 1.0;
 
-    // Changing the matrix, so we set the dirty flag so AM can reset
-    this->setCovMatrixIsDirty(true);
-
     // Update all the RVs with new cov matrix (including all the ones used in
     // Delayed Rejection)
     this->updateLawCovMatrix(new_matrix);
@@ -69,6 +66,20 @@ MyTransitionKernel<V, M>::updateTK()
 
   // Just keeping track of a counter so I can trigger a 'dirty' matrix
   m_counter++;
+}
+
+template <class V, class M>
+bool
+MyTransitionKernel<V, M>::covMatrixIsDirty()
+{
+  return m_counter == 15;
+}
+
+template <class V, class M>
+void
+MyTransitionKernel<V, M>::cleanCovMatrix()
+{
+  // Don't need to do anything since we handled it in covMatrixIsDirty
 }
 
 // Explicit instantiation of the template

--- a/examples/custom_tk/hessian_eg.C
+++ b/examples/custom_tk/hessian_eg.C
@@ -39,7 +39,8 @@ MyTransitionKernel<V, M>::MyTransitionKernel(
   const M&                       covMatrix)
   :
   ScaledCovMatrixTKGroup<V, M>(prefix, vectorSpace, scales, covMatrix),
-  m_vectorSpace(vectorSpace)
+  m_vectorSpace(vectorSpace),
+  m_counter(0)
 {
   std::cout << "Hello from MyTransitionKernel!" << std::endl;
 }
@@ -53,14 +54,21 @@ template <class V, class M>
 void
 MyTransitionKernel<V, M>::updateTK()
 {
-  std::cout << "QUESO called `updateTK'" << std::endl;
+  if (m_counter == 15) {
+    GslMatrix new_matrix(m_vectorSpace.zeroVector());
 
-  GslMatrix new_matrix(m_vectorSpace.zeroVector());
-  new_matrix(0, 0) = 1.0;
+    new_matrix(0, 0) = 1.0;
 
-  // Update all the RVs with new cov matrix (including all the ones used in
-  // Delayed Rejection)
-  this->updateLawCovMatrix(new_matrix);
+    // Changing the matrix, so we set the dirty flag so AM can reset
+    this->setCovMatrixIsDirty(true);
+
+    // Update all the RVs with new cov matrix (including all the ones used in
+    // Delayed Rejection)
+    this->updateLawCovMatrix(new_matrix);
+  }
+
+  // Just keeping track of a counter so I can trigger a 'dirty' matrix
+  m_counter++;
 }
 
 // Explicit instantiation of the template

--- a/examples/custom_tk/hessian_eg.C
+++ b/examples/custom_tk/hessian_eg.C
@@ -1,0 +1,72 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "hessian_eg.h"
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/GaussianJointPdf.h>
+#include <queso/TKFactoryRandomWalk.h>
+
+namespace QUESO {
+
+template<class V, class M>
+MyTransitionKernel<V, M>::MyTransitionKernel(
+  const char*                    prefix,
+  const VectorSpace<V, M>& vectorSpace, // FIX ME: vectorSubset ???
+  const std::vector<double>&     scales,
+  const M&                       covMatrix)
+  :
+  ScaledCovMatrixTKGroup<V, M>(prefix, vectorSpace, scales, covMatrix),
+  m_vectorSpace(vectorSpace)
+{
+  std::cout << "Hello from MyTransitionKernel!" << std::endl;
+}
+
+template<class V, class M>
+MyTransitionKernel<V, M>::~MyTransitionKernel()
+{
+}
+
+template <class V, class M>
+void
+MyTransitionKernel<V, M>::updateTK()
+{
+  std::cout << "QUESO called `updateTK'" << std::endl;
+
+  GslMatrix new_matrix(m_vectorSpace.zeroVector());
+  new_matrix(0, 0) = 1.0;
+
+  // Update all the RVs with new cov matrix (including all the ones used in
+  // Delayed Rejection)
+  this->updateLawCovMatrix(new_matrix);
+}
+
+// Explicit instantiation of the template
+template class MyTransitionKernel<GslVector, GslMatrix>;
+
+// Register this TK with the appropriate factory
+TKFactoryRandomWalk<MyTransitionKernel<GslVector, GslMatrix> > tk_factory_mytk("my_tk");
+
+}  // End namespace QUESO

--- a/examples/custom_tk/hessian_eg.h
+++ b/examples/custom_tk/hessian_eg.h
@@ -4,7 +4,7 @@
 // QUESO - a library to support the Quantification of Uncertainty
 // for Estimation, Simulation and Optimization
 //
-// Copyright (C) 2008-2015 The PECOS Development Team
+// Copyright (C) 2008-2017 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the Version 2.1 GNU Lesser General

--- a/examples/custom_tk/hessian_eg.h
+++ b/examples/custom_tk/hessian_eg.h
@@ -44,6 +44,8 @@ public:
 
   virtual ~MyTransitionKernel();
   virtual void updateTK();
+  virtual bool covMatrixIsDirty();
+  virtual void cleanCovMatrix();
 
   const VectorSpace<V, M> & m_vectorSpace;
 

--- a/examples/custom_tk/hessian_eg.h
+++ b/examples/custom_tk/hessian_eg.h
@@ -1,0 +1,53 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef QUESO_CUSTOM_TK_HESS_H
+#define QUESO_CUSTOM_TK_HESS_H
+
+#include <queso/ScaledCovMatrixTKGroup.h>
+#include <queso/VectorRV.h>
+#include <queso/ScalarFunctionSynchronizer.h>
+
+namespace QUESO {
+
+class GslVector;
+class GslMatrix;
+
+template <class V = GslVector, class M = GslMatrix>
+class MyTransitionKernel : public ScaledCovMatrixTKGroup<V, M> {
+public:
+  MyTransitionKernel(const char * prefix,
+                     const VectorSpace<V, M> & vectorSpace,
+                     const std::vector<double> & scales,
+                     const M & covMatrix);
+
+  virtual ~MyTransitionKernel();
+  virtual void updateTK();
+
+  const VectorSpace<V, M> & m_vectorSpace;
+};
+
+}  // End namespace QUESO
+
+#endif // QUESO_CUSTOM_TK_HESS_H

--- a/examples/custom_tk/hessian_eg.h
+++ b/examples/custom_tk/hessian_eg.h
@@ -46,6 +46,9 @@ public:
   virtual void updateTK();
 
   const VectorSpace<V, M> & m_vectorSpace;
+
+private:
+  unsigned int m_counter;
 };
 
 }  // End namespace QUESO

--- a/examples/custom_tk/hessian_eg_main.C
+++ b/examples/custom_tk/hessian_eg_main.C
@@ -4,7 +4,7 @@
 // QUESO - a library to support the Quantification of Uncertainty
 // for Estimation, Simulation and Optimization
 //
-// Copyright (C) 2008-2015 The PECOS Development Team
+// Copyright (C) 2008-2017 The PECOS Development Team
 //
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the Version 2.1 GNU Lesser General

--- a/examples/custom_tk/hessian_eg_main.C
+++ b/examples/custom_tk/hessian_eg_main.C
@@ -1,0 +1,115 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2015 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/EnvironmentOptions.h>
+#include <queso/GenericScalarFunction.h>
+#include <queso/GslMatrix.h>
+#include <queso/UniformVectorRV.h>
+#include <queso/StatisticalInverseProblem.h>
+
+template <class V = QUESO::GslVector, class M = QUESO::GslMatrix>
+class Likelihood : public QUESO::BaseScalarFunction<V, M>
+{
+public:
+  Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domainSet)
+    : QUESO::BaseScalarFunction<V, M>(prefix, domainSet)
+  {
+  }
+
+  ~Likelihood()
+  {
+  }
+
+  virtual double lnValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const
+  {
+    return -0.5 * domainVector[0] * domainVector[0];
+  }
+
+  virtual double actualValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const
+  {
+    return std::exp(this->lnValue(domainVector, domainDirection, gradVector,
+          hessianMatrix, hessianEffect));
+  }
+
+  double m_obsStdDev;
+};
+
+int main(int argc, char ** argv)
+{
+#ifdef QUESO_HAS_MPI
+  MPI_Init(&argc,&argv);
+#endif
+
+  QUESO::EnvOptionsValues options;
+  options.m_numSubEnvironments = 1;
+  options.m_subDisplayFileName = ".";
+  options.m_subDisplayAllowAll = 0;
+  options.m_subDisplayAllowedSet.insert(0);
+  options.m_seed = 1.0;
+  options.m_checkingLevel = 1;
+  options.m_displayVerbosity = 0;
+
+#ifdef QUESO_HAS_MPI
+  QUESO::FullEnvironment env(MPI_COMM_WORLD, "", "", &options);
+#else
+  QUESO::FullEnvironment env("", "", &options);
+#endif
+
+  QUESO::VectorSpace<> paramSpace(env, "param_", 1, NULL);
+
+  QUESO::GslVector paramMins(paramSpace.zeroVector());
+  QUESO::GslVector paramMaxs(paramSpace.zeroVector());
+
+  paramMins.cwSet(-INFINITY);
+  paramMaxs.cwSet( INFINITY);
+
+  QUESO::BoxSubset<> paramDomain("param_", paramSpace, paramMins, paramMaxs);
+
+  Likelihood<> likelihood("", paramDomain);
+
+  // Step 4 of 5: Instantiate the inverse problem
+  QUESO::UniformVectorRV<> priorRv("prior_", paramDomain);
+  QUESO::GenericVectorRV<> postRv("post_", paramSpace);
+  QUESO::StatisticalInverseProblem<> ip("", NULL, priorRv, likelihood, postRv);
+
+  // Step 5 of 5: Solve the inverse problem
+  QUESO::GslVector paramInitials(paramSpace.zeroVector());
+
+  QUESO::GslMatrix proposalCovMatrix(paramSpace.zeroVector());
+  proposalCovMatrix(0,0) = 10.0;
+
+  QUESO::MhOptionsValues mh_options;
+  mh_options.m_tk = "my_tk";
+  mh_options.m_rawChainSize = 5;
+
+  ip.solveWithBayesMetropolisHastings(&mh_options, paramInitials, &proposalCovMatrix);
+
+#ifdef QUESO_HAS_MPI
+  MPI_Finalize();
+#endif
+
+  return 0;
+}

--- a/examples/custom_tk/hessian_eg_main.C
+++ b/examples/custom_tk/hessian_eg_main.C
@@ -99,11 +99,13 @@ int main(int argc, char ** argv)
   QUESO::GslVector paramInitials(paramSpace.zeroVector());
 
   QUESO::GslMatrix proposalCovMatrix(paramSpace.zeroVector());
-  proposalCovMatrix(0,0) = 10.0;
+  proposalCovMatrix(0,0) = 1e-6;
 
   QUESO::MhOptionsValues mh_options;
   mh_options.m_tk = "my_tk";
-  mh_options.m_rawChainSize = 5;
+  mh_options.m_rawChainSize = 50;
+  mh_options.m_amInitialNonAdaptInterval = 10;
+  mh_options.m_amAdaptInterval = 10;
 
   ip.solveWithBayesMetropolisHastings(&mh_options, paramInitials, &proposalCovMatrix);
 

--- a/src/stats/inc/HessianCovMatricesTKGroup.h
+++ b/src/stats/inc/HessianCovMatricesTKGroup.h
@@ -79,6 +79,9 @@ public:
   void                          clearPreComputingPositions();
 
   virtual unsigned int set_dr_stage(unsigned int stageId);
+
+  virtual bool covMatrixIsDirty() { return false; }
+  virtual void cleanCovMatrix() { }
   //@}
 
   //! @name I/O methods

--- a/src/stats/inc/MLSamplingLevelOptions.h
+++ b/src/stats/inc/MLSamplingLevelOptions.h
@@ -109,6 +109,7 @@
 #define UQ_ML_SAMPLING_L_DO_LOGIT_TRANSFORM                                   0
 #define UQ_ML_SAMPLING_L_ALGORITHM                                            "random_walk"
 #define UQ_ML_SAMPLING_L_TK                                                   "random_walk"
+#define UQ_ML_SAMPLING_L_UPDATE_INTERVAL                                      1
 
 namespace QUESO {
 
@@ -365,6 +366,9 @@ public:
   //! Which transition kernel to use for sampling
   std::string m_tk;
 
+  //! How often to call the TK's updateTK method
+  unsigned int m_updateInterval;
+
 private:
   //! Copies the option values from \c srcOptions to \c this.
   void   copyOptionsValues(const MLSamplingLevelOptions& srcOptions);
@@ -453,6 +457,7 @@ private:
   std::string                   m_option_doLogitTransform;
   std::string                   m_option_algorithm;
   std::string                   m_option_tk;
+  std::string                   m_option_updateInterval;
 
   void checkOptions(const BaseEnvironment * env);
 

--- a/src/stats/inc/MetropolisAdjustedLangevinTK.h
+++ b/src/stats/inc/MetropolisAdjustedLangevinTK.h
@@ -85,6 +85,9 @@ public:
 
   //! Clears the pre-computing positions \c m_preComputingPositions[stageId]
   void clearPreComputingPositions();
+
+  virtual bool covMatrixIsDirty() { return false; }
+  virtual void cleanCovMatrix() { }
   //@}
 
   //! @name I/O methods

--- a/src/stats/inc/MetropolisHastingsSG.h
+++ b/src/stats/inc/MetropolisHastingsSG.h
@@ -345,6 +345,8 @@ private:
       boxSubset);
 
   bool m_userDidNotProvideOptions;
+
+  unsigned int m_latestDirtyCovMatrixIteration;
 };
 
 }  // End namespace QUESO

--- a/src/stats/inc/MetropolisHastingsSGOptions.h
+++ b/src/stats/inc/MetropolisHastingsSGOptions.h
@@ -98,6 +98,7 @@
 #define UQ_MH_SG_DO_LOGIT_TRANSFORM                                   1
 #define UQ_MH_SG_ALGORITHM                                            "logit_random_walk"
 #define UQ_MH_SG_TK                                                   "logit_random_walk"
+#define UQ_MH_SG_UPDATE_INTERVAL                                      1
 
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
 namespace boost {
@@ -612,6 +613,9 @@ public:
   //! Which transition kernel to use for MCMC.  Default is "random_walk"
   std::string m_tk;
 
+  //! How often to call the TK's updateTK method.  Default is 1.
+  unsigned int m_updateInterval;
+
 private:
   // Cache a pointer to the environment.
   const BaseEnvironment * m_env;
@@ -737,6 +741,8 @@ private:
   std::string                   m_option_algorithm;
   //! Option name for MhOptionsValues::m_tk.  Option name is m_prefix + "mh_tk"
   std::string                   m_option_tk;
+  //! Option name for MhOptionsValues::m_updateInterval.  Option name is m_prefix + "mh_updateInterval"
+  std::string                   m_option_updateInterval;
 
   //! Copies the option values from \c src to \c this.
   void copy(const MhOptionsValues& src);
@@ -887,6 +893,7 @@ private:
   std::string                   m_option_doLogitTransform;
   std::string                   m_option_algorithm;
   std::string                   m_option_tk;
+  std::string                   m_option_updateInterval;
 };
 
 std::ostream& operator<<(std::ostream& os, const MetropolisHastingsSGOptions& obj);

--- a/src/stats/inc/ScaledCovMatrixTKGroup.h
+++ b/src/stats/inc/ScaledCovMatrixTKGroup.h
@@ -83,6 +83,9 @@ public:
 
   //! Sets the internal \c m_stageId varialbe to \c stageId
   virtual unsigned int set_dr_stage(unsigned int stageId);
+
+  virtual bool covMatrixIsDirty() { return false; }
+  virtual void cleanCovMatrix() { }
   //@}
 
   //! @name I/O methods

--- a/src/stats/inc/TKGroup.h
+++ b/src/stats/inc/TKGroup.h
@@ -100,6 +100,13 @@ public:
    * Default behaviour is a no-op.
    */
   virtual void updateTK() { };
+
+  //! This flag determines whether or not the user has 'dirtied' the covariance
+  //! matrix, thereby necessitating an AM reset
+  bool covMatrixIsDirty() const;
+
+  //! Sets the dirty flag for the covariance matrix.
+  void setCovMatrixIsDirty(bool isDirty);
   //@}
 
   //! @name I/O methods
@@ -118,6 +125,10 @@ protected:
         std::vector<BaseVectorRV<V,M>* > m_rvs; // Gaussian, not Base... And nothing const...
   unsigned int m_stageId;
 
+private:
+  //! This flag determines whether or not the user has 'dirtied' the covariance
+  //! matrix, thereby necessitating an AM reset
+  bool m_dirtyCovarianceMatrix;
 };
 
 }  // End namespace QUESO

--- a/src/stats/inc/TKGroup.h
+++ b/src/stats/inc/TKGroup.h
@@ -93,6 +93,13 @@ public:
 
   //! Does nothing.  Subclasses may re-implement.  Returns the current stage id.
   virtual unsigned int set_dr_stage(unsigned int stageId);
+
+  //! The user can override this method to implement state-dependent
+  //! transition kernel behaviour.
+  /*!
+   * Default behaviour is a no-op.
+   */
+  virtual void updateTK() { };
   //@}
 
   //! @name I/O methods
@@ -110,6 +117,7 @@ protected:
         std::vector<const V*>            m_preComputingPositions;
         std::vector<BaseVectorRV<V,M>* > m_rvs; // Gaussian, not Base... And nothing const...
   unsigned int m_stageId;
+
 };
 
 }  // End namespace QUESO

--- a/src/stats/inc/TKGroup.h
+++ b/src/stats/inc/TKGroup.h
@@ -101,12 +101,20 @@ public:
    */
   virtual void updateTK() { };
 
-  //! This flag determines whether or not the user has 'dirtied' the covariance
-  //! matrix, thereby necessitating an AM reset
-  bool covMatrixIsDirty() const;
+  //! This method determines whether or not the user has 'dirtied' the
+  //! covariance matrix, thereby necessitating an AM reset.
+  /*!
+   * Should return true if the cov matrix was modified in such a way to affect
+   * the Adaptive Metropolis sample covariance calculation.
+   */
+  virtual bool covMatrixIsDirty() = 0;
 
-  //! Sets the dirty flag for the covariance matrix.
-  void setCovMatrixIsDirty(bool isDirty);
+  //! Performs whatever cleanup is needed (usually just resetting an internal
+  //! bool flag) after the covariance matrix was modified.
+  /*!
+   * After this method is called, covMatrixIsDirty should return \c true.
+   */
+  virtual void cleanCovMatrix() = 0;
   //@}
 
   //! @name I/O methods
@@ -124,11 +132,6 @@ protected:
         std::vector<const V*>            m_preComputingPositions;
         std::vector<BaseVectorRV<V,M>* > m_rvs; // Gaussian, not Base... And nothing const...
   unsigned int m_stageId;
-
-private:
-  //! This flag determines whether or not the user has 'dirtied' the covariance
-  //! matrix, thereby necessitating an AM reset
-  bool m_dirtyCovarianceMatrix;
 };
 
 }  // End namespace QUESO

--- a/src/stats/inc/TransformedScaledCovMatrixTKGroup.h
+++ b/src/stats/inc/TransformedScaledCovMatrixTKGroup.h
@@ -91,6 +91,9 @@ public:
   void clearPreComputingPositions();
 
   virtual unsigned int set_dr_stage(unsigned int stageId);
+
+  virtual bool covMatrixIsDirty() { return false; }
+  virtual void cleanCovMatrix() { }
   //@}
 
   //! @name I/O methods

--- a/src/stats/src/MLSamplingLevelOptions.C
+++ b/src/stats/src/MLSamplingLevelOptions.C
@@ -183,7 +183,8 @@ MLSamplingLevelOptions::MLSamplingLevelOptions(
     m_option_am_epsilon                                (m_prefix + "am_epsilon"                                ),
     m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          ),
     m_option_algorithm                                 (m_prefix + "algorithm"                                 ),
-    m_option_tk                                        (m_prefix + "tk"                                        )
+    m_option_tk                                        (m_prefix + "tk"                                        ),
+    m_option_updateInterval                            (m_prefix + "updateInterval"                            )
 {
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
   this->defineAllOptions();
@@ -268,6 +269,7 @@ MLSamplingLevelOptions::defineAllOptions()
   m_parser->registerOption<bool        >(m_option_doLogitTransform,                           UQ_ML_SAMPLING_L_DO_LOGIT_TRANSFORM        , "flag for doing logit transform for bounded domains"              );
   m_parser->registerOption<std::string >(m_option_algorithm,                                  UQ_ML_SAMPLING_L_ALGORITHM                 , "which algorithm to use for sampling"                             );
   m_parser->registerOption<std::string >(m_option_tk,                                         UQ_ML_SAMPLING_L_TK                        , "which transition kernel to use for sampling"                     );
+  m_parser->registerOption<unsigned int>(m_option_updateInterval,                             UQ_ML_SAMPLING_L_UPDATE_INTERVAL           , "how often to call TK's updateTK method"                          );
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 }
 
@@ -345,6 +347,7 @@ MLSamplingLevelOptions::getAllOptions()
   m_parser->getOption<bool        >(m_option_doLogitTransform,                           m_doLogitTransform);
   m_parser->getOption<std::string >(m_option_algorithm,                                  m_algorithm);
   m_parser->getOption<std::string >(m_option_tk,                                         m_tk);
+  m_parser->getOption<unsigned int>(m_option_updateInterval,                             m_updateInterval);
 #else
   m_help = m_env.input()(m_option_help,                                       UQ_ML_SAMPLING_L_HELP                      );
 #ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY
@@ -477,6 +480,7 @@ MLSamplingLevelOptions::getAllOptions()
   m_doLogitTransform                          = m_env.input()(m_option_doLogitTransform,                           UQ_ML_SAMPLING_L_DO_LOGIT_TRANSFORM        );
   m_algorithm                                 = m_env.input()(m_option_algorithm,                                  UQ_ML_SAMPLING_L_ALGORITHM                 );
   m_tk                                        = m_env.input()(m_option_tk,                                         UQ_ML_SAMPLING_L_TK                        );
+  m_updateInterval                            = m_env.input()(m_option_updateInterval,                             UQ_ML_SAMPLING_L_UPDATE_INTERVAL           );
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 }
 
@@ -564,6 +568,7 @@ MLSamplingLevelOptions::copyOptionsValues(const MLSamplingLevelOptions& srcOptio
   m_doLogitTransform                          = srcOptions.m_doLogitTransform;
   m_algorithm                                 = srcOptions.m_algorithm;
   m_tk                                        = srcOptions.m_tk;
+  m_updateInterval                            = srcOptions.m_updateInterval;
 
   return;
 }
@@ -821,6 +826,7 @@ MLSamplingLevelOptions::print(std::ostream& os) const
      << "\n" << m_option_doLogitTransform                           << " = " << m_doLogitTransform
      << "\n" << m_option_algorithm                                  << " = " << m_algorithm
      << "\n" << m_option_tk                                         << " = " << m_tk
+     << "\n" << m_option_updateInterval                             << " = " << m_updateInterval
      << std::endl;
 
   return;

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -1562,6 +1562,9 @@ MetropolisHastingsSG<P_V,P_M>::generateFullChain(
 
     m_tk->clearPreComputingPositions();
 
+    // Possibly user-overridded to implement strange things, but we allow it.
+    m_tk->updateTK();
+
     if ((m_env.subDisplayFile()                   ) &&
         (m_env.displayVerbosity() >= 5            ) &&
         (m_optionsObj->m_totallyMute == false)) {

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -1844,7 +1844,9 @@ MetropolisHastingsSG<P_V,P_M>::generateFullChain(
     }
 
     // Possibly user-overridden to implement strange things, but we allow it.
-    m_tk->updateTK();
+    if (positionId % m_optionsObj->m_updateInterval == 0) {
+      m_tk->updateTK();
+    }
 
     // If the user dirtied the cov matrix, keep track of the latest iteration
     // number it happened at.

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -1562,9 +1562,6 @@ MetropolisHastingsSG<P_V,P_M>::generateFullChain(
 
     m_tk->clearPreComputingPositions();
 
-    // Possibly user-overridded to implement strange things, but we allow it.
-    m_tk->updateTK();
-
     if ((m_env.subDisplayFile()                   ) &&
         (m_env.displayVerbosity() >= 5            ) &&
         (m_optionsObj->m_totallyMute == false)) {
@@ -1841,6 +1838,9 @@ MetropolisHastingsSG<P_V,P_M>::generateFullChain(
         }
       }
     }
+
+    // Possibly user-overridden to implement strange things, but we allow it.
+    m_tk->updateTK();
 
     //****************************************************
     // Point 5/6 of logic for new position

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -169,7 +169,8 @@ MetropolisHastingsSG<P_V,P_M>::MetropolisHastingsSG(
   m_computeInitialPriorAndLikelihoodValues(true),
   m_initialLogPriorValue      (0.),
   m_initialLogLikelihoodValue (0.),
-  m_userDidNotProvideOptions(false)
+  m_userDidNotProvideOptions(false),
+  m_latestDirtyCovMatrixIteration(0)
 {
   if (inputProposalCovMatrix != NULL) {
     m_initialProposalCovMatrix = *inputProposalCovMatrix;
@@ -250,7 +251,8 @@ MetropolisHastingsSG<P_V,P_M>::MetropolisHastingsSG(
   m_computeInitialPriorAndLikelihoodValues(false),
   m_initialLogPriorValue      (initialLogPrior),
   m_initialLogLikelihoodValue (initialLogLikelihood),
-  m_userDidNotProvideOptions(false)
+  m_userDidNotProvideOptions(false),
+  m_latestDirtyCovMatrixIteration(0)
 {
   if (inputProposalCovMatrix != NULL) {
     m_initialProposalCovMatrix = *inputProposalCovMatrix;
@@ -326,7 +328,8 @@ MetropolisHastingsSG<P_V,P_M>::MetropolisHastingsSG(
   m_computeInitialPriorAndLikelihoodValues(true),
   m_initialLogPriorValue      (0.),
   m_initialLogLikelihoodValue (0.),
-  m_userDidNotProvideOptions(true)
+  m_userDidNotProvideOptions(true),
+  m_latestDirtyCovMatrixIteration(0)
 {
   // We do this dance because one of the MetropolisHastingsSGOptions
   // constructors takes one of the old-style MLSamplingLevelOptions options
@@ -393,7 +396,8 @@ MetropolisHastingsSG<P_V,P_M>::MetropolisHastingsSG(
   m_computeInitialPriorAndLikelihoodValues(false),
   m_initialLogPriorValue      (initialLogPrior),
   m_initialLogLikelihoodValue (initialLogLikelihood),
-  m_userDidNotProvideOptions(true)
+  m_userDidNotProvideOptions(true),
+  m_latestDirtyCovMatrixIteration(0)
 {
   // We do this dance because one of the MetropolisHastingsSGOptions
   // constructors takes one of the old-style MLSamplingLevelOptions options
@@ -1841,6 +1845,12 @@ MetropolisHastingsSG<P_V,P_M>::generateFullChain(
 
     // Possibly user-overridden to implement strange things, but we allow it.
     m_tk->updateTK();
+
+    // If the user dirtied the cov matrix, keep track of the latest iteration
+    // number it happened at
+    if (m_tk->covMatrixIsDirty()) {
+      m_latestDirtyCovMatrixIteration = positionId;
+    }
 
     //****************************************************
     // Point 5/6 of logic for new position

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -2054,7 +2054,7 @@ MetropolisHastingsSG<P_V, P_M>::adapt(unsigned int positionId,
 
     // Transform to the space without boundaries.  This is the space
     // where the proposal distribution is Gaussian
-    if (this->m_optionsObj->m_algorithm == "logit_random_walk") {
+    if (this->m_optionsObj->m_tk == "logit_random_walk") {
       // Only do this when we don't use the Hessian (this may change in
       // future, but transformToGaussianSpace() is only implemented in
       // TransformedScaledCovMatrixTKGroup
@@ -2239,11 +2239,11 @@ MetropolisHastingsSG<P_V, P_M>::adapt(unsigned int positionId,
 
     // Transform the proposal covariance matrix if we have Logit transforms
     // turned on
-    if (this->m_optionsObj->m_algorithm == "logit_random_walk") {
+    if (this->m_optionsObj->m_tk == "logit_random_walk") {
       (dynamic_cast<TransformedScaledCovMatrixTKGroup<P_V,P_M>* >(m_tk.get()))
         ->updateLawCovMatrix(tmpMatrix);
     }
-    else if (this->m_optionsObj->m_algorithm == "random_walk") {
+    else if (this->m_optionsObj->m_tk == "random_walk") {
       (dynamic_cast<ScaledCovMatrixTKGroup<P_V,P_M>* >(m_tk.get()))
         ->updateLawCovMatrix(tmpMatrix);
     }

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -2238,12 +2238,16 @@ MetropolisHastingsSG<P_V, P_M>::adapt(unsigned int positionId,
     }
 
     // Transform the proposal covariance matrix if we have Logit transforms
-    // turned on
+    // turned on.
+    //
+    // This logic should really be done inside the kernel itself
     if (this->m_optionsObj->m_tk == "logit_random_walk") {
       (dynamic_cast<TransformedScaledCovMatrixTKGroup<P_V,P_M>* >(m_tk.get()))
         ->updateLawCovMatrix(tmpMatrix);
     }
-    else if (this->m_optionsObj->m_tk == "random_walk") {
+    else {
+      // Assume that if we're not doing a logit transform, we're doing a random
+      // something sensible
       (dynamic_cast<ScaledCovMatrixTKGroup<P_V,P_M>* >(m_tk.get()))
         ->updateLawCovMatrix(tmpMatrix);
     }

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -1851,9 +1851,9 @@ MetropolisHastingsSG<P_V,P_M>::generateFullChain(
     if (m_tk->covMatrixIsDirty()) {
       m_latestDirtyCovMatrixIteration = positionId;
 
-      // Set the dirty flag to false so that the last dirty iteration tracker
+      // Clean the covariance matrix so that the last dirty iteration tracker
       // doesn't get wiped in the next iteration.
-      m_tk->setCovMatrixIsDirty(false);
+      m_tk->cleanCovMatrix();
     }
 
     //****************************************************

--- a/src/stats/src/MetropolisHastingsSGOptions.C
+++ b/src/stats/src/MetropolisHastingsSGOptions.C
@@ -106,6 +106,7 @@ MhOptionsValues::MhOptionsValues(
     m_doLogitTransform                         (UQ_MH_SG_DO_LOGIT_TRANSFORM),
     m_algorithm                                (UQ_MH_SG_ALGORITHM),
     m_tk                                       (UQ_MH_SG_TK),
+    m_updateInterval                           (UQ_MH_SG_UPDATE_INTERVAL),
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
     m_alternativeRawSsOptionsValues            (),
     m_alternativeFilteredSsOptionsValues       (),
@@ -171,7 +172,8 @@ MhOptionsValues::MhOptionsValues(
     m_option_outputLogTarget                           (m_prefix + "outputLogTarget"                           ),
     m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          ),
     m_option_algorithm                                 (m_prefix + "algorithm"                                 ),
-    m_option_tk                                        (m_prefix + "tk"                                        )
+    m_option_tk                                        (m_prefix + "tk"                                        ),
+    m_option_updateInterval                            (m_prefix + "updateInterval"                            )
 {
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
   if (alternativeRawSsOptionsValues     ) m_alternativeRawSsOptionsValues      = *alternativeRawSsOptionsValues;
@@ -247,6 +249,7 @@ MhOptionsValues::MhOptionsValues(
     m_doLogitTransform                         (UQ_MH_SG_DO_LOGIT_TRANSFORM),
     m_algorithm                                (UQ_MH_SG_ALGORITHM),
     m_tk                                       (UQ_MH_SG_TK),
+    m_updateInterval                           (UQ_MH_SG_UPDATE_INTERVAL),
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
     m_alternativeRawSsOptionsValues            (),
     m_alternativeFilteredSsOptionsValues       (),
@@ -312,7 +315,8 @@ MhOptionsValues::MhOptionsValues(
     m_option_outputLogTarget                           (m_prefix + "outputLogTarget"                           ),
     m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          ),
     m_option_algorithm                                 (m_prefix + "algorithm"                                 ),
-    m_option_tk                                        (m_prefix + "tk"                                        )
+    m_option_tk                                        (m_prefix + "tk"                                        ),
+    m_option_updateInterval                            (m_prefix + "updateInterval"                            )
 {
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
   if (alternativeRawSsOptionsValues     ) m_alternativeRawSsOptionsValues      = *alternativeRawSsOptionsValues;
@@ -378,6 +382,7 @@ MhOptionsValues::MhOptionsValues(
   m_parser->registerOption<bool        >(m_option_doLogitTransform,                           UQ_MH_SG_DO_LOGIT_TRANSFORM                                  , "flag to toggle logit transform for bounded domains"         );
   m_parser->registerOption<std::string >(m_option_algorithm,                                  UQ_MH_SG_ALGORITHM                                           , "which MCMC algorithm to use"                                );
   m_parser->registerOption<std::string >(m_option_tk,                                         UQ_MH_SG_TK                                                  , "which MCMC transition kernel to use"                        );
+  m_parser->registerOption<unsigned int>(m_option_updateInterval,                             UQ_MH_SG_UPDATE_INTERVAL                                     , "how often to call updateTK method"                          );
 
   m_parser->scanInputFile();
 
@@ -439,6 +444,7 @@ MhOptionsValues::MhOptionsValues(
   m_parser->getOption<bool        >(m_option_doLogitTransform,                           m_doLogitTransform);
   m_parser->getOption<std::string >(m_option_algorithm,                                  m_algorithm);
   m_parser->getOption<std::string >(m_option_tk,                                         m_tk);
+  m_parser->getOption<unsigned int>(m_option_updateInterval,                             m_updateInterval);
 #else
   m_help = m_env->input()(m_option_help, UQ_MH_SG_HELP);
   m_dataOutputFileName = m_env->input()(m_option_dataOutputFileName, UQ_MH_SG_DATA_OUTPUT_FILE_NAME_ODV);
@@ -553,6 +559,7 @@ MhOptionsValues::MhOptionsValues(
   m_doLogitTransform = m_env->input()(m_option_doLogitTransform, UQ_MH_SG_DO_LOGIT_TRANSFORM);
   m_algorithm = m_env->input()(m_option_algorithm, UQ_MH_SG_ALGORITHM);
   m_tk = m_env->input()(m_option_tk, UQ_MH_SG_TK);
+  m_updateInterval = m_env->input()(m_option_updateInterval, UQ_MH_SG_UPDATE_INTERVAL);
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 
   checkOptions(env);
@@ -724,6 +731,7 @@ MhOptionsValues::copy(const MhOptionsValues& src)
   m_doLogitTransform                          = src.m_doLogitTransform;
   m_algorithm                                 = src.m_algorithm;
   m_tk                                        = src.m_tk;
+  m_updateInterval                            = src.m_updateInterval;
 
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
   m_alternativeRawSsOptionsValues             = src.m_alternativeRawSsOptionsValues;
@@ -815,6 +823,7 @@ std::ostream & operator<<(std::ostream & os, const MhOptionsValues & obj)
      << "\n" << obj.m_option_doLogitTransform                           << " = " << obj.m_doLogitTransform
      << "\n" << obj.m_option_algorithm                                  << " = " << obj.m_algorithm
      << "\n" << obj.m_option_tk                                         << " = " << obj.m_tk
+     << "\n" << obj.m_option_updateInterval                             << " = " << obj.m_updateInterval
      << std::endl;
 
   return os;
@@ -900,7 +909,8 @@ MetropolisHastingsSGOptions::MetropolisHastingsSGOptions(
   m_option_outputLogTarget                           (m_prefix + "outputLogTarget"                           ),
   m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          ),
   m_option_algorithm                                 (m_prefix + "algorithm"                                 ),
-  m_option_tk                                        (m_prefix + "tk"                                        )
+  m_option_tk                                        (m_prefix + "tk"                                        ),
+  m_option_updateInterval                            (m_prefix + "updateInterval"                            )
 {
   queso_deprecated();
 
@@ -981,7 +991,8 @@ MetropolisHastingsSGOptions::MetropolisHastingsSGOptions(
   m_option_outputLogTarget                           (m_prefix + "outputLogTarget"                           ),
   m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          ),
   m_option_algorithm                                 (m_prefix + "algorithm"                                 ),
-  m_option_tk                                        (m_prefix + "tk"                                        )
+  m_option_tk                                        (m_prefix + "tk"                                        ),
+  m_option_updateInterval                            (m_prefix + "updateInterval"                            )
 {
   queso_deprecated();
 
@@ -1082,7 +1093,8 @@ MetropolisHastingsSGOptions::MetropolisHastingsSGOptions(
   m_option_outputLogTarget                           (m_prefix + "outputLogTarget"                           ),
   m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          ),
   m_option_algorithm                                 (m_prefix + "algorithm"                                 ),
-  m_option_tk                                        (m_prefix + "tk"                                        )
+  m_option_tk                                        (m_prefix + "tk"                                        ),
+  m_option_updateInterval                            (m_prefix + "updateInterval"                            )
 {
   queso_deprecated();
 
@@ -1143,6 +1155,7 @@ MetropolisHastingsSGOptions::MetropolisHastingsSGOptions(
   m_ov.m_doLogitTransform                          = mlOptions.m_doLogitTransform;
   m_ov.m_algorithm                                 = mlOptions.m_algorithm;
   m_ov.m_tk                                        = mlOptions.m_tk;
+  m_ov.m_updateInterval                            = mlOptions.m_updateInterval;
 
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
 //m_ov.m_alternativeRawSsOptionsValues             = mlOptions.; // dakota
@@ -1294,6 +1307,7 @@ MetropolisHastingsSGOptions::print(std::ostream& os) const
      << "\n" << m_option_doLogitTransform                           << " = " << m_ov.m_doLogitTransform
      << "\n" << m_option_algorithm                                  << " = " << m_ov.m_algorithm
      << "\n" << m_option_tk                                         << " = " << m_ov.m_tk
+     << "\n" << m_option_updateInterval                             << " = " << m_ov.m_updateInterval
      << std::endl;
 
   return;
@@ -1365,6 +1379,7 @@ MetropolisHastingsSGOptions::defineMyOptions(boost::program_options::options_des
     (m_option_doLogitTransform.c_str(),                           boost::program_options::value<bool        >()->default_value(UQ_MH_SG_DO_LOGIT_TRANSFORM                                  ), "flag to toggle logit transform for bounded domains"         )
     (m_option_algorithm.c_str(),                                  boost::program_options::value<std::string >()->default_value(UQ_MH_SG_ALGORITHM                                           ), "which mcmc algorithm to use"                                )
     (m_option_tk.c_str(),                                         boost::program_options::value<std::string >()->default_value(UQ_MH_SG_TK                                                  ), "which mcmc tk to use"                                       )
+    (m_option_updateInterval.c_str(),                             boost::program_options::value<unsigned int>()->default_value(UQ_MH_SG_UPDATE_INTERVAL                                     ), "how often to call updateTK method"                          )
   ;
 
   return;
@@ -1690,6 +1705,10 @@ MetropolisHastingsSGOptions::getMyOptionValues(boost::program_options::options_d
 
   if (m_env.allOptionsMap().count(m_option_tk)) {
     m_ov.m_tk = ((const boost::program_options::variable_value&) m_env.allOptionsMap()[m_option_tk]).as<std::string>();
+  }
+
+  if (m_env.allOptionsMap().count(m_option_updateInterval)) {
+    m_ov.m_updateInterval = ((const boost::program_options::variable_value&) m_env.allOptionsMap()[m_option_updateInterval]).as<unsigned int>();
   }
 }
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS

--- a/src/stats/src/TKGroup.C
+++ b/src/stats/src/TKGroup.C
@@ -127,6 +127,20 @@ BaseTKGroup<V, M>::set_dr_stage(unsigned int stageId)
   return this->m_stageId;
 }
 
+template <class V, class M>
+bool
+BaseTKGroup<V, M>::covMatrixIsDirty() const
+{
+  return this->m_dirtyCovarianceMatrix;
+}
+
+template <class V, class M>
+void
+BaseTKGroup<V, M>::setCovMatrixIsDirty(bool isDirty)
+{
+  this->m_dirtyCovarianceMatrix = isDirty;
+}
+
 // I/O methods---------------------------------------
 template<class V, class M>
 void

--- a/src/stats/src/TKGroup.C
+++ b/src/stats/src/TKGroup.C
@@ -127,20 +127,6 @@ BaseTKGroup<V, M>::set_dr_stage(unsigned int stageId)
   return this->m_stageId;
 }
 
-template <class V, class M>
-bool
-BaseTKGroup<V, M>::covMatrixIsDirty() const
-{
-  return this->m_dirtyCovarianceMatrix;
-}
-
-template <class V, class M>
-void
-BaseTKGroup<V, M>::setCovMatrixIsDirty(bool isDirty)
-{
-  this->m_dirtyCovarianceMatrix = isDirty;
-}
-
 // I/O methods---------------------------------------
 template<class V, class M>
 void

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -76,6 +76,7 @@ check_PROGRAMS += SipSfpExample_gsl
 check_PROGRAMS += SequenceExample_gsl
 check_PROGRAMS += BimodalExample_gsl
 check_PROGRAMS += test_fd_fallback
+check_PROGRAMS += test_custom_tk_am
 
 LDADD       = $(top_builddir)/src/libqueso.la
 
@@ -245,6 +246,12 @@ BimodalExample_gsl_SOURCES += t04_bimodal/example_compute.h
 BimodalExample_gsl_SOURCES += t04_bimodal/example_likelihood.h
 BimodalExample_gsl_CPPFLAGS = -I$(srcdir)/t04_bimodal $(AM_CPPFLAGS)
 
+test_custom_tk_am_SOURCES =
+test_custom_tk_am_SOURCES += custom_tk/adaptive_metropolis_main.C
+test_custom_tk_am_SOURCES += custom_tk/adaptive_metropolis.C
+test_custom_tk_am_SOURCES += test_custom_tk/adaptive_metropolis.h
+test_custom_tk_am_CPPFLAGS = -I$(srcdir)/custom_tk $(AM_CPPFLAGS)
+
 TESTS =
 TESTS += unit_driver
 TESTS += test_boxsubset_centroid
@@ -322,6 +329,7 @@ TESTS += t02_sip_sfp/rtest02.sh
 TESTS += t04_bimodal/rtest04.sh
 TESTS += test_fd_fallback
 TESTS += test_SequenceOfVectorsErase
+TESTS += test_custom_tk_am
 
 if ! MPI_ENABLED
 XFAIL_TESTS = test_SequenceOfVectors/test_unifiedPositionsOfMaximum.sh
@@ -386,6 +394,9 @@ EXTRA_DIST += t04_bimodal/regression
 EXTRA_DIST += t04_bimodal/rtest04.sh
 EXTRA_DIST += t04_bimodal/example_1chain.inp
 
+EXTRA_DIST += custom_tk/adaptive_metropolis.h
+EXTRA_DIST += custom_tk/output_test_custom_tk_am_regression
+
 CLEANFILES =
 CLEANFILES += test_Environment/debug_output_sub0.txt
 CLEANFILES += gslvector_out_sub0.m
@@ -408,6 +419,7 @@ clean-local:
 	rm -rf $(top_builddir)/test/output_test_mala
 	rm -rf $(top_builddir)/test/output_test_TgaValidationCycle_gsl
 	rm -rf $(top_builddir)/test/output_test_SipSfpExample_gsl
+	rm -rf $(top_builddir)/test/output_test_custom_tk_am
 
 if CODE_COVERAGE_ENABLED
   CLEANFILES += *.gcda *.gcno

--- a/test/custom_tk/adaptive_metropolis.C
+++ b/test/custom_tk/adaptive_metropolis.C
@@ -40,9 +40,9 @@ MyTransitionKernel<V, M>::MyTransitionKernel(
   :
   ScaledCovMatrixTKGroup<V, M>(prefix, vectorSpace, scales, covMatrix),
   m_vectorSpace(vectorSpace),
-  m_counter(0)
+  m_counter(0),
+  m_dirtyCovMatrix(false)
 {
-  std::cout << "Hello from MyTransitionKernel!" << std::endl;
 }
 
 template<class V, class M>
@@ -59,8 +59,7 @@ MyTransitionKernel<V, M>::updateTK()
 
     new_matrix(0, 0) = 1.0;
 
-    // Changing the matrix, so we set the dirty flag so AM can reset
-    this->setCovMatrixIsDirty(true);
+    this->m_dirtyCovMatrix = true;
 
     // Update all the RVs with new cov matrix (including all the ones used in
     // Delayed Rejection)
@@ -69,6 +68,20 @@ MyTransitionKernel<V, M>::updateTK()
 
   // Just keeping track of a counter so I can trigger a 'dirty' matrix
   m_counter++;
+}
+
+template <class V, class M>
+bool
+MyTransitionKernel<V, M>::covMatrixIsDirty()
+{
+  return m_dirtyCovMatrix;
+}
+
+template <class V, class M>
+void
+MyTransitionKernel<V, M>::cleanCovMatrix()
+{
+  this->m_dirtyCovMatrix = false;
 }
 
 // Explicit instantiation of the template

--- a/test/custom_tk/adaptive_metropolis.C
+++ b/test/custom_tk/adaptive_metropolis.C
@@ -1,0 +1,80 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2017 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "adaptive_metropolis.h"
+
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/GaussianJointPdf.h>
+#include <queso/TKFactoryRandomWalk.h>
+
+namespace QUESO {
+
+template<class V, class M>
+MyTransitionKernel<V, M>::MyTransitionKernel(
+  const char*                    prefix,
+  const VectorSpace<V, M>& vectorSpace, // FIX ME: vectorSubset ???
+  const std::vector<double>&     scales,
+  const M&                       covMatrix)
+  :
+  ScaledCovMatrixTKGroup<V, M>(prefix, vectorSpace, scales, covMatrix),
+  m_vectorSpace(vectorSpace),
+  m_counter(0)
+{
+  std::cout << "Hello from MyTransitionKernel!" << std::endl;
+}
+
+template<class V, class M>
+MyTransitionKernel<V, M>::~MyTransitionKernel()
+{
+}
+
+template <class V, class M>
+void
+MyTransitionKernel<V, M>::updateTK()
+{
+  if (m_counter == 15) {
+    GslMatrix new_matrix(m_vectorSpace.zeroVector());
+
+    new_matrix(0, 0) = 1.0;
+
+    // Changing the matrix, so we set the dirty flag so AM can reset
+    this->setCovMatrixIsDirty(true);
+
+    // Update all the RVs with new cov matrix (including all the ones used in
+    // Delayed Rejection)
+    this->updateLawCovMatrix(new_matrix);
+  }
+
+  // Just keeping track of a counter so I can trigger a 'dirty' matrix
+  m_counter++;
+}
+
+// Explicit instantiation of the template
+template class MyTransitionKernel<GslVector, GslMatrix>;
+
+// Register this TK with the appropriate factory
+TKFactoryRandomWalk<MyTransitionKernel<GslVector, GslMatrix> > tk_factory_mytk("my_tk");
+
+}  // End namespace QUESO

--- a/test/custom_tk/adaptive_metropolis.h
+++ b/test/custom_tk/adaptive_metropolis.h
@@ -1,0 +1,56 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2017 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#ifndef QUESO_CUSTOM_TK_HESS_H
+#define QUESO_CUSTOM_TK_HESS_H
+
+#include <queso/ScaledCovMatrixTKGroup.h>
+#include <queso/VectorRV.h>
+#include <queso/ScalarFunctionSynchronizer.h>
+
+namespace QUESO {
+
+class GslVector;
+class GslMatrix;
+
+template <class V = GslVector, class M = GslMatrix>
+class MyTransitionKernel : public ScaledCovMatrixTKGroup<V, M> {
+public:
+  MyTransitionKernel(const char * prefix,
+                     const VectorSpace<V, M> & vectorSpace,
+                     const std::vector<double> & scales,
+                     const M & covMatrix);
+
+  virtual ~MyTransitionKernel();
+  virtual void updateTK();
+
+  const VectorSpace<V, M> & m_vectorSpace;
+
+private:
+  unsigned int m_counter;
+};
+
+}  // End namespace QUESO
+
+#endif // QUESO_CUSTOM_TK_HESS_H

--- a/test/custom_tk/adaptive_metropolis.h
+++ b/test/custom_tk/adaptive_metropolis.h
@@ -44,11 +44,14 @@ public:
 
   virtual ~MyTransitionKernel();
   virtual void updateTK();
+  virtual bool covMatrixIsDirty();
+  virtual void cleanCovMatrix();
 
   const VectorSpace<V, M> & m_vectorSpace;
 
 private:
   unsigned int m_counter;
+  bool m_dirtyCovMatrix;
 };
 
 }  // End namespace QUESO

--- a/test/custom_tk/adaptive_metropolis_main.C
+++ b/test/custom_tk/adaptive_metropolis_main.C
@@ -1,0 +1,145 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2017 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include <queso/EnvironmentOptions.h>
+#include <queso/GenericScalarFunction.h>
+#include <queso/GslMatrix.h>
+#include <queso/UniformVectorRV.h>
+#include <queso/StatisticalInverseProblem.h>
+
+template <class V = QUESO::GslVector, class M = QUESO::GslMatrix>
+class Likelihood : public QUESO::BaseScalarFunction<V, M>
+{
+public:
+  Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domainSet)
+    : QUESO::BaseScalarFunction<V, M>(prefix, domainSet)
+  {
+  }
+
+  ~Likelihood()
+  {
+  }
+
+  virtual double lnValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const
+  {
+    return -0.5 * domainVector[0] * domainVector[0];
+  }
+
+  virtual double actualValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const
+  {
+    return std::exp(this->lnValue(domainVector, domainDirection, gradVector,
+          hessianMatrix, hessianEffect));
+  }
+
+  double m_obsStdDev;
+};
+
+int main(int argc, char ** argv)
+{
+#ifdef QUESO_HAS_MPI
+  MPI_Init(&argc,&argv);
+#endif
+
+  QUESO::EnvOptionsValues options;
+  options.m_numSubEnvironments = 1;
+  options.m_subDisplayFileName = ".";
+  options.m_subDisplayAllowAll = 0;
+  options.m_subDisplayAllowedSet.insert(0);
+  options.m_seed = 1.0;
+  options.m_checkingLevel = 1;
+  options.m_displayVerbosity = 0;
+
+#ifdef QUESO_HAS_MPI
+  QUESO::FullEnvironment env(MPI_COMM_WORLD, "", "", &options);
+#else
+  QUESO::FullEnvironment env("", "", &options);
+#endif
+
+  QUESO::VectorSpace<> paramSpace(env, "param_", 1, NULL);
+
+  QUESO::GslVector paramMins(paramSpace.zeroVector());
+  QUESO::GslVector paramMaxs(paramSpace.zeroVector());
+
+  paramMins.cwSet(-INFINITY);
+  paramMaxs.cwSet( INFINITY);
+
+  QUESO::BoxSubset<> paramDomain("param_", paramSpace, paramMins, paramMaxs);
+
+  Likelihood<> likelihood("", paramDomain);
+
+  // Step 4 of 5: Instantiate the inverse problem
+  QUESO::UniformVectorRV<> priorRv("prior_", paramDomain);
+  QUESO::GenericVectorRV<> postRv("post_", paramSpace);
+  QUESO::StatisticalInverseProblem<> ip("", NULL, priorRv, likelihood, postRv);
+
+  // Step 5 of 5: Solve the inverse problem
+  QUESO::GslVector paramInitials(paramSpace.zeroVector());
+
+  QUESO::GslMatrix proposalCovMatrix(paramSpace.zeroVector());
+  proposalCovMatrix(0,0) = 1e-6;
+
+  QUESO::MhOptionsValues mh_options;
+  mh_options.m_tk = "my_tk";
+  mh_options.m_rawChainSize = 50;
+  mh_options.m_amInitialNonAdaptInterval = 10;
+  mh_options.m_amAdaptInterval = 10;
+  mh_options.m_amAdaptedMatricesDataOutputFileName = "output_test_custom_tk_am/matrices";
+  mh_options.m_amAdaptedMatricesDataOutputPeriod = 1;
+
+  ip.solveWithBayesMetropolisHastings(&mh_options, paramInitials, &proposalCovMatrix);
+
+  // Now read in test output and regression output and check they're the same
+  QUESO::ScalarSequence<> computed_mat10(env, 1, "");
+  QUESO::ScalarSequence<> computed_mat20(env, 1, "");
+  QUESO::ScalarSequence<> computed_mat30(env, 1, "");
+  QUESO::ScalarSequence<> computed_mat40(env, 1, "");
+
+  QUESO::ScalarSequence<> expected_mat10(env, 1, "");
+  QUESO::ScalarSequence<> expected_mat20(env, 1, "");
+  QUESO::ScalarSequence<> expected_mat30(env, 1, "");
+  QUESO::ScalarSequence<> expected_mat40(env, 1, "");
+
+  computed_mat10.unifiedReadContents("output_test_custom_tk_am/matrices_am10_sub0", "m", 1);
+  computed_mat20.unifiedReadContents("output_test_custom_tk_am/matrices_am20_sub0", "m", 1);
+  computed_mat30.unifiedReadContents("output_test_custom_tk_am/matrices_am30_sub0", "m", 1);
+  computed_mat40.unifiedReadContents("output_test_custom_tk_am/matrices_am40_sub0", "m", 1);
+
+  expected_mat10.unifiedReadContents("output_test_custom_tk_am/matrices_am10_sub0", "m", 1);
+  expected_mat20.unifiedReadContents("output_test_custom_tk_am/matrices_am20_sub0", "m", 1);
+  expected_mat30.unifiedReadContents("output_test_custom_tk_am/matrices_am30_sub0", "m", 1);
+  expected_mat40.unifiedReadContents("output_test_custom_tk_am/matrices_am40_sub0", "m", 1);
+
+  queso_require_equal_to_msg(computed_mat10[0], expected_mat10[0], "adapted matrix at iter 10 not equal");
+  queso_require_equal_to_msg(computed_mat20[0], expected_mat20[0], "adapted matrix at iter 20 not equal");
+  queso_require_equal_to_msg(computed_mat30[0], expected_mat30[0], "adapted matrix at iter 30 not equal");
+  queso_require_equal_to_msg(computed_mat40[0], expected_mat40[0], "adapted matrix at iter 40 not equal");
+
+#ifdef QUESO_HAS_MPI
+  MPI_Finalize();
+#endif
+
+  return 0;
+}

--- a/test/custom_tk/adaptive_metropolis_main.C
+++ b/test/custom_tk/adaptive_metropolis_main.C
@@ -127,10 +127,16 @@ int main(int argc, char ** argv)
   computed_mat30.unifiedReadContents("output_test_custom_tk_am/matrices_am30_sub0", "m", 1);
   computed_mat40.unifiedReadContents("output_test_custom_tk_am/matrices_am40_sub0", "m", 1);
 
-  expected_mat10.unifiedReadContents("output_test_custom_tk_am/matrices_am10_sub0", "m", 1);
-  expected_mat20.unifiedReadContents("output_test_custom_tk_am/matrices_am20_sub0", "m", 1);
-  expected_mat30.unifiedReadContents("output_test_custom_tk_am/matrices_am30_sub0", "m", 1);
-  expected_mat40.unifiedReadContents("output_test_custom_tk_am/matrices_am40_sub0", "m", 1);
+  std::string regressionsFileName = "custom_tk/output_test_custom_tk_am_regression";
+  const char * regressions_srcdir = std::getenv("srcdir");
+  if (regressions_srcdir) {
+    regressionsFileName = regressions_srcdir + ('/' + regressionsFileName);
+  }
+
+  expected_mat10.unifiedReadContents(regressionsFileName + ('/' + std::string("matrices_am10_sub0")), "m", 1);
+  expected_mat20.unifiedReadContents(regressionsFileName + ('/' + std::string("matrices_am20_sub0")), "m", 1);
+  expected_mat30.unifiedReadContents(regressionsFileName + ('/' + std::string("matrices_am30_sub0")), "m", 1);
+  expected_mat40.unifiedReadContents(regressionsFileName + ('/' + std::string("matrices_am40_sub0")), "m", 1);
 
   queso_require_equal_to_msg(computed_mat10[0], expected_mat10[0], "adapted matrix at iter 10 not equal");
   queso_require_equal_to_msg(computed_mat20[0], expected_mat20[0], "adapted matrix at iter 20 not equal");

--- a/test/custom_tk/output_test_custom_tk_am_regression/matrices_am10_sub0.m
+++ b/test/custom_tk/output_test_custom_tk_am_regression/matrices_am10_sub0.m
@@ -1,0 +1,3 @@
+mat_am10_sub0 = zeros(1,1);
+mat_am10_sub0 = [4.69518e-07 
+];

--- a/test/custom_tk/output_test_custom_tk_am_regression/matrices_am20_sub0.m
+++ b/test/custom_tk/output_test_custom_tk_am_regression/matrices_am20_sub0.m
@@ -1,0 +1,3 @@
+mat_am20_sub0 = zeros(1,1);
+mat_am20_sub0 = [2.21864e-07 
+];

--- a/test/custom_tk/output_test_custom_tk_am_regression/matrices_am30_sub0.m
+++ b/test/custom_tk/output_test_custom_tk_am_regression/matrices_am30_sub0.m
@@ -1,0 +1,3 @@
+mat_am30_sub0 = zeros(1,1);
+mat_am30_sub0 = [0.069827 
+];

--- a/test/custom_tk/output_test_custom_tk_am_regression/matrices_am40_sub0.m
+++ b/test/custom_tk/output_test_custom_tk_am_regression/matrices_am40_sub0.m
@@ -1,0 +1,3 @@
+mat_am40_sub0 = zeros(1,1);
+mat_am40_sub0 = [0.0899602 
+];


### PR DESCRIPTION
`BaseTKGroup` learned the `set_current_iteration` method, which sets the internal `m_currentIteration` variable and calls the private `virtual` method `update_tk`.  The default behaviour of this method is to do nothing and the user can subclass this method to implement any iteration-dependent transition kernel behaviour.

I think, before merging this, it's worth discussing how this should interact with the adaptively update proposal covariance matrix and the delayed rejection functionality.