### PR TITLE
GPMSA data re-centering

### DIFF
--- a/src/gp/inc/GPMSA.h
+++ b/src/gp/inc/GPMSA.h
@@ -322,6 +322,9 @@ public:
   std::vector<V *> m_experimentScenarios;
   std::vector<V *> m_experimentOutputs;
 
+  // We will be recentering data around the simulation output mean
+  typename ScopedPtr<V>::Type simulationOutputMeans;
+
   std::vector<V> m_discrepancyBases;
 
   std::vector<M> m_observationErrorMatrices;

--- a/src/gp/src/GPMSA.C
+++ b/src/gp/src/GPMSA.C
@@ -1015,13 +1015,15 @@ GPMSAFactory<V, M>::setUpHyperpriors()
       for (unsigned int i = 0; i < this->m_numExperiments; i++) {
         for (unsigned int k = 0; k != numOutputs; ++k)
           y[i*numOutputs+k] =
-            (*((this->m_experimentOutputs)[i]))[k];
+            (*((this->m_experimentOutputs)[i]))[k] -
+            (*simulationOutputMeans)[k];
       }
 
       for (unsigned int i = 0; i < this->m_numSimulations; i++) {
         for (unsigned int k = 0; k != numOutputs; ++k)
           eta[i*numOutputs+k] =
-            (*((this->m_simulationOutputs)[i]))[k];
+            (*((this->m_simulationOutputs)[i]))[k] -
+            (*simulationOutputMeans)[k];
       }
 
       M& B = *m_BMatrix;
@@ -1065,13 +1067,16 @@ GPMSAFactory<V, M>::setUpHyperpriors()
       residual.reset(new V (this->m_env, z_map));
 
       // Form residual = D - mean // = D - mu*1 in (3)
-      // We don't subtract off mean here because we expect normalized data
+      // We currently use the mean of the simulation data, not a free
+      // hyperparameter mean
       for (unsigned int i = 0; i < this->m_numExperiments; i++) {
-        (*residual)[i] = (*((this->m_experimentOutputs)[i]))[0];
+        (*residual)[i] = (*((this->m_experimentOutputs)[i]))[0] -
+                         (*simulationOutputMeans)[0];
       }
       for (unsigned int i = 0; i < this->m_numSimulations; i++) {
         (*residual)[i+this->m_numExperiments] =
-          (*((this->m_simulationOutputs)[i]))[0];
+          (*((this->m_simulationOutputs)[i]))[0] -
+          (*simulationOutputMeans)[0];
       }
     }
 

--- a/src/gp/src/GPMSA.C
+++ b/src/gp/src/GPMSA.C
@@ -705,7 +705,9 @@ GPMSAFactory<V, M>::setUpEmulator()
   const unsigned int num_svd_terms =
     std::min(MAX_SVD_TERMS, numOutputs);
 
-  const MpiComm & comm = m_simulationOutputs[0]->map().Comm();
+  const Map & output_map = m_simulationOutputs[0]->map();
+
+  const MpiComm & comm = output_map.Comm();
 
   Map serial_map(m_numSimulations, 0, comm);
 
@@ -732,20 +734,16 @@ GPMSAFactory<V, M>::setUpEmulator()
 
   // Copy only those vectors we want into K_eta
   m_TruncatedSVD_simulationOutputs.reset
-    (new M(m_simulationOutputs[0]->env(),
-           m_simulationOutputs[0]->map(),
-           num_svd_terms));
+    (new M(env, output_map, num_svd_terms));
 
   for (unsigned int i=0; i != numOutputs; ++i)
     for (unsigned int k = 0; k != num_svd_terms; ++k)
       (*m_TruncatedSVD_simulationOutputs)(i,k) = SM_singularVectors(i,k);
 
-  Map copied_map(numOutputs * m_numSimulations, 0,
-                 m_simulationOutputs[0]->map().Comm());
+  Map copied_map(numOutputs * m_numSimulations, 0, comm);
 
   K.reset
-    (new M(m_simulationOutputs[0]->env(), copied_map,
-           m_numSimulations * num_svd_terms));
+    (new M(env, copied_map, m_numSimulations * num_svd_terms));
   for (unsigned int k=0; k != num_svd_terms; ++k)
     for (unsigned int i1=0; i1 != m_numSimulations; ++i1)
       for (unsigned int i2=0; i2 != numOutputs; ++i2)
@@ -793,14 +791,14 @@ GPMSAFactory<V, M>::setUpEmulator()
   const Map B_row_map(Brows, 0, comm);
 
   m_BMatrix.reset
-    (new M(m_simulationOutputs[0]->env(), B_row_map, Bcols));
+    (new M(env, B_row_map, Bcols));
 
   const unsigned int Wyrows = m_numExperiments * numOutputs;
 
   const Map Wy_row_map(Wyrows, 0, comm);
 
   m_observationErrorMatrix.reset
-    (new M(m_simulationOutputs[0]->env(), Wy_row_map, Wyrows));
+    (new M(env, Wy_row_map, Wyrows));
 
   M& B = *m_BMatrix;
   M& Wy = *m_observationErrorMatrix;

--- a/src/gp/src/GPMSA.C
+++ b/src/gp/src/GPMSA.C
@@ -1201,8 +1201,10 @@ GPMSAFactory<V, M>::setUpHyperpriors()
     (new V(this->observationalPrecisionSpace->zeroVector()));
   this->observationalPrecisionMin->cwSet(0.3);
   this->observationalPrecisionMax->cwSet(INFINITY);
-  this->m_observationalPrecisionShapeVec->cwSet(observationalPrecisionShape);
-  this->m_observationalPrecisionScaleVec->cwSet(observationalPrecisionScale);
+  this->m_observationalPrecisionShapeVec->cwSet
+    (this->m_opts->m_observationalPrecisionShape);
+  this->m_observationalPrecisionScaleVec->cwSet
+    (this->m_opts->m_observationalPrecisionScale);
 
   this->observationalPrecisionDomain.reset
     (new BoxSubset<V, M>

--- a/src/gp/src/GPMSA.C
+++ b/src/gp/src/GPMSA.C
@@ -72,9 +72,8 @@ GPMSAEmulator<V, M>::GPMSAEmulator(
 {
   queso_assert_greater(m_numSimulations, 0);
 
-  const MpiComm & comm = m_simulationOutputs[0]->map().Comm();
-
-  queso_assert_equal_to(comm.NumProc(), 1);
+  queso_assert_equal_to
+    (m_simulationOutputs[0]->map().Comm().NumProc(), 1);
 
   const unsigned int numOutputs =
     this->m_experimentOutputSpace.dimLocal();

--- a/src/gp/src/GPMSA.C
+++ b/src/gp/src/GPMSA.C
@@ -756,11 +756,11 @@ GPMSAFactory<V, M>::setUpEmulator()
   KT_K_inv.reset
     (new M((K->transpose() * *K).inverse()));
 
-  Map outputs_map(numOutputs, 0, comm);
+  Map serial_output_map(numOutputs, 0, comm);
 
   for (unsigned int i = 0; i != m_numExperiments; ++i)
     {
-      M D_i(m_simulationOutputs[0]->env(), outputs_map,
+      M D_i(env, serial_output_map,
             (unsigned int)(m_discrepancyBases.size()));
 
       for (unsigned int j=0; j != numOutputs; ++j)

--- a/src/gp/src/GPMSA.C
+++ b/src/gp/src/GPMSA.C
@@ -713,12 +713,22 @@ GPMSAFactory<V, M>::setUpEmulator()
 
   const BaseEnvironment &env = m_simulationOutputs[0]->env();
 
+  simulationOutputMeans.reset
+    (new V (env, output_map));
+
+  for (unsigned int i=0; i != m_numSimulations; ++i)
+    for (unsigned int j=0; j != numOutputs; ++j)
+      (*simulationOutputMeans)[j] += (*m_simulationOutputs[i])[j];
+
+  for (unsigned int j=0; j != numOutputs; ++j)
+    (*simulationOutputMeans)[j] /= m_numSimulations;
+
   M simulation_matrix(env, serial_map, numOutputs);
 
   for (unsigned int i=0; i != m_numSimulations; ++i)
     for (unsigned int j=0; j != numOutputs; ++j)
       simulation_matrix(i,j) =
-        (*m_simulationOutputs[i])[j];
+        (*m_simulationOutputs[i])[j] - (*simulationOutputMeans)[j];
 
   // GSL only finds left singular vectors if n_rows>=n_columns, so we need to
   // calculate them indirectly from the eigenvalues of M^T*M

--- a/test/test_gpmsa/test_gpmsa_vector.C
+++ b/test/test_gpmsa/test_gpmsa_vector.C
@@ -72,13 +72,20 @@ readData(const std::vector<QUESO::GslVector *> & simulationScenarios,
   double stdsim = m2sim / (double)(i - 1);
   double stdexpsim = m2expsim / (double)(i - 1);
 
-  // The user is required to standardise the experimental and simulation data
+  // The user was required to standardise the experimental and
+  // simulation data in the original GPMSA code.
+  //
+  // This is no longer required, but we'll do a rescaling *without*
+  // recentering now to make sure that we can replicate our older
+  // results.
   for (unsigned int j = 0; j < i; j++) {
     (*(simulationOutputs[j]))[0] -= meansim;
     (*(simulationOutputs[j]))[0] /= stdsim;
+    (*(simulationOutputs[j]))[0] += meansim;
 
     (*(simulationOutputs[j]))[1] -= meanexpsim;
     (*(simulationOutputs[j]))[1] /= stdexpsim;
+    (*(simulationOutputs[j]))[1] += meanexpsim;
   }
 
   fclose(fp_in);  // Done with simulation data
@@ -99,13 +106,15 @@ readData(const std::vector<QUESO::GslVector *> & simulationScenarios,
     i++;
   }
 
-  // Also required to standardise experimental data too
+  // We used to be required to standardise experimental data too
   for (unsigned int j = 0; j < i; j++) {
     (*(experimentOutputs[j]))[0] -= meansim;
     (*(experimentOutputs[j]))[0] /= stdsim;
+    (*(experimentOutputs[j]))[0] += meansim;
 
     (*(experimentOutputs[j]))[1] -= meanexpsim;
     (*(experimentOutputs[j]))[1] /= stdexpsim;
+    (*(experimentOutputs[j]))[1] += meanexpsim;
   }
 
   fclose(fp_in);


### PR DESCRIPTION
This fixes the issue where non-normalized simulation and experiment data would give inaccurate results from GPMSA.

We can't rescale any user data ourselves without more extensive work (because half our hyperparameter outputs would end up affected by the scaling, with no way for the user to straighten them out) but we can shift the output data by its own mean transparently to the user.

This PR does that shift, and modifies the GPMSA regression test to pass in non-shifted data.  We still pass in rescaled data so we can compare against the original "gold standard" test results.