### PR TITLE
Remove `typename' for non-dependent types

### DIFF
--- a/src/core/inc/InfiniteDimensionalMCMCSampler.h
+++ b/src/core/inc/InfiniteDimensionalMCMCSampler.h
@@ -80,7 +80,7 @@ public:
   unsigned int iteration() const;
 
   //! Returns a pointer to new sampler, with all the moments reset.
-  typename SharedPtr<InfiniteDimensionalMCMCSampler>::Type clone_and_reset() const;
+  SharedPtr<InfiniteDimensionalMCMCSampler>::Type clone_and_reset() const;
 
 private:
   // Current iteration
@@ -109,22 +109,22 @@ private:
   const BaseEnvironment& m_env;
 
   // Pointer to the current physical state
-  typename SharedPtr<FunctionBase>::Type current_physical_state;
+  SharedPtr<FunctionBase>::Type current_physical_state;
 
   // Pointer to the current proposed state
-  typename SharedPtr<FunctionBase>::Type proposed_physical_state;
+  SharedPtr<FunctionBase>::Type proposed_physical_state;
 
   // Pointer to the current physical mean
-  typename SharedPtr<FunctionBase>::Type current_physical_mean;
+  SharedPtr<FunctionBase>::Type current_physical_mean;
 
   // Pointer to the current physical variance
-  typename SharedPtr<FunctionBase>::Type current_physical_var;
+  SharedPtr<FunctionBase>::Type current_physical_var;
 
   // Stores the differences from the mean
-  typename SharedPtr<FunctionBase>::Type _delta;
+  SharedPtr<FunctionBase>::Type _delta;
 
   // Stores a running sum-of-squares (kinda)
-  typename SharedPtr<FunctionBase>::Type _M2;
+  SharedPtr<FunctionBase>::Type _M2;
 
   // A pointer to the random number generator to use.
   // Should probably use the one in the queso environment.

--- a/src/core/inc/LibMeshFunction.h
+++ b/src/core/inc/LibMeshFunction.h
@@ -98,15 +98,15 @@ public:
    * identically zero (by copying \c this) everywhere and return a boost shared
    * pointer to it
    */
-  virtual typename SharedPtr<FunctionBase>::Type zero_clone() const;
+  virtual SharedPtr<FunctionBase>::Type zero_clone() const;
 
   //! Return the internal libmesh equation systems object
-  virtual typename SharedPtr<libMesh::EquationSystems>::Type get_equation_systems() const;
+  virtual SharedPtr<libMesh::EquationSystems>::Type get_equation_systems() const;
 
 private:
   const FunctionOperatorBuilder & builder;
 
-  typename SharedPtr<libMesh::EquationSystems>::Type equation_systems;
+  SharedPtr<libMesh::EquationSystems>::Type equation_systems;
 };
 
 }  // End namespace QUESO

--- a/src/core/inc/LibMeshOperatorBase.h
+++ b/src/core/inc/LibMeshOperatorBase.h
@@ -112,11 +112,11 @@ public:
    *  where the lambda are eigenvalues of the precision operator, \c this, and
    *  the \phi(x) are eigenfunctions of the precision operator, \c this
    */
-  virtual typename SharedPtr<FunctionBase>::Type
+  virtual SharedPtr<FunctionBase>::Type
   inverse_kl_transform(std::vector<double> & xi, double alpha) const;
 
 protected:
-  typename SharedPtr<libMesh::EquationSystems>::Type equation_systems;
+  SharedPtr<libMesh::EquationSystems>::Type equation_systems;
 
   const FunctionOperatorBuilder & builder;
 

--- a/src/core/src/InfiniteDimensionalMCMCSampler.C
+++ b/src/core/src/InfiniteDimensionalMCMCSampler.C
@@ -151,7 +151,7 @@ void InfiniteDimensionalMCMCSampler::_propose()
   const double rwmh_step_sq = (this->m_ov->m_rwmh_step * this->m_ov->m_rwmh_step);
   const double coeff = std::sqrt(1.0 - rwmh_step_sq);
 
-  typename SharedPtr<FunctionBase>::Type p(prior.draw());
+  SharedPtr<FunctionBase>::Type p(prior.draw());
 
   this->proposed_physical_state->zero();
   this->proposed_physical_state->add(coeff, *(this->current_physical_state));
@@ -201,7 +201,7 @@ void InfiniteDimensionalMCMCSampler::_update_moments()
   this->current_physical_mean->add(1.0 / this->iteration(), *(this->_delta));
 
   // Update running sum-of-squares
-  typename SharedPtr<FunctionBase>::Type temp_ptr(this->_delta->zero_clone());
+  SharedPtr<FunctionBase>::Type temp_ptr(this->_delta->zero_clone());
   // LibMeshFunction & temp = static_cast<LibMeshFunction &>(*temp_ptr);
 
   temp_ptr->pointwise_mult(*(this->_delta), *(this->current_physical_state));
@@ -336,10 +336,10 @@ void InfiniteDimensionalMCMCSampler::_write_state()
   this->current_physical_var->save_function(var_name, this->iteration());
 }
 
-typename SharedPtr<InfiniteDimensionalMCMCSampler>::Type InfiniteDimensionalMCMCSampler::clone_and_reset() const
+SharedPtr<InfiniteDimensionalMCMCSampler>::Type InfiniteDimensionalMCMCSampler::clone_and_reset() const
 {
   // Set up a clone
-  typename SharedPtr<InfiniteDimensionalMCMCSampler>::Type clone(new InfiniteDimensionalMCMCSampler(this->m_env, this->prior, this->llhd, this->m_ov));
+  SharedPtr<InfiniteDimensionalMCMCSampler>::Type clone(new InfiniteDimensionalMCMCSampler(this->m_env, this->prior, this->llhd, this->m_ov));
 
   // Copy the state.
   clone->current_physical_state = this->current_physical_state;

--- a/src/core/src/LibMeshFunction.C
+++ b/src/core/src/LibMeshFunction.C
@@ -135,14 +135,14 @@ double LibMeshFunction::L2_norm() const {
   return norm;
 }
 
-typename SharedPtr<FunctionBase>::Type LibMeshFunction::zero_clone() const
+SharedPtr<FunctionBase>::Type LibMeshFunction::zero_clone() const
 {
   LibMeshFunction * clone = new LibMeshFunction(this->builder,
       this->equation_systems->get_mesh());
   clone->equation_systems->get_system<libMesh::ExplicitSystem>(
       "Function").solution->zero();
 
-  typename SharedPtr<FunctionBase>::Type ptr(clone);
+  SharedPtr<FunctionBase>::Type ptr(clone);
   return ptr;
 }
 

--- a/src/core/src/LibMeshNegativeLaplacianOperator.C
+++ b/src/core/src/LibMeshNegativeLaplacianOperator.C
@@ -57,7 +57,7 @@ LibMeshNegativeLaplacianOperator::LibMeshNegativeLaplacianOperator(
     const FunctionOperatorBuilder & builder, libMesh::MeshBase & m)
   : LibMeshOperatorBase(builder, m)
 {
-  typename SharedPtr<libMesh::EquationSystems>::Type es(this->equation_systems);
+  SharedPtr<libMesh::EquationSystems>::Type es(this->equation_systems);
 
   // Give the system a pointer to the matrix assembly
   // function defined below.
@@ -142,7 +142,7 @@ void LibMeshNegativeLaplacianOperator::assemble()
 {
 #ifdef LIBMESH_HAVE_SLEPC
 
-  typename SharedPtr<libMesh::EquationSystems>::Type es(this->equation_systems);
+  SharedPtr<libMesh::EquationSystems>::Type es(this->equation_systems);
 
   // Get a constant reference to the mesh object.
   const libMesh::MeshBase& mesh = es->get_mesh();

--- a/src/core/src/LibMeshOperatorBase.C
+++ b/src/core/src/LibMeshOperatorBase.C
@@ -104,7 +104,7 @@ void LibMeshOperatorBase::save_converged_evec(const std::string & filename,
     unsigned int i) const
 {
   if (i < this->nconv) {
-    typename SharedPtr<libMesh::EquationSystems>::Type es(this->equation_systems);
+    SharedPtr<libMesh::EquationSystems>::Type es(this->equation_systems);
     es->get_system<libMesh::EigenSystem>("Eigensystem").get_eigenpair(i);
     libMesh::ExodusII_IO(es->get_mesh()).write_equation_systems(filename, *es);
   }
@@ -123,7 +123,7 @@ double LibMeshOperatorBase::get_eigenvalue(unsigned int i) const
 {
   if (i < this->nconv) {
     std::pair<libMesh::Real, libMesh::Real> eval;
-    typename SharedPtr<libMesh::EquationSystems>::Type es(this->equation_systems);
+    SharedPtr<libMesh::EquationSystems>::Type es(this->equation_systems);
     eval = es->get_system<libMesh::EigenSystem>("Eigensystem").get_eigenpair(i);
     return eval.first;
   }
@@ -142,12 +142,12 @@ libMesh::EquationSystems & LibMeshOperatorBase::get_equation_systems() const
   return *this->equation_systems;
 }
 
-typename SharedPtr<FunctionBase>::Type
+SharedPtr<FunctionBase>::Type
 LibMeshOperatorBase::inverse_kl_transform(std::vector<double> & xi,
     double alpha) const
 {
   unsigned int i;
-  typename SharedPtr<libMesh::EquationSystems>::Type es(this->equation_systems);
+  SharedPtr<libMesh::EquationSystems>::Type es(this->equation_systems);
   LibMeshFunction *kl = new LibMeshFunction(this->builder, es->get_mesh());
 
   // Make sure all procs in libmesh mpi communicator all have the same xi.  No,
@@ -155,7 +155,7 @@ LibMeshOperatorBase::inverse_kl_transform(std::vector<double> & xi,
   // communicator.
   this->equation_systems->comm().broadcast(xi);
 
-  typename SharedPtr<libMesh::EquationSystems>::Type kl_eq_sys(kl->get_equation_systems());
+  SharedPtr<libMesh::EquationSystems>::Type kl_eq_sys(kl->get_equation_systems());
 
   std::pair<libMesh::Real, libMesh::Real> eval;
   for (i = 0; i < this->get_num_converged(); i++) {
@@ -165,7 +165,7 @@ LibMeshOperatorBase::inverse_kl_transform(std::vector<double> & xi,
         *es->get_system<libMesh::EigenSystem>("Eigensystem").solution);
   }
 
-  typename SharedPtr<FunctionBase>::Type ap(kl);
+  SharedPtr<FunctionBase>::Type ap(kl);
   return ap;
 }
 


### PR DESCRIPTION
This is fine, but it triggers a compiler error in older versions of gcc.

Fixes #489.

@briadam Look good?