### PR TITLE
Make BoostInputOptionsParser more const-friendly

### DIFF
--- a/src/core/inc/BoostInputOptionsParser.h
+++ b/src/core/inc/BoostInputOptionsParser.h
@@ -74,14 +74,16 @@ public:
    * the option with a helpful message using \c description.
    */
   template <class T>
-  void registerOption(std::string name, T defaultValue, std::string description);
+  void registerOption(const std::string & name,
+                      const T & defaultValue,
+                      const std::string & description);
 
   //! For flags *without* values.  Like a help message, for example.
-  void registerOption(std::string name, std::string description);
+  void registerOption(const std::string & name, const std::string & description);
 
   //! Get option \c name from the parser and set \c value to the parsed value.
   template <class T>
-  void getOption(std::string & name, T & value);
+  void getOption(const std::string & name, T & value) const;
 
   //! Helpful stream operator for printing the parser state
   friend std::ostream & operator<<(std::ostream & os,

--- a/src/core/src/BoostInputOptionsParser.C
+++ b/src/core/src/BoostInputOptionsParser.C
@@ -82,8 +82,9 @@ BoostInputOptionsParser::scanInputFile()
 
 template <typename T>
 void
-BoostInputOptionsParser::registerOption(std::string name, T defaultValue,
-    std::string description)
+BoostInputOptionsParser::registerOption(const std::string & name,
+                                        const T & defaultValue,
+                                        const std::string & description)
 {
   queso_deprecated();
   m_optionsDescription->add_options()
@@ -93,7 +94,8 @@ BoostInputOptionsParser::registerOption(std::string name, T defaultValue,
 }
 
 void
-BoostInputOptionsParser::registerOption(std::string name, std::string description)
+BoostInputOptionsParser::registerOption(const std::string & name,
+                                        const std::string & description)
 {
   queso_deprecated();
   m_optionsDescription->add_options()
@@ -103,7 +105,7 @@ BoostInputOptionsParser::registerOption(std::string name, std::string descriptio
 
 template <typename T>
 void
-BoostInputOptionsParser::getOption(std::string & name, T & value)
+BoostInputOptionsParser::getOption(const std::string & name, T & value) const
 {
   queso_deprecated();
   if (m_scannedInputFile) {
@@ -113,7 +115,7 @@ BoostInputOptionsParser::getOption(std::string & name, T & value)
 
 template <>
 void
-BoostInputOptionsParser::getOption(std::string & name, std::set<unsigned int, std::less<unsigned int>, std::allocator<unsigned int> > & value)
+BoostInputOptionsParser::getOption(const std::string & name, std::set<unsigned int, std::less<unsigned int>, std::allocator<unsigned int> > & value) const
 {
   queso_deprecated();
   if (m_scannedInputFile) {
@@ -136,7 +138,7 @@ BoostInputOptionsParser::getOption(std::string & name, std::set<unsigned int, st
 
 template <>
 void
-BoostInputOptionsParser::getOption<std::vector<double, std::allocator<double> > >(std::string & name, std::vector<double, std::allocator<double> > & value)
+BoostInputOptionsParser::getOption<std::vector<double, std::allocator<double> > >(const std::string & name, std::vector<double, std::allocator<double> > & value) const
 {
   queso_deprecated();
   if (m_scannedInputFile) {
@@ -158,20 +160,20 @@ operator<<(std::ostream & os, const BoostInputOptionsParser & parser)
   return os;
 }
 
-template void BoostInputOptionsParser::registerOption<int>(std::string, int, std::string);
-template void BoostInputOptionsParser::registerOption<unsigned int>(std::string, unsigned int, std::string);
-template void BoostInputOptionsParser::registerOption<bool>(std::string, bool, std::string);
-template void BoostInputOptionsParser::registerOption<double>(std::string, double, std::string);
-template void BoostInputOptionsParser::registerOption<std::string>(std::string, std::string, std::string);
+template void BoostInputOptionsParser::registerOption<int>(const std::string &, const int &, const std::string &);
+template void BoostInputOptionsParser::registerOption<unsigned int>(const std::string &, const unsigned int &, const std::string &);
+template void BoostInputOptionsParser::registerOption<bool>(const std::string &, const bool &, const std::string &);
+template void BoostInputOptionsParser::registerOption<double>(const std::string &, const double &, const std::string &);
+template void BoostInputOptionsParser::registerOption<std::string>(const std::string &, const std::string &, const std::string &);
 
-template void BoostInputOptionsParser::getOption<int>(std::string&, int&);
-template void BoostInputOptionsParser::getOption<unsigned int>(std::string&, unsigned int&);
-template void BoostInputOptionsParser::getOption<double>(std::string&, double&);
-template void BoostInputOptionsParser::getOption<bool>(std::string&, bool&);
-template void BoostInputOptionsParser::getOption<std::string>(std::string&, std::string&);
-template void BoostInputOptionsParser::getOption<std::set<unsigned int, std::less<unsigned int>, std::allocator<unsigned int> > >(std::string&, std::set<unsigned int, std::less<unsigned int>, std::allocator<unsigned int> >&);
-template void BoostInputOptionsParser::getOption<std::vector<unsigned int, std::allocator<unsigned int> > >(std::string&, std::vector<unsigned int, std::allocator<unsigned int> >&);
-template void BoostInputOptionsParser::getOption<std::vector<double, std::allocator<double> > >(std::string&, std::vector<double, std::allocator<double> >&);
+template void BoostInputOptionsParser::getOption<int>(const std::string&, int&) const;
+template void BoostInputOptionsParser::getOption<unsigned int>(const std::string&, unsigned int&) const;
+template void BoostInputOptionsParser::getOption<double>(const std::string&, double&) const;
+template void BoostInputOptionsParser::getOption<bool>(const std::string&, bool&) const;
+template void BoostInputOptionsParser::getOption<std::string>(const std::string&, std::string&) const;
+template void BoostInputOptionsParser::getOption<std::set<unsigned int, std::less<unsigned int>, std::allocator<unsigned int> > >(const std::string&, std::set<unsigned int, std::less<unsigned int>, std::allocator<unsigned int> >&) const;
+template void BoostInputOptionsParser::getOption<std::vector<unsigned int, std::allocator<unsigned int> > >(const std::string&, std::vector<unsigned int, std::allocator<unsigned int> >&) const;
+template void BoostInputOptionsParser::getOption<std::vector<double, std::allocator<double> > >(const std::string&, std::vector<double, std::allocator<double> >&) const;
 
 }  // End namespace QUESO
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS


### PR DESCRIPTION
We don't modify default variables, or option names, so we shouldn't
need either to be non-const.  We can also call getOption on a const
parser object.