### PR TITLE
Turn off doxygen C-preprocessing

### DIFF
--- a/doxygen/queso.dox.in
+++ b/doxygen/queso.dox.in
@@ -1235,7 +1235,7 @@ PERLMOD_MAKEVAR_PREFIX =
 # evaluate all C-preprocessor directives found in the sources and include 
 # files.
 
-ENABLE_PREPROCESSING   = YES
+ENABLE_PREPROCESSING   = NO
 
 # If the MACRO_EXPANSION tag is set to YES Doxygen will expand all macro 
 # names in the source code. If set to NO (the default) only conditional 


### PR DESCRIPTION
This allows one to generate queso documentation that may be #ifdef'd out
due to not all configure options being enabled, configure options that
can't all be enabled because they conflict, or configure options that
weren't enabled because I am too lazy to build queso with every single
optional dependency just to build documentation.

Fixes #167.