### PR TITLE
Tidy up `*Environment` memory management

### DIFF
--- a/src/core/inc/Environment.h
+++ b/src/core/inc/Environment.h
@@ -375,8 +375,8 @@ protected:
   std::string m_optionsInputFileName;
   mutable bool m_optionsInputFileAccessState; // Yes, 'mutable'
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
-  boost::program_options::options_description * m_allOptionsDesc;
-  boost::program_options::variables_map * m_allOptionsMap;
+  ScopedPtr<boost::program_options::options_description>::Type m_allOptionsDesc;
+  ScopedPtr<boost::program_options::variables_map>::Type m_allOptionsMap;
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
   ScopedPtr<GetPot>::Type m_input;
 

--- a/src/core/inc/Environment.h
+++ b/src/core/inc/Environment.h
@@ -363,41 +363,41 @@ public:
 
   //@}
 protected:
-  bool                            m_fullEnvIsReady;
-  int                                   m_worldRank;
+  bool m_fullEnvIsReady;
+  int m_worldRank;
 
-  MpiComm*                 m_fullComm;
-  int                        m_fullRank;
-  int                        m_fullCommSize;
-  RawType_MPI_Group        m_fullGroup;
+  MpiComm * m_fullComm;
+  int m_fullRank;
+  int m_fullCommSize;
+  RawType_MPI_Group m_fullGroup;
 
-  std::string                     m_optionsInputFileName;
-  mutable bool                    m_optionsInputFileAccessState; // Yes, 'mutable'
+  std::string m_optionsInputFileName;
+  mutable bool m_optionsInputFileAccessState; // Yes, 'mutable'
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
-  boost::program_options::options_description*   m_allOptionsDesc;
-  boost::program_options::variables_map*              m_allOptionsMap;
+  boost::program_options::options_description * m_allOptionsDesc;
+  boost::program_options::variables_map * m_allOptionsMap;
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
   ScopedPtr<GetPot>::Type m_input;
 
-  unsigned int               m_subId;
-  std::string                      m_subIdString;
-  RawType_MPI_Group        m_subGroup;
-  MpiComm*            m_subComm;
-  int                             m_subRank;
-  int                             m_subCommSize;
+  unsigned int m_subId;
+  std::string m_subIdString;
+  RawType_MPI_Group m_subGroup;
+  MpiComm * m_subComm;
+  int m_subRank;
+  int m_subCommSize;
 
-  MpiComm*            m_selfComm;
+  MpiComm * m_selfComm;
 
-  RawType_MPI_Group        m_inter0Group;
-  MpiComm*            m_inter0Comm;
-  int                             m_inter0Rank;
-  int                        m_inter0CommSize;
+  RawType_MPI_Group m_inter0Group;
+  MpiComm * m_inter0Comm;
+  int m_inter0Rank;
+  int m_inter0CommSize;
 
-  mutable std::ofstream*     m_subDisplayFile;
-  RngBase*                 m_rngObject;
-  BasicPdfsBase*      m_basicPdfs;
-  struct timeval             m_timevalBegin;
-  mutable bool                    m_exceptionalCircumstance;
+  mutable std::ofstream * m_subDisplayFile;
+  RngBase * m_rngObject;
+  BasicPdfsBase * m_basicPdfs;
+  struct timeval m_timevalBegin;
+  mutable bool m_exceptionalCircumstance;
 
   EnvOptionsValues * m_optionsObj;
 };

--- a/src/core/inc/Environment.h
+++ b/src/core/inc/Environment.h
@@ -382,7 +382,7 @@ protected:
   unsigned int m_subId;
   std::string m_subIdString;
   RawType_MPI_Group m_subGroup;
-  MpiComm * m_subComm;
+  ScopedPtr<MpiComm>::Type m_subComm;
   int m_subRank;
   int m_subCommSize;
 

--- a/src/core/inc/Environment.h
+++ b/src/core/inc/Environment.h
@@ -386,7 +386,7 @@ protected:
   int m_subRank;
   int m_subCommSize;
 
-  MpiComm * m_selfComm;
+  ScopedPtr<MpiComm>::Type m_selfComm;
 
   RawType_MPI_Group m_inter0Group;
   MpiComm * m_inter0Comm;

--- a/src/core/inc/Environment.h
+++ b/src/core/inc/Environment.h
@@ -366,7 +366,7 @@ protected:
   bool m_fullEnvIsReady;
   int m_worldRank;
 
-  MpiComm * m_fullComm;
+  ScopedPtr<MpiComm>::Type m_fullComm;
   int m_fullRank;
   int m_fullCommSize;
   RawType_MPI_Group m_fullGroup;

--- a/src/core/inc/Environment.h
+++ b/src/core/inc/Environment.h
@@ -394,7 +394,7 @@ protected:
   int m_inter0CommSize;
 
   mutable ScopedPtr<std::ofstream>::Type m_subDisplayFile;
-  RngBase * m_rngObject;
+  ScopedPtr<RngBase>::Type m_rngObject;
   BasicPdfsBase * m_basicPdfs;
   struct timeval m_timevalBegin;
   mutable bool m_exceptionalCircumstance;

--- a/src/core/inc/Environment.h
+++ b/src/core/inc/Environment.h
@@ -389,7 +389,7 @@ protected:
   ScopedPtr<MpiComm>::Type m_selfComm;
 
   RawType_MPI_Group m_inter0Group;
-  MpiComm * m_inter0Comm;
+  ScopedPtr<MpiComm>::Type m_inter0Comm;
   int m_inter0Rank;
   int m_inter0CommSize;
 

--- a/src/core/inc/Environment.h
+++ b/src/core/inc/Environment.h
@@ -29,15 +29,14 @@
 #undef UQ_USES_COMMAND_LINE_OPTIONS
 
 #include <queso/MpiComm.h>
+#include <queso/ScopedPtr.h>
+
 #ifdef QUESO_HAS_HDF5
 #include <hdf5.h>
 #endif
 #include <iostream>
 #include <fstream>
 
-#include <queso/ScopedPtr.h>
-#include <queso/RngBase.h>
-#include <queso/BasicPdfsBase.h>
 
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
 // Forward declarations
@@ -55,6 +54,8 @@ namespace QUESO {
 class GetPot;
 class EnvironmentOptions;
 class EnvOptionsValues;
+class BasicPdfsBase;
+class RngBase;
 
 
   /*! queso_terminate_handler

--- a/src/core/inc/Environment.h
+++ b/src/core/inc/Environment.h
@@ -330,21 +330,21 @@ public:
 
   //! Opens an output file for each sub-environment that was chosen to send data to the file.
   bool    openOutputFile(const std::string& fileName, const std::string& fileType,
-			 const std::set<unsigned int>& allowedSubEnvIds, bool writeOver,
-			 FilePtrSetStruct& filePtrSet) const;
+                         const std::set<unsigned int>& allowedSubEnvIds, bool writeOver,
+                         FilePtrSetStruct& filePtrSet) const;
 
   //! Opens a unified output file, that will contain data from all sub-environments.
   bool    openUnifiedOutputFile (const std::string& fileName, const std::string& fileType,
-				 bool writeOver, FilePtrSetStruct& filePtrSet) const;
+                                 bool writeOver, FilePtrSetStruct& filePtrSet) const;
 
   //! Opens an input file.
   bool    openInputFile (const std::string& fileName, const std::string& fileType,
-			 const std::set<unsigned int>& allowedSubEnvIds,
-			 FilePtrSetStruct& filePtrSet) const;
+                         const std::set<unsigned int>& allowedSubEnvIds,
+                         FilePtrSetStruct& filePtrSet) const;
 
   //! Opens the unified input file.
   bool    openUnifiedInputFile  (const std::string& fileName, const std::string& fileType,
-				 FilePtrSetStruct& filePtrSet) const;
+                                 FilePtrSetStruct& filePtrSet) const;
 
   //! Closes the file.
   void    closeFile     (FilePtrSetStruct& filePtrSet, const std::string& fileType) const;
@@ -363,41 +363,41 @@ public:
 
   //@}
 protected:
-  bool       		     m_fullEnvIsReady;
-  int 	     		     m_worldRank;
+  bool                            m_fullEnvIsReady;
+  int                                   m_worldRank;
 
-  MpiComm*    	     m_fullComm;
+  MpiComm*                 m_fullComm;
   int                        m_fullRank;
   int                        m_fullCommSize;
   RawType_MPI_Group        m_fullGroup;
 
-  std::string		     m_optionsInputFileName;
-  mutable bool       	     m_optionsInputFileAccessState; // Yes, 'mutable'
+  std::string                     m_optionsInputFileName;
+  mutable bool                    m_optionsInputFileAccessState; // Yes, 'mutable'
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
   boost::program_options::options_description*   m_allOptionsDesc;
-  boost::program_options::variables_map* 	     m_allOptionsMap;
+  boost::program_options::variables_map*              m_allOptionsMap;
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
   ScopedPtr<GetPot>::Type m_input;
 
   unsigned int               m_subId;
-  std::string 		     m_subIdString;
+  std::string                      m_subIdString;
   RawType_MPI_Group        m_subGroup;
   MpiComm*            m_subComm;
-  int			     m_subRank;
-  int			     m_subCommSize;
+  int                             m_subRank;
+  int                             m_subCommSize;
 
   MpiComm*            m_selfComm;
 
   RawType_MPI_Group        m_inter0Group;
   MpiComm*            m_inter0Comm;
-  int	                     m_inter0Rank;
+  int                             m_inter0Rank;
   int                        m_inter0CommSize;
 
   mutable std::ofstream*     m_subDisplayFile;
-  RngBase*    	     m_rngObject;
+  RngBase*                 m_rngObject;
   BasicPdfsBase*      m_basicPdfs;
   struct timeval             m_timevalBegin;
-  mutable bool       	     m_exceptionalCircumstance;
+  mutable bool                    m_exceptionalCircumstance;
 
   EnvOptionsValues * m_optionsObj;
 };
@@ -469,22 +469,22 @@ public:
   //! @name I/O methods
   //@{
   //! Sends the environment options to the stream.
-  void	print       (std::ostream& os) const;
+  void        print       (std::ostream& os) const;
   //@}
 
 private:
 #ifdef QUESO_HAS_MPI
   //! Named constructor backend for multiple constructor overloads
-  void	construct(RawType_MPI_Comm inputComm,
+  void        construct(RawType_MPI_Comm inputComm,
                   const char *prefix);
 #endif
 
   //! Named constructor backend for multiple constructor overloads
-  void	construct(const char *prefix);
+  void        construct(const char *prefix);
 
   //! Checks the options input file and reads the options.
-  void	readOptionsInputFile();
-  //void	queso_terminate_handler();
+  void        readOptionsInputFile();
+  //void        queso_terminate_handler();
 
 };
 

--- a/src/core/inc/Environment.h
+++ b/src/core/inc/Environment.h
@@ -400,7 +400,7 @@ protected:
   struct timeval m_timevalBegin;
   mutable bool m_exceptionalCircumstance;
 
-  EnvOptionsValues * m_optionsObj;
+  ScopedPtr<EnvOptionsValues>::Type m_optionsObj;
 };
 
 //*****************************************************

--- a/src/core/inc/Environment.h
+++ b/src/core/inc/Environment.h
@@ -393,7 +393,7 @@ protected:
   int m_inter0Rank;
   int m_inter0CommSize;
 
-  mutable std::ofstream * m_subDisplayFile;
+  mutable ScopedPtr<std::ofstream>::Type m_subDisplayFile;
   RngBase * m_rngObject;
   BasicPdfsBase * m_basicPdfs;
   struct timeval m_timevalBegin;

--- a/src/core/inc/Environment.h
+++ b/src/core/inc/Environment.h
@@ -395,7 +395,7 @@ protected:
 
   mutable ScopedPtr<std::ofstream>::Type m_subDisplayFile;
   ScopedPtr<RngBase>::Type m_rngObject;
-  BasicPdfsBase * m_basicPdfs;
+  ScopedPtr<BasicPdfsBase>::Type m_basicPdfs;
   struct timeval m_timevalBegin;
   mutable bool m_exceptionalCircumstance;
 

--- a/src/core/src/Environment.C
+++ b/src/core/src/Environment.C
@@ -150,8 +150,8 @@ BaseEnvironment::BaseEnvironment(
   m_optionsInputFileName       (""),
   m_optionsInputFileAccessState(true),
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
-  m_allOptionsDesc             (NULL),
-  m_allOptionsMap              (NULL),
+  m_allOptionsDesc             (),
+  m_allOptionsMap              (),
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
   m_input                      (new GetPot),
   m_subComm                    (),
@@ -189,8 +189,8 @@ BaseEnvironment::BaseEnvironment(
   m_optionsInputFileName       (passedOptionsInputFileName),
   m_optionsInputFileAccessState(true),
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
-  m_allOptionsDesc             (NULL),
-  m_allOptionsMap              (NULL),
+  m_allOptionsDesc             (),
+  m_allOptionsMap              (),
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
   m_input                      (new GetPot),
   m_subComm                    (),
@@ -241,13 +241,6 @@ BaseEnvironment::~BaseEnvironment()
                 << std::endl;
       }
     }
-
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
-  if (m_allOptionsMap) {
-    delete m_allOptionsMap;
-    delete m_allOptionsDesc;
-  }
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 
   //if (m_subDisplayFile) {
   //  *m_subDisplayFile << "Leaving BaseEnvironment::destructor()"
@@ -1239,8 +1232,8 @@ FullEnvironment::construct (RawType_MPI_Comm inputComm,
     // defaults are used
     if (m_optionsInputFileName != "") {
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
-      m_allOptionsMap  = new boost::program_options::variables_map();
-      m_allOptionsDesc = new boost::program_options::options_description("Allowed options");
+      m_allOptionsMap.reset(new boost::program_options::variables_map());
+      m_allOptionsDesc.reset(new boost::program_options::options_description("Allowed options"));
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 
       readOptionsInputFile();
@@ -1512,8 +1505,8 @@ FullEnvironment::construct (const char *prefix)
     // defaults are used
     if (m_optionsInputFileName != "") {
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
-      m_allOptionsMap  = new boost::program_options::variables_map();
-      m_allOptionsDesc = new boost::program_options::options_description("Allowed options");
+      m_allOptionsMap.reset(new boost::program_options::variables_map());
+      m_allOptionsDesc.reset(new boost::program_options::options_description("Allowed options"));
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 
       readOptionsInputFile();

--- a/src/core/src/Environment.C
+++ b/src/core/src/Environment.C
@@ -161,7 +161,7 @@ BaseEnvironment::BaseEnvironment(
   m_inter0Comm                 (),
   m_inter0Rank                 (-1),
   m_inter0CommSize             (1),
-  m_subDisplayFile             (NULL),
+  m_subDisplayFile             (),
   m_rngObject                  (NULL),
   m_basicPdfs                  (NULL),
   m_exceptionalCircumstance    (false),
@@ -193,7 +193,7 @@ BaseEnvironment::BaseEnvironment(
   m_inter0Comm                 (),
   m_inter0Rank                 (-1),
   m_inter0CommSize             (1),
-  m_subDisplayFile             (NULL),
+  m_subDisplayFile             (),
   m_rngObject                  (NULL),
   m_basicPdfs                  (NULL),
   m_exceptionalCircumstance    (false),
@@ -243,8 +243,6 @@ BaseEnvironment::~BaseEnvironment()
   //  *m_subDisplayFile << "Leaving BaseEnvironment::destructor()"
   //                          << std::endl;
   //}
-
-  if (m_subDisplayFile) delete m_subDisplayFile;
 }
 // Environment, Communicator and Options Input File methods
 bool
@@ -314,7 +312,8 @@ BaseEnvironment::inter0Comm() const
 std::ofstream*
 BaseEnvironment::subDisplayFile() const
 {
-  return m_subDisplayFile;
+  // Potentially dangerous?  The user might delete it...
+  return m_subDisplayFile.get();
 }
 //-------------------------------------------------------
 std::string
@@ -1372,8 +1371,8 @@ FullEnvironment::construct (RawType_MPI_Comm inputComm,
     //////////////////////////////////////////////////////////////////
     // Always write over an eventual pre-existing file
     //////////////////////////////////////////////////////////////////
-    m_subDisplayFile = new std::ofstream((m_optionsObj->m_subDisplayFileName+"_sub"+m_subIdString+".txt").c_str(),
-                                         std::ofstream::out | std::ofstream::trunc);
+    m_subDisplayFile.reset(new std::ofstream((m_optionsObj->m_subDisplayFileName+"_sub"+m_subIdString+".txt").c_str(),
+                                         std::ofstream::out | std::ofstream::trunc));
     queso_require_msg((m_subDisplayFile && m_subDisplayFile->is_open()), "failed to open sub screen file");
 
     QUESO_version_print(*m_subDisplayFile);
@@ -1628,8 +1627,8 @@ FullEnvironment::construct (const char *prefix)
     //////////////////////////////////////////////////////////////////
     // Always write over an eventual pre-existing file
     //////////////////////////////////////////////////////////////////
-    m_subDisplayFile = new std::ofstream((m_optionsObj->m_subDisplayFileName+"_sub"+m_subIdString+".txt").c_str(),
-                                         std::ofstream::out | std::ofstream::trunc);
+    m_subDisplayFile.reset(new std::ofstream((m_optionsObj->m_subDisplayFileName+"_sub"+m_subIdString+".txt").c_str(),
+                                         std::ofstream::out | std::ofstream::trunc));
     queso_require_msg((m_subDisplayFile && m_subDisplayFile->is_open()), "failed to open sub screen file");
 
     QUESO_version_print(*m_subDisplayFile);

--- a/src/core/src/Environment.C
+++ b/src/core/src/Environment.C
@@ -157,7 +157,7 @@ BaseEnvironment::BaseEnvironment(
   m_subComm                    (),
   m_subRank                    (-1),
   m_subCommSize                (1),
-  m_selfComm                   (NULL),
+  m_selfComm                   (),
   m_inter0Comm                 (NULL),
   m_inter0Rank                 (-1),
   m_inter0CommSize             (1),
@@ -189,7 +189,7 @@ BaseEnvironment::BaseEnvironment(
   m_subComm                    (),
   m_subRank                    (-1),
   m_subCommSize                (1),
-  m_selfComm                   (NULL),
+  m_selfComm                   (),
   m_inter0Comm                 (NULL),
   m_inter0Rank                 (-1),
   m_inter0CommSize             (1),
@@ -246,7 +246,6 @@ BaseEnvironment::~BaseEnvironment()
 
   if (m_subDisplayFile) delete m_subDisplayFile;
   if (m_inter0Comm    ) delete m_inter0Comm;
-  if (m_selfComm      ) delete m_selfComm;
 }
 // Environment, Communicator and Options Input File methods
 bool
@@ -1316,7 +1315,7 @@ FullEnvironment::construct (RawType_MPI_Comm inputComm,
   //////////////////////////////////////////////////
   // Deal with multiple subEnvironments: create the self communicator
   //////////////////////////////////////////////////
-  m_selfComm = new MpiComm(*this,RawValue_MPI_COMM_SELF);
+  m_selfComm.reset(new MpiComm(*this,RawValue_MPI_COMM_SELF));
 
   //////////////////////////////////////////////////
   // Deal with multiple subEnvironments: create the inter0 communicator
@@ -1579,7 +1578,7 @@ FullEnvironment::construct (const char *prefix)
   //////////////////////////////////////////////////
   // Deal with multiple subEnvironments: create the self communicator
   //////////////////////////////////////////////////
-  m_selfComm = new MpiComm(*this);
+  m_selfComm.reset(new MpiComm(*this));
 
   //////////////////////////////////////////////////
   // Deal with multiple subEnvironments: create the inter0 communicator

--- a/src/core/src/Environment.C
+++ b/src/core/src/Environment.C
@@ -162,7 +162,7 @@ BaseEnvironment::BaseEnvironment(
   m_inter0Rank                 (-1),
   m_inter0CommSize             (1),
   m_subDisplayFile             (),
-  m_rngObject                  (NULL),
+  m_rngObject                  (),
   m_basicPdfs                  (NULL),
   m_exceptionalCircumstance    (false),
   m_optionsObj                 (alternativeOptionsValues)
@@ -194,7 +194,7 @@ BaseEnvironment::BaseEnvironment(
   m_inter0Rank                 (-1),
   m_inter0CommSize             (1),
   m_subDisplayFile             (),
-  m_rngObject                  (NULL),
+  m_rngObject                  (),
   m_basicPdfs                  (NULL),
   m_exceptionalCircumstance    (false),
   m_optionsObj                 (alternativeOptionsValues)
@@ -237,7 +237,6 @@ BaseEnvironment::~BaseEnvironment()
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 
   if (m_basicPdfs) delete m_basicPdfs;
-  if (m_rngObject) delete m_rngObject;
 
   //if (m_subDisplayFile) {
   //  *m_subDisplayFile << "Leaving BaseEnvironment::destructor()"
@@ -463,7 +462,7 @@ BaseEnvironment::checkingLevel() const
 const RngBase*
 BaseEnvironment::rngObject() const
 {
-  return m_rngObject;
+  return m_rngObject.get();
 }
 //-------------------------------------------------------
 int
@@ -1424,11 +1423,11 @@ FullEnvironment::construct (RawType_MPI_Comm inputComm,
   // Deal with seed
   //////////////////////////////////////////////////
   if (m_optionsObj->m_rngType == "gsl") {
-    m_rngObject = new RngGsl(m_optionsObj->m_seed,m_worldRank);
+    m_rngObject.reset(new RngGsl(m_optionsObj->m_seed,m_worldRank));
     m_basicPdfs = new BasicPdfsGsl(m_worldRank);
   }
   else if (m_optionsObj->m_rngType == "boost") {
-    m_rngObject = new RngBoost(m_optionsObj->m_seed,m_worldRank);
+    m_rngObject.reset(new RngBoost(m_optionsObj->m_seed,m_worldRank));
     m_basicPdfs = new BasicPdfsBoost(m_worldRank);
   }
   else {
@@ -1673,11 +1672,11 @@ FullEnvironment::construct (const char *prefix)
   // Deal with seed
   //////////////////////////////////////////////////
   if (m_optionsObj->m_rngType == "gsl") {
-    m_rngObject = new RngGsl(m_optionsObj->m_seed,m_worldRank);
+    m_rngObject.reset(new RngGsl(m_optionsObj->m_seed,m_worldRank));
     m_basicPdfs = new BasicPdfsGsl(m_worldRank);
   }
   else if (m_optionsObj->m_rngType == "boost") {
-    m_rngObject = new RngBoost(m_optionsObj->m_seed,m_worldRank);
+    m_rngObject.reset(new RngBoost(m_optionsObj->m_seed,m_worldRank));
     m_basicPdfs = new BasicPdfsBoost(m_worldRank);
   }
   else {

--- a/src/core/src/Environment.C
+++ b/src/core/src/Environment.C
@@ -213,20 +213,19 @@ BaseEnvironment::~BaseEnvironment()
   /*int iRC = 0;*/
   /*iRC = */gettimeofday(&timevalNow, NULL);
 
-  if( this->displayVerbosity() > 0 )
-    {
-     if (m_subDisplayFile) {
-	*m_subDisplayFile << "Ending run at "    << ctime(&timevalNow.tv_sec)
-			  << "Total run time = " << timevalNow.tv_sec - m_timevalBegin.tv_sec
-			  << " seconds"
-			  << std::endl;
-      }
+  if (this->displayVerbosity() > 0) {
+    if (m_subDisplayFile) {
+       *m_subDisplayFile << "Ending run at "    << ctime(&timevalNow.tv_sec)
+                         << "Total run time = " << timevalNow.tv_sec - m_timevalBegin.tv_sec
+                         << " seconds"
+                         << std::endl;
+    }
 
     if (m_fullRank == 0) {
-	std::cout << "Ending run at "    << ctime(&timevalNow.tv_sec)
-		  << "Total run time = " << timevalNow.tv_sec - m_timevalBegin.tv_sec
-		  << " seconds"
-		  << std::endl;
+      std::cout << "Ending run at "    << ctime(&timevalNow.tv_sec)
+                << "Total run time = " << timevalNow.tv_sec - m_timevalBegin.tv_sec
+                << " seconds"
+                << std::endl;
       }
     }
 
@@ -1405,7 +1404,7 @@ FullEnvironment::construct (RawType_MPI_Comm inputComm,
         for (unsigned int j = 0; j < fullRanksOfMySubEnvironment.size(); ++j) {
           std::cout << " " << fullRanksOfMySubEnvironment[j];
         }
-	std::cout << "\n";
+        std::cout << "\n";
 
         if (m_inter0Comm) {
           std::cout << "MPI node of worldRank " << m_worldRank
@@ -1415,9 +1414,9 @@ FullEnvironment::construct (RawType_MPI_Comm inputComm,
           }
           std::cout << ", and has inter0Rank " << m_inter0Rank;
         }
-	std::cout << "\n";
+        std::cout << "\n";
 
-	std::cout << std::endl;
+        std::cout << std::endl;
       }
       m_fullComm->Barrier();
     }

--- a/src/core/src/Environment.C
+++ b/src/core/src/Environment.C
@@ -154,7 +154,7 @@ BaseEnvironment::BaseEnvironment(
   m_allOptionsMap              (NULL),
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
   m_input                      (new GetPot),
-  m_subComm                    (NULL),
+  m_subComm                    (),
   m_subRank                    (-1),
   m_subCommSize                (1),
   m_selfComm                   (NULL),
@@ -186,7 +186,7 @@ BaseEnvironment::BaseEnvironment(
   m_allOptionsMap              (NULL),
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
   m_input                      (new GetPot),
-  m_subComm                    (NULL),
+  m_subComm                    (),
   m_subRank                    (-1),
   m_subCommSize                (1),
   m_selfComm                   (NULL),
@@ -247,7 +247,6 @@ BaseEnvironment::~BaseEnvironment()
   if (m_subDisplayFile) delete m_subDisplayFile;
   if (m_inter0Comm    ) delete m_inter0Comm;
   if (m_selfComm      ) delete m_selfComm;
-  if (m_subComm       ) delete m_subComm;
 }
 // Environment, Communicator and Options Input File methods
 bool
@@ -1310,7 +1309,7 @@ FullEnvironment::construct (RawType_MPI_Comm inputComm,
   RawType_MPI_Comm subRawComm;
   mpiRC = MPI_Comm_create(m_fullComm->Comm(), m_subGroup, &subRawComm);
   queso_require_equal_to_msg(mpiRC, MPI_SUCCESS, "failed MPI_Comm_group() for a subEnvironment");
-  m_subComm = new MpiComm(*this,subRawComm);
+  m_subComm.reset(new MpiComm(*this,subRawComm));
   m_subRank     = m_subComm->MyPID();
   m_subCommSize = m_subComm->NumProc();
 
@@ -1573,7 +1572,7 @@ FullEnvironment::construct (const char *prefix)
   m_subGroup = 0;
 #endif
 
-  m_subComm = new MpiComm(*this);
+  m_subComm.reset(new MpiComm(*this));
   m_subRank     = 0;
   m_subCommSize = 1;
 

--- a/src/core/src/Environment.C
+++ b/src/core/src/Environment.C
@@ -163,7 +163,7 @@ BaseEnvironment::BaseEnvironment(
   m_inter0CommSize             (1),
   m_subDisplayFile             (),
   m_rngObject                  (),
-  m_basicPdfs                  (NULL),
+  m_basicPdfs                  (),
   m_exceptionalCircumstance    (false),
   m_optionsObj                 (alternativeOptionsValues)
 {
@@ -195,7 +195,7 @@ BaseEnvironment::BaseEnvironment(
   m_inter0CommSize             (1),
   m_subDisplayFile             (),
   m_rngObject                  (),
-  m_basicPdfs                  (NULL),
+  m_basicPdfs                  (),
   m_exceptionalCircumstance    (false),
   m_optionsObj                 (alternativeOptionsValues)
 {
@@ -235,8 +235,6 @@ BaseEnvironment::~BaseEnvironment()
     delete m_allOptionsDesc;
   }
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
-
-  if (m_basicPdfs) delete m_basicPdfs;
 
   //if (m_subDisplayFile) {
   //  *m_subDisplayFile << "Leaving BaseEnvironment::destructor()"
@@ -481,7 +479,7 @@ BaseEnvironment::resetSeed(int newSeedOption)
 const BasicPdfsBase*
 BaseEnvironment::basicPdfs() const
 {
-  return m_basicPdfs;
+  return m_basicPdfs.get();
 }
 //-------------------------------------------------------
 std::string
@@ -1424,11 +1422,11 @@ FullEnvironment::construct (RawType_MPI_Comm inputComm,
   //////////////////////////////////////////////////
   if (m_optionsObj->m_rngType == "gsl") {
     m_rngObject.reset(new RngGsl(m_optionsObj->m_seed,m_worldRank));
-    m_basicPdfs = new BasicPdfsGsl(m_worldRank);
+    m_basicPdfs.reset(new BasicPdfsGsl(m_worldRank));
   }
   else if (m_optionsObj->m_rngType == "boost") {
     m_rngObject.reset(new RngBoost(m_optionsObj->m_seed,m_worldRank));
-    m_basicPdfs = new BasicPdfsBoost(m_worldRank);
+    m_basicPdfs.reset(new BasicPdfsBoost(m_worldRank));
   }
   else {
     std::cerr << "In Environment::constructor()"
@@ -1673,11 +1671,11 @@ FullEnvironment::construct (const char *prefix)
   //////////////////////////////////////////////////
   if (m_optionsObj->m_rngType == "gsl") {
     m_rngObject.reset(new RngGsl(m_optionsObj->m_seed,m_worldRank));
-    m_basicPdfs = new BasicPdfsGsl(m_worldRank);
+    m_basicPdfs.reset(new BasicPdfsGsl(m_worldRank));
   }
   else if (m_optionsObj->m_rngType == "boost") {
     m_rngObject.reset(new RngBoost(m_optionsObj->m_seed,m_worldRank));
-    m_basicPdfs = new BasicPdfsBoost(m_worldRank);
+    m_basicPdfs.reset(new BasicPdfsBoost(m_worldRank));
   }
   else {
     std::cerr << "In Environment::constructor()"

--- a/src/core/src/Environment.C
+++ b/src/core/src/Environment.C
@@ -165,9 +165,16 @@ BaseEnvironment::BaseEnvironment(
   m_rngObject                  (),
   m_basicPdfs                  (),
   m_exceptionalCircumstance    (false),
-  m_optionsObj                 (alternativeOptionsValues)
+  m_optionsObj                 ()
 {
   if (passedOptionsInputFileName) m_optionsInputFileName     = passedOptionsInputFileName;
+
+  // If the user passed in an options object pointer, we really shouldn't let
+  // ScopedPtr delete their object, so we make a copy.  That way, the dtor
+  // will kill this local copy and leave the user's object in tact.
+  if (alternativeOptionsValues != NULL) {
+    m_optionsObj.reset(new EnvOptionsValues(*alternativeOptionsValues));
+  }
 }
 
 BaseEnvironment::BaseEnvironment(
@@ -197,8 +204,14 @@ BaseEnvironment::BaseEnvironment(
   m_rngObject                  (),
   m_basicPdfs                  (),
   m_exceptionalCircumstance    (false),
-  m_optionsObj                 (alternativeOptionsValues)
+  m_optionsObj                 ()
 {
+  // If the user passed in an options object pointer, we really shouldn't let
+  // ScopedPtr delete their object, so we make a copy.  That way, the dtor
+  // will kill this local copy and leave the user's object in tact.
+  if (alternativeOptionsValues != NULL) {
+    m_optionsObj.reset(new EnvOptionsValues(*alternativeOptionsValues));
+  }
 }
 
 // Destructor -------------------------------------------
@@ -1235,11 +1248,7 @@ FullEnvironment::construct (RawType_MPI_Comm inputComm,
       m_input->parse_input_file(m_optionsInputFileName);
     }
 
-    EnvOptionsValues * tempOptions = new EnvOptionsValues(this, prefix);
-
-    // We did this dance because scanOptionsValues is not a const method, but
-    // m_optionsObj is a pointer to const
-    m_optionsObj = tempOptions;
+    m_optionsObj.reset(new EnvOptionsValues(this, prefix));
   }
 
   // If help option was supplied, print info
@@ -1512,11 +1521,7 @@ FullEnvironment::construct (const char *prefix)
       m_input->parse_input_file(m_optionsInputFileName);
     }
 
-    EnvOptionsValues * tempOptions = new EnvOptionsValues(this, prefix);
-
-    // We did this dance because scanOptionsValues is not a const method, but
-    // m_optionsObj is a pointer to const
-    m_optionsObj = tempOptions;
+    m_optionsObj.reset(new EnvOptionsValues(this, prefix));
   }
 
   // If help option was supplied, print info

--- a/src/core/src/Environment.C
+++ b/src/core/src/Environment.C
@@ -158,7 +158,7 @@ BaseEnvironment::BaseEnvironment(
   m_subRank                    (-1),
   m_subCommSize                (1),
   m_selfComm                   (),
-  m_inter0Comm                 (NULL),
+  m_inter0Comm                 (),
   m_inter0Rank                 (-1),
   m_inter0CommSize             (1),
   m_subDisplayFile             (NULL),
@@ -190,7 +190,7 @@ BaseEnvironment::BaseEnvironment(
   m_subRank                    (-1),
   m_subCommSize                (1),
   m_selfComm                   (),
-  m_inter0Comm                 (NULL),
+  m_inter0Comm                 (),
   m_inter0Rank                 (-1),
   m_inter0CommSize             (1),
   m_subDisplayFile             (NULL),
@@ -245,7 +245,6 @@ BaseEnvironment::~BaseEnvironment()
   //}
 
   if (m_subDisplayFile) delete m_subDisplayFile;
-  if (m_inter0Comm    ) delete m_inter0Comm;
 }
 // Environment, Communicator and Options Input File methods
 bool
@@ -1330,7 +1329,7 @@ FullEnvironment::construct (RawType_MPI_Comm inputComm,
   mpiRC = MPI_Comm_create(m_fullComm->Comm(), m_inter0Group, &inter0RawComm);
   queso_require_equal_to_msg(mpiRC, MPI_SUCCESS, "failed MPI_Comm_group() for inter0");
   if (m_fullRank%numRanksPerSubEnvironment == 0) {
-    m_inter0Comm = new MpiComm(*this,inter0RawComm);
+    m_inter0Comm.reset(new MpiComm(*this,inter0RawComm));
     m_inter0Rank     = m_inter0Comm->MyPID();
     m_inter0CommSize = m_inter0Comm->NumProc();
   }
@@ -1587,7 +1586,7 @@ FullEnvironment::construct (const char *prefix)
 #ifndef QUESO_HAS_MPI
   m_inter0Group = 0;
 #endif
-  m_inter0Comm = new MpiComm(*this);
+  m_inter0Comm.reset(new MpiComm(*this));
   m_inter0Rank     = 0;
   m_inter0CommSize = 1;
 

--- a/src/core/src/Environment.C
+++ b/src/core/src/Environment.C
@@ -144,7 +144,7 @@ BaseEnvironment::BaseEnvironment(
   :
   m_fullEnvIsReady             (false),
   m_worldRank                  (-1),
-  m_fullComm                   (NULL),
+  m_fullComm                   (),
   m_fullRank                   (-1),
   m_fullCommSize               (1),
   m_optionsInputFileName       (""),
@@ -176,7 +176,7 @@ BaseEnvironment::BaseEnvironment(
   :
   m_fullEnvIsReady             (false),
   m_worldRank                  (-1),
-  m_fullComm                   (NULL),
+  m_fullComm                   (),
   m_fullRank                   (-1),
   m_fullCommSize               (1),
   m_optionsInputFileName       (passedOptionsInputFileName),
@@ -248,7 +248,6 @@ BaseEnvironment::~BaseEnvironment()
   if (m_inter0Comm    ) delete m_inter0Comm;
   if (m_selfComm      ) delete m_selfComm;
   if (m_subComm       ) delete m_subComm;
-  if (m_fullComm      ) delete m_fullComm;
 }
 // Environment, Communicator and Options Input File methods
 bool
@@ -1210,7 +1209,7 @@ FullEnvironment::construct (RawType_MPI_Comm inputComm,
   int mpiRC = MPI_Comm_rank(inputComm,&m_worldRank);
   queso_require_equal_to_msg(mpiRC, MPI_SUCCESS, "failed to get world fullRank()");
 
-  m_fullComm = new MpiComm(*this,inputComm);
+  m_fullComm.reset(new MpiComm(*this,inputComm));
 
   m_fullRank     = m_fullComm->MyPID();
   m_fullCommSize = m_fullComm->NumProc();
@@ -1487,7 +1486,7 @@ FullEnvironment::construct (const char *prefix)
 
   m_worldRank = 0;
 
-  m_fullComm = new MpiComm(*this);
+  m_fullComm.reset(new MpiComm(*this));
   m_fullRank     = 0;
   m_fullCommSize = 1;
 

--- a/src/core/src/GslVector.C
+++ b/src/core/src/GslVector.C
@@ -22,9 +22,10 @@
 //
 //-----------------------------------------------------------------------el-
 
-#include <algorithm>
-#include <queso/GslVector.h>
 #include <queso/Defines.h>
+#include <queso/GslVector.h>
+#include <queso/RngBase.h>
+#include <algorithm>
 #include <gsl/gsl_sort_vector.h>
 #include <cmath>
 

--- a/src/core/src/InfiniteDimensionalGaussian.C
+++ b/src/core/src/InfiniteDimensionalGaussian.C
@@ -31,6 +31,7 @@
 #include <queso/Environment.h>
 #include <queso/FunctionBase.h>
 #include <queso/OperatorBase.h>
+#include <queso/RngBase.h>
 
 namespace QUESO {
 

--- a/src/stats/src/BetaJointPdf.C
+++ b/src/stats/src/BetaJointPdf.C
@@ -25,6 +25,7 @@
 #include <queso/BetaJointPdf.h>
 #include <queso/GslVector.h>
 #include <queso/GslMatrix.h>
+#include <queso/BasicPdfsBase.h>
 
 namespace QUESO {
 

--- a/src/stats/src/FiniteDistribution.C
+++ b/src/stats/src/FiniteDistribution.C
@@ -23,6 +23,7 @@
 //-----------------------------------------------------------------------el-
 
 #include <queso/FiniteDistribution.h>
+#include <queso/RngBase.h>
 
 namespace QUESO {
 

--- a/src/stats/src/GammaJointPdf.C
+++ b/src/stats/src/GammaJointPdf.C
@@ -25,6 +25,7 @@
 #include <queso/GammaJointPdf.h>
 #include <queso/GslVector.h>
 #include <queso/GslMatrix.h>
+#include <queso/BasicPdfsBase.h>
 
 namespace QUESO {
 


### PR DESCRIPTION
This pull request wraps up all internal raw pointers in `ScopedPtr` objects.  Better memory management and better exception safety for free.

I had to compromise on one thing, which is the options object.  Instead of just taking the pointer the user passes and throwing it in a `ScopedPtr` we copy the user's object and throw the copy in a `ScopedPtr`.  Options objects aren't too big and are only copied once during the construction of `BaseEnvironment`.

Feedback welcome. 