### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/core/src/InfiniteDimensionalGaussian.C
+++ b/src/core/src/InfiniteDimensionalGaussian.C
@@ -62,9 +62,11 @@ SharedPtr<FunctionBase>::Type InfiniteDimensionalGaussian::draw()
     (this->coeffs)[i] = env.rngObject()->gaussianSample(this->beta);
   }
 
-#warning We never use the mean?
+  SharedPtr<FunctionBase>::Type f(this->precision.inverse_kl_transform(this->coeffs, this->alpha));
 
-SharedPtr<FunctionBase>::Type f(this->precision.inverse_kl_transform(this->coeffs, this->alpha));
+  // Add on the mean
+  f->add(1.0, mean);
+
   return f;
 }
 

--- a/src/core/src/InfiniteDimensionalMCMCSampler.C
+++ b/src/core/src/InfiniteDimensionalMCMCSampler.C
@@ -264,7 +264,7 @@ hid_t InfiniteDimensionalMCMCSampler::_create_scalar_dataset(const std::string &
     return dset;
   }
 
-  hid_t dummy;
+  hid_t dummy = -1;
   return dummy;
 }
 
@@ -282,6 +282,7 @@ void InfiniteDimensionalMCMCSampler::_append_scalar_dataset(hid_t dset, double d
     // Set dims to be the *new* dimension of the extended dataset
     dims[0] = this->_iteration / this->m_ov->m_save_freq;
     err = H5Dset_extent(dset, dims);
+    queso_require_greater_equal_msg(err, 0, "H5DSet_extent(dset, dims) failed");
 
     // Select hyperslab on file dataset
     hid_t file_space = H5Dget_space(dset);
@@ -289,6 +290,7 @@ void InfiniteDimensionalMCMCSampler::_append_scalar_dataset(hid_t dset, double d
     hsize_t count[1] = {1};
 
     err = H5Sselect_hyperslab(file_space, H5S_SELECT_SET, start, NULL, count, NULL);
+    queso_require_greater_equal_msg(err, 0, "H5Sselect_hyperslab(file_space, H5S_SELECT_SET, start, NULL, count, NULL) failed");
 
     // hsize_t      size[1];
     // size[0]   = this->_iteration / this->m_ov->m_save_freq;


### PR DESCRIPTION
A silly unused variable warning, but also a more serious warning due to
not using the mean in random draws in the infinite dimensional case.