### PR TITLE
Implement finite difference fallback for `BaseScalarFunction::lnValue`

### DIFF
--- a/src/basic/inc/ScalarFunction.h
+++ b/src/basic/inc/ScalarFunction.h
@@ -25,15 +25,16 @@
 #ifndef UQ_SCALAR_FUNCTION_H
 #define UQ_SCALAR_FUNCTION_H
 
+#include <queso/Environment.h>
 #include <queso/VectorSet.h>
 #include <queso/VectorSubset.h>
-#include <queso/Environment.h>
-#include <queso/Defines.h>
+#include <queso/ScopedPtr.h>
 
 namespace QUESO {
 
 class GslVector;
 class GslMatrix;
+class BoostInputOptionsParser;
 
 /*! \file ScalarFunction.h
  * \brief Set of classes for handling vector functions.
@@ -139,6 +140,15 @@ protected:
 
   //! Domain set of the scalar function.
   const VectorSet<V, M> & m_domainSet;
+
+private:
+#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+  //! Input parser
+  ScopedPtr<BoostInputOptionsParser>::Type m_parser;
+#endif
+
+  //! Finite different step size
+  double m_fdStepSize;
 };
 
 }  // End namespace QUESO

--- a/src/basic/inc/ScalarFunction.h
+++ b/src/basic/inc/ScalarFunction.h
@@ -106,6 +106,28 @@ public:
    */
   virtual double lnValue(const V & domainVector, V & gradVector) const;
 
+  //! Returns the logarithm of the function \c domainVector, the gradient of
+  //! the logarithm at \c domainVector, and the effect of the hessian of the
+  //! logarithm in the direction at \c domainDirection
+  /*!
+   * Default implementation throws an exception because we don't expect the
+   * user to tolerate a finite difference approximation of the hessian.
+   *
+   * Note, gradVector should be filled with the gradient of the logarithm of
+   * the function, not the gradient of the function.
+   *
+   * The 'hessian' referred to here should be the hessian of the logarithm
+   * of the function at \c domainVector.
+   *
+   * QUESO calls this method when it needs to evaluate the function, needs
+   * first order derivative information, and also needs second-order deriative
+   * information
+   */
+  virtual double lnValue(const V & domainVector,
+                         V & gradVector,
+                         const V & domainDirection,
+                         V & hessianEffect) const;
+
   //! Actual value of the scalar function.
   virtual double actualValue(const V & domainVector, const V * domainDirection,
       V * gradVector, M * hessianMatrix, V * hessianEffect) const = 0;

--- a/src/basic/inc/ScalarFunction.h
+++ b/src/basic/inc/ScalarFunction.h
@@ -67,15 +67,50 @@ public:
   //@{
   //! Access to the protected attribute \c m_domainSet: domain set of the scalar function.
   const VectorSet<V, M> & domainSet() const;
+  //@}
+
+  //! @name Evaluation methods
+  //@{
+  //! Logarithm of the value of the scalar function.  Deprecated.
+  /*!
+   * Pointers will be NULL if derivative information is not required by QUESO.
+   *
+   * Default implementation throws an exception.
+   */
+  virtual double lnValue(const V & domainVector,
+                         const V * domainDirection,
+                         V * gradVector,
+                         M * hessianMatrix,
+                         V * hessianEffect) const;
+
+  //! Returns the logarithm of the function at \c domainVector
+  /*!
+   * Default implementation calls the deprecated method.
+   *
+   * QUESO calls this method when it needs to evaluate the function but doesn't
+   * need derivative information about that function.
+   */
+  virtual double lnValue(const V & domainVector) const;
+
+  //! Returns the logarithm of the function and its gradient at \c domainVector
+  /*!
+   * Default implementation calls above method successively to fill up
+   * \c gradVector with a finite difference approximation.
+   *
+   * Note, gradVector should be filled with the gradient of the logarithm of
+   * the function, not the gradient of the function.
+   *
+   * QUESO calls this method when it needs to evaluate the function, needs
+   * first order derivative information, but doesn't need second order
+   * derivative information.
+   */
+  virtual double lnValue(const V & domainVector, V & gradVector) const;
 
   //! Actual value of the scalar function.
   virtual double actualValue(const V & domainVector, const V * domainDirection,
       V * gradVector, M * hessianMatrix, V * hessianEffect) const = 0;
-
-  //! Logarithm of the value of the scalar function.
-  virtual double lnValue(const V & domainVector, const V * domainDirection,
-      V * gradVector, M * hessianMatrix, V * hessianEffect) const = 0;
   //@}
+
 protected:
   const BaseEnvironment & m_env;
   std::string m_prefix;

--- a/src/basic/inc/ScalarFunction.h
+++ b/src/basic/inc/ScalarFunction.h
@@ -134,6 +134,13 @@ public:
       V * gradVector, M * hessianMatrix, V * hessianEffect) const = 0;
   //@}
 
+  //! Sets the step size for finite differencing gradients
+  /*!
+   * If the function is multi-dimensional then the same finite difference step
+   * size is used in every direction.
+   */
+  void setFiniteDifferenceStepSize(double fdStepSize);
+
 protected:
   const BaseEnvironment & m_env;
   std::string m_prefix;

--- a/src/basic/inc/ScalarFunction.h
+++ b/src/basic/inc/ScalarFunction.h
@@ -141,6 +141,15 @@ public:
    */
   void setFiniteDifferenceStepSize(double fdStepSize);
 
+  //! Sets the step size for the i-th component of the finite differencing
+  //! vector
+  /*!
+   * i is a zero-based index.
+   *
+   * If the function is one-dimensional, the only allowed value for i is 0.
+   */
+  void setFiniteDifferenceStepSize(unsigned int i, double fdStepSize);
+
 protected:
   const BaseEnvironment & m_env;
   std::string m_prefix;
@@ -155,7 +164,7 @@ private:
 #endif
 
   //! Finite different step size
-  double m_fdStepSize;
+  std::vector<double> m_fdStepSize;
 };
 
 }  // End namespace QUESO

--- a/src/basic/src/ScalarFunction.C
+++ b/src/basic/src/ScalarFunction.C
@@ -52,6 +52,56 @@ const VectorSet<V, M> & BaseScalarFunction<V, M>::domainSet() const
   return m_domainSet;
 }
 
+template <class V, class M>
+double
+BaseScalarFunction<V, M>::lnValue(const V & domainVector,
+                                  const V * domainDirection,
+                                  V * gradVector,
+                                  M * hessianMatrix,
+                                  V * hessianEffect) const
+{
+  std::string msg;
+
+  msg += "Implementation of all lnValue methods is missing.  Please implement";
+  msg += "at least lnValue(const V &).";
+
+  queso_error_msg(msg);
+}
+
+template <class V, class M>
+double
+BaseScalarFunction<V, M>::lnValue(const V & domainVector) const
+{
+  return this->lnValue(domainVector, NULL, NULL, NULL, NULL);
+}
+
+template <class V, class M>
+double
+BaseScalarFunction<V, M>::lnValue(const V & domainVector, V & gradVector) const
+{
+  // Read this from an input file, or make it a settable member variable.
+  double h = 1e-6;
+
+  double value = this->lnValue(domainVector);
+
+  // Create perturbed version of domainVector to use in finite difference
+  V perturbedVector(domainVector);
+
+  // Fill up gradVector with a finite difference approximation
+  for (unsigned int i = 0; i < domainVector.sizeLocal(); ++i) {
+    // Store the old value of the perturbed element so we can undo it later
+    double tmp = perturbedVector[i];
+
+    perturbedVector[i] += h;
+    gradVector[i] = (this->lnValue(perturbedVector) - value) / h;
+
+    // Restore the old value of the perturbedVector element
+    perturbedVector[i] = tmp;
+  }
+
+  return value;
+}
+
 }  // End namespace QUESO
 
 template class QUESO::BaseScalarFunction<QUESO::GslVector, QUESO::GslMatrix>;

--- a/src/basic/src/ScalarFunction.C
+++ b/src/basic/src/ScalarFunction.C
@@ -63,7 +63,7 @@ BaseScalarFunction<V, M>::lnValue(const V & domainVector,
   std::string msg;
 
   msg += "Implementation of all lnValue methods is missing.  Please implement";
-  msg += "at least lnValue(const V &).";
+  msg += " at least lnValue(const V &).";
 
   queso_error_msg(msg);
 }
@@ -100,6 +100,22 @@ BaseScalarFunction<V, M>::lnValue(const V & domainVector, V & gradVector) const
   }
 
   return value;
+}
+
+template <class V, class M>
+double
+BaseScalarFunction<V, M>::lnValue(const V & domainVector,
+                                  V & gradVector,
+                                  const V & domainDirection,
+                                  V & hessianEffect) const
+{
+  std::string msg;
+
+  msg += "QUESO asked for Hessian information from an lnValue method, but the";
+  msg += " implementation of is missing.  Please implement";
+  msg += " lnValue(const V &, V &, const V &, V &).";
+
+  queso_error_msg(msg);
 }
 
 }  // End namespace QUESO

--- a/src/basic/src/ScalarFunction.C
+++ b/src/basic/src/ScalarFunction.C
@@ -137,6 +137,16 @@ BaseScalarFunction<V, M>::lnValue(const V & domainVector,
   queso_error_msg(msg);
 }
 
+template <class V, class M>
+void
+BaseScalarFunction<V, M>::setFiniteDifferenceStepSize(double fdStepSize)
+{
+  queso_require_greater_msg(fdStepSize, 0.0,
+                            "Must provide a finite difference step > 0");
+
+  this->m_fdStepSize = fdStepSize;
+}
+
 }  // End namespace QUESO
 
 template class QUESO::BaseScalarFunction<QUESO::GslVector, QUESO::GslMatrix>;

--- a/src/stats/inc/BayesianJointPdf.h
+++ b/src/stats/inc/BayesianJointPdf.h
@@ -97,6 +97,11 @@ public:
 
   //@}
 
+  //! @name Using declarations
+  //@{
+  using BaseScalarFunction<V, M>::lnValue;
+  //@}
+
 protected:
   using BaseScalarFunction<V,M>::m_env;
   using BaseScalarFunction<V,M>::m_prefix;

--- a/src/stats/inc/JointPdf.h
+++ b/src/stats/inc/JointPdf.h
@@ -69,9 +69,6 @@ public:
   //! Actual value of the PDF (scalar function).
   virtual double actualValue                    (const V& domainVector, const V* domainDirection, V* gradVector, M* hessianMatrix, V* hessianEffect) const = 0;
 
-  //! Logarithm of the value of the function.
-  virtual double lnValue                        (const V& domainVector, const V* domainDirection, V* gradVector, M* hessianMatrix, V* hessianEffect) const = 0;
-
   /*! Mean value of the underlying random variable.
    * Not implemented in base class, but not pure virtual for backwards
    * compatibility reasons.

--- a/src/stats/src/Algorithm.C
+++ b/src/stats/src/Algorithm.C
@@ -104,12 +104,12 @@ Algorithm<V, M>::acceptance_ratio(
         }
       }
       else {
-        double qyx = m_tk.rv(tk_pos_x).pdf().lnValue(x.vecValues(),NULL,NULL,NULL,NULL);
+        double qyx = m_tk.rv(tk_pos_x).pdf().lnValue(x.vecValues());
         if ((m_env.subDisplayFile()                   ) &&
             (m_env.displayVerbosity() >= 10           )) {
           *m_env.subDisplayFile() << m_tk.rv(tk_pos_x).pdf() << std::endl;
         }
-        double qxy = m_tk.rv(tk_pos_y).pdf().lnValue(y.vecValues(),NULL,NULL,NULL,NULL);
+        double qxy = m_tk.rv(tk_pos_y).pdf().lnValue(y.vecValues());
         if ((m_env.subDisplayFile()                   ) &&
             (m_env.displayVerbosity() >= 10           )) {
           *m_env.subDisplayFile() << m_tk.rv(tk_pos_y).pdf() << std::endl;

--- a/src/stats/src/MetropolisAdjustedLangevinTK.C
+++ b/src/stats/src/MetropolisAdjustedLangevinTK.C
@@ -144,7 +144,7 @@ MetropolisAdjustedLangevinTK<V, M>::rv(const V & position) const
 
   // Get the gradient of the log-posterior.  This is so inefficient it's
   // painful.  We should be caching the gradient evaluations.
-  this->m_targetPdf.lnValue(position, NULL, &grad, NULL, NULL);
+  this->m_targetPdf.lnValue(position, grad);
 
   // Euler time-step
   grad *= 0.5 * this->m_time_step;

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -652,9 +652,9 @@ MetropolisHastingsSG<P_V,P_M>::alpha(
   const P_V& _lastTKPosition         = m_tk->preComputingPosition(        tkStageIds[inputSize-1]);
   const P_V& _lastBackwardTKPosition = m_tk->preComputingPosition(backwardTKStageIds[inputSize-1]);
 
-  double numContrib = m_tk->rv(backwardTKStageIdsLess1).pdf().lnValue(_lastBackwardTKPosition,NULL,NULL,NULL,NULL);
+  double numContrib = m_tk->rv(backwardTKStageIdsLess1).pdf().lnValue(_lastBackwardTKPosition);
 
-  double denContrib = m_tk->rv(tkStageIdsLess1).pdf().lnValue(_lastTKPosition,NULL,NULL,NULL,NULL);
+  double denContrib = m_tk->rv(tkStageIdsLess1).pdf().lnValue(_lastTKPosition);
   if ((m_env.subDisplayFile()                   ) &&
       (m_env.displayVerbosity() >= 10           ) &&
       (m_optionsObj->m_totallyMute == false)) {
@@ -682,9 +682,9 @@ MetropolisHastingsSG<P_V,P_M>::alpha(
             tkStageIdsLess1.pop_back();
     backwardTKStageIdsLess1.pop_back();
 
-    numContrib = m_tk->rv(backwardTKStageIdsLess1).pdf().lnValue(lastBackwardTKPosition,NULL,NULL,NULL,NULL);
+    numContrib = m_tk->rv(backwardTKStageIdsLess1).pdf().lnValue(lastBackwardTKPosition);
 
-    denContrib = m_tk->rv(tkStageIdsLess1).pdf().lnValue(lastTKPosition,NULL,NULL,NULL,NULL);
+    denContrib = m_tk->rv(tkStageIdsLess1).pdf().lnValue(lastTKPosition);
     if ((m_env.subDisplayFile()                   ) &&
         (m_env.displayVerbosity() >= 10           ) &&
         (m_optionsObj->m_totallyMute == false)) {

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -80,6 +80,7 @@ check_PROGRAMS += TgaValidationCycle_gsl
 check_PROGRAMS += SipSfpExample_gsl
 check_PROGRAMS += SequenceExample_gsl
 check_PROGRAMS += BimodalExample_gsl
+check_PROGRAMS += test_fd_fallback
 
 LDADD       = $(top_builddir)/src/libqueso.la
 
@@ -202,6 +203,7 @@ test_seq_of_vec_hdf5_write_SOURCES = test_SequenceOfVectors/test_HDF5Write.C
 test_optimizer_input_parameters_SOURCES = test_optimizer/test_optimizer_input_parameters.C
 test_sip_gslopt_options_SOURCES = test_optimizer/test_sip_gslopt_options.C
 test_mala_SOURCES = test_algorithms/test_mala.C
+test_fd_fallback_SOURCES = test_BaseScalarFunction/test_fd_fallback.C
 
 TgaValidationCycle_gsl_SOURCES =
 TgaValidationCycle_gsl_SOURCES += t01_valid_cycle/TgaValidationCycle_gsl.C
@@ -313,6 +315,7 @@ srcstamp += $(test_mala_SOURCES)
 srcstamp += $(TgaValidationCycle_gsl_SOURCES)
 srcstamp += $(SequenceExample_gsl_SOURCES)
 srcstamp += $(SipSfpExample_gsl_SOURCES)
+srcstamp += $(test_fd_fallback_SOURCES)
 
 TESTS =
 TESTS += test_gsl_get_set_row_column
@@ -394,6 +397,7 @@ TESTS += t01_valid_cycle/rtest01.sh
 TESTS += t02_sip_sfp/rtest02.sh
 # TESTS += rtest03.sh  # Leaving disabled for now, need to check with Ernesto
 TESTS += t04_bimodal/rtest04.sh
+TESTS += test_fd_fallback
 
 XFAIL_TESTS = test_SequenceOfVectorsErase
 if ! MPI_ENABLED

--- a/test/test_BaseScalarFunction/test_fd_fallback.C
+++ b/test/test_BaseScalarFunction/test_fd_fallback.C
@@ -1,0 +1,161 @@
+#include <iostream>
+#include <cmath>
+#include <queso/asserts.h>
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/VectorSet.h>
+#include <queso/VectorSpace.h>
+#include <queso/BoxSubset.h>
+#include <queso/ScalarFunction.h>
+#include <queso/GslOptimizer.h>
+#include <queso/OptimizerMonitor.h>
+
+// Common function for both objectives
+template <class V = QUESO::GslVector, class M = QUESO::GslMatrix>
+double
+f(const V & domainVector)
+{
+  // Mean = (1, 2, 3)
+  return -((domainVector[0] - 1)*(domainVector[0] - 1) +
+           (domainVector[1] - 2)*(domainVector[1] - 2) +
+           (domainVector[2] - 3)*(domainVector[2] - 3));
+}
+
+// Function without a gradient (falls back to finite difference approximation
+template <class V = QUESO::GslVector, class M = QUESO::GslMatrix>
+class ObjectiveFunctionWithoutGradient : public QUESO::BaseScalarFunction<V, M> {
+public:
+  ObjectiveFunctionWithoutGradient(const char * prefix,
+      const QUESO::VectorSet<V, M> & domainSet)
+    : QUESO::BaseScalarFunction<V, M>(prefix, domainSet) {
+      // Do nothing
+    }
+
+  virtual double actualValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const {
+    return std::exp(this->lnValue(domainVector, domainDirection,
+          gradVector, hessianMatrix, hessianEffect));
+  }
+
+  virtual double lnValue(const V & domainVector) const {
+    return f(domainVector);
+  }
+
+  using QUESO::BaseScalarFunction<V, M>::lnValue;
+};
+
+// Objective function with analytical gradient (same function basically)
+template <class V = QUESO::GslVector, class M = QUESO::GslMatrix>
+class ObjectiveFunctionWithGradient : public QUESO::BaseScalarFunction<V, M> {
+public:
+  ObjectiveFunctionWithGradient(const char * prefix,
+      const QUESO::VectorSet<V, M> & domainSet)
+    : QUESO::BaseScalarFunction<V, M>(prefix, domainSet) {
+      // Do nothing
+    }
+
+  virtual double actualValue(const V & domainVector, const V * domainDirection,
+      V * gradVector, M * hessianMatrix, V * hessianEffect) const {
+    return std::exp(this->lnValue(domainVector, domainDirection,
+          gradVector, hessianMatrix, hessianEffect));
+  }
+
+  virtual double lnValue(const V & domainVector) const {
+    return f(domainVector);
+  }
+
+  virtual double lnValue(const V & domainVector, V & gradVector) const {
+    gradVector[0] = -2.0 * (domainVector[0]-1);
+    gradVector[1] = -2.0 * (domainVector[1]-2);
+    gradVector[2] = -2.0 * (domainVector[2]-3);
+
+    return f(domainVector);
+  }
+
+  using QUESO::BaseScalarFunction<V, M>::lnValue;
+};
+
+int main(int argc, char ** argv) {
+#ifdef QUESO_HAS_MPI
+  MPI_Init(&argc, &argv);
+  QUESO::FullEnvironment env(MPI_COMM_WORLD, "", "", NULL);
+#else
+  QUESO::FullEnvironment env("", "", NULL);
+#endif
+
+  QUESO::VectorSpace<> paramSpace(env, "space_", 3, NULL);
+
+  QUESO::GslVector minBound(paramSpace.zeroVector());
+  minBound[0] = -10.0;
+  minBound[1] = -10.0;
+  minBound[2] = -10.0;
+
+  QUESO::GslVector maxBound(paramSpace.zeroVector());
+  maxBound[0] = 10.0;
+  maxBound[1] = 10.0;
+  maxBound[2] = 10.0;
+
+  QUESO::BoxSubset<> domain("", paramSpace, minBound, maxBound);
+
+  ObjectiveFunctionWithoutGradient<> objectiveFunctionWithoutGradient("", domain);
+  ObjectiveFunctionWithGradient<> objectiveFunctionWithGradient("", domain);
+
+  QUESO::GslVector point(paramSpace.zeroVector());
+  point[0] = 9.0;
+  point[1] = -9.0;
+  point[1] = -1.0;
+
+  double value1;
+  value1 = objectiveFunctionWithoutGradient.lnValue(point);
+
+  double value2;
+  value2 = objectiveFunctionWithGradient.lnValue(point);
+
+  double tol = 1e-13;
+  if (std::abs(value1 - value2) > tol) {
+    std::string msg;
+
+    msg += "Objective function values with and without gradients do not match";
+    queso_error_msg(msg);
+  }
+
+  QUESO::GslVector grad1(paramSpace.zeroVector());
+  QUESO::GslVector grad2(paramSpace.zeroVector());
+
+  objectiveFunctionWithoutGradient.lnValue(point, grad1);
+  objectiveFunctionWithGradient.lnValue(point, grad2);
+
+  std::cout << "grad1: " << std::endl;
+  std::cout << grad1 << std::endl;
+
+  std::cout << "grad2: " << std::endl;
+  std::cout << grad2 << std::endl;
+
+  grad1 -= grad2;
+
+  std::cout << "diff: " << std::endl;
+  std::cout << grad1 << std::endl;
+
+  double norm2 = grad1.norm2();  // Should be close to zero?
+
+  std::cout << "norm2: " << std::endl;
+  std::cout << norm2 << std::endl;
+
+  tol = 1e-5;  // Because this is a finite difference approximation, we use a
+               // much smaller tolerance for the following comparison.
+
+  if (std::abs(norm2) > tol) {
+    std::string msg;
+
+    msg += "Objective function gradients (finite diff and analytical) do not";
+    msg += " match.";
+
+    queso_error_msg(msg);
+  }
+
+#ifdef QUESO_HAS_MPI
+  MPI_Finalize();
+#endif
+
+  return 0;
+}


### PR DESCRIPTION
The pull request introduces a bunch of new virtual methods in `BaseScalarFunction` to allow the user to refuse to implement gradient-informed likelihoods, forcing QUESO to fall back to a finite difference approximation instead.  We've traded a compile-time error (not overriding a pure virtual method in a class that will be instantiated) with a run-time error (throw an exception when the user hasn't implemented any of the old or new `lnValue` methods), but I believe it's worth it given the added functionality.

Finite difference fallbacks for Hessian information are not implemented.  If QUESO asks for Hessian information and the user hasn't implemented it, an exception is thrown.  We suspect the user would never tolerate the a) inaccuracy; and b) expense of a first order finite difference approximation to a Hessian operator.

Test has been added.

I'm taking input as to how the finite difference step size should be set.  I'm currently leaning towards a member variable that is set programatically, but I'll also accept that another viable option is to have it set via an input file option.

This pull request fixes #475.