### PR TITLE
GPMSAOptions refactor

### DIFF
--- a/src/gp/inc/GPMSAOptions.h
+++ b/src/gp/inc/GPMSAOptions.h
@@ -25,6 +25,7 @@
 
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
 #include <queso/BoostInputOptionsParser.h>
+#include <queso/ScopedPtr.h>
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 
 #ifndef UQ_GPMSA_OPTIONS_H
@@ -43,8 +44,20 @@ namespace QUESO {
 class GPMSAOptions
 {
 public:
-  //! Given prefix, read the input file for parameters named prefix_*
+  //! Given prefix, read the input file for parameters named "prefix"+*
   GPMSAOptions(const BaseEnvironment& env, const char* prefix);
+
+  //! Construct with default parameters
+  GPMSAOptions();
+
+  //! Set parameter option names to begin with prefix
+  void set_prefix(const char* prefix);
+
+  //! Set default values for parameter options
+  void set_defaults();
+
+  //! Given prefix, read the input file for parameters named "prefix"+*
+  void parse(const BaseEnvironment& env, const char* prefix);
 
   //! Destructor
   virtual ~GPMSAOptions();
@@ -101,10 +114,10 @@ public:
   friend std::ostream & operator<<(std::ostream& os, const GPMSAOptions & obj);
 
 private:
-  const BaseEnvironment& m_env;
+  const BaseEnvironment * m_env;
 
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
-  BoostInputOptionsParser * m_parser;
+  QUESO::ScopedPtr<BoostInputOptionsParser>::Type m_parser;
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 
   std::string m_option_help;

--- a/src/gp/src/GPMSAOptions.C
+++ b/src/gp/src/GPMSAOptions.C
@@ -124,19 +124,64 @@ GPMSAOptions::parse(const BaseEnvironment & env,
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
   m_parser.reset(new BoostInputOptionsParser(env.optionsInputFileName()));
 
-  m_parser->registerOption<std::string>(m_option_help, UQ_GPMSA_HELP, "produce help message Gaussian process emulator");
-  m_parser->registerOption<double>(m_option_emulatorPrecisionShape, UQ_GPMSA_EMULATOR_PRECISION_SHAPE_ODV, "shape hyperprior (Gamma) parameter for emulator precision");
-  m_parser->registerOption<double>(m_option_emulatorPrecisionScale, UQ_GPMSA_EMULATOR_PRECISION_SCALE_ODV, "scale hyperprior (Gamma) parameter for emulator precision");
-  m_parser->registerOption<double>(m_option_observationalPrecisionShape, UQ_GPMSA_OBSERVATIONAL_PRECISION_SHAPE_ODV, "shape hyperprior (Gamma) parameter for observational precision");
-  m_parser->registerOption<double>(m_option_observationalPrecisionScale, UQ_GPMSA_OBSERVATIONAL_PRECISION_SCALE_ODV, "scale hyperprior (Gamma) parameter for observational precision");
-  m_parser->registerOption<double>(m_option_emulatorCorrelationStrengthAlpha, UQ_GPMSA_EMULATOR_CORRELATION_STRENGTH_ALPHA_ODV, "alpha hyperprior (Beta) parameter for emulator correlation strength");
-  m_parser->registerOption<double>(m_option_emulatorCorrelationStrengthBeta, UQ_GPMSA_EMULATOR_CORRELATION_STRENGTH_BETA_ODV, "beta hyperprior (Beta) parameter for emulator correlation strength");
-  m_parser->registerOption<double>(m_option_discrepancyPrecisionShape, UQ_GPMSA_DISCREPANCY_PRECISION_SHAPE_ODV, "shape hyperprior (Gamma) parameter for discrepancy precision");
-  m_parser->registerOption<double>(m_option_discrepancyPrecisionScale, UQ_GPMSA_DISCREPANCY_PRECISION_SCALE_ODV, "scale hyperprior (Gamma) parameter for discrepancy precision");
-  m_parser->registerOption<double>(m_option_discrepancyCorrelationStrengthAlpha, UQ_GPMSA_DISCREPANCY_CORRELATION_STRENGTH_ALPHA_ODV, "alpha hyperprior (Beta) parameter for discrepancy correlation strength");
-  m_parser->registerOption<double>(m_option_discrepancyCorrelationStrengthBeta, UQ_GPMSA_DISCREPANCY_CORRELATION_STRENGTH_BETA_ODV, "beta hyperprior (Beta) parameter for discrepancy correlation strength");
-  m_parser->registerOption<double>(m_option_emulatorDataPrecisionShape, UQ_GPMSA_EMULATOR_DATA_PRECISION_SHAPE_ODV, "shape hyperprior (Gamma) parameter for emulator data precision");
-  m_parser->registerOption<double>(m_option_emulatorDataPrecisionScale, UQ_GPMSA_EMULATOR_DATA_PRECISION_SCALE_ODV, "scale hyperprior (Gamma) parameter for emulator data precision");
+  m_parser->registerOption<std::string>
+    (m_option_help,
+     m_help,
+     "produce help message Gaussian process emulator");
+
+  m_parser->registerOption
+    (m_option_emulatorPrecisionShape,
+     m_emulatorPrecisionShape,
+     "shape hyperprior (Gamma) parameter for emulator precision");
+  m_parser->registerOption
+    (m_option_emulatorPrecisionScale,
+    m_emulatorPrecisionScale,
+    "scale hyperprior (Gamma) parameter for emulator precision");
+
+  m_parser->registerOption
+    (m_option_observationalPrecisionShape,
+    m_observationalPrecisionShape,
+    "shape hyperprior (Gamma) parameter for observational precision");
+  m_parser->registerOption
+    (m_option_observationalPrecisionScale,
+    m_observationalPrecisionScale,
+    "scale hyperprior (Gamma) parameter for observational precision");
+
+  m_parser->registerOption
+    (m_option_emulatorCorrelationStrengthAlpha,
+    m_emulatorCorrelationStrengthAlpha,
+    "alpha hyperprior (Beta) parameter for emulator correlation strength");
+  m_parser->registerOption
+    (m_option_emulatorCorrelationStrengthBeta,
+    m_emulatorCorrelationStrengthBeta,
+    "beta hyperprior (Beta) parameter for emulator correlation strength");
+
+  m_parser->registerOption
+    (m_option_discrepancyPrecisionShape,
+    m_discrepancyPrecisionShape,
+    "shape hyperprior (Gamma) parameter for discrepancy precision");
+  m_parser->registerOption
+    (m_option_discrepancyPrecisionScale,
+    m_discrepancyPrecisionScale,
+    "scale hyperprior (Gamma) parameter for discrepancy precision");
+
+  m_parser->registerOption
+    (m_option_discrepancyCorrelationStrengthAlpha,
+    m_discrepancyCorrelationStrengthAlpha,
+    "alpha hyperprior (Beta) parameter for discrepancy correlation strength");
+  m_parser->registerOption
+    (m_option_discrepancyCorrelationStrengthBeta,
+    m_discrepancyCorrelationStrengthBeta,
+    "beta hyperprior (Beta) parameter for discrepancy correlation strength");
+
+  m_parser->registerOption
+    (m_option_emulatorDataPrecisionShape,
+    m_emulatorDataPrecisionShape,
+    "shape hyperprior (Gamma) parameter for emulator data precision");
+  m_parser->registerOption
+    (m_option_emulatorDataPrecisionScale,
+    m_emulatorDataPrecisionScale,
+    "scale hyperprior (Gamma) parameter for emulator data precision");
 
   m_parser->scanInputFile();
 
@@ -155,18 +200,47 @@ GPMSAOptions::parse(const BaseEnvironment & env,
   m_parser->getOption<double>(m_option_emulatorDataPrecisionScale,          m_emulatorDataPrecisionScale);
 #else
   m_help = env.input()(m_option_help, UQ_GPMSA_HELP);
-  m_emulatorPrecisionShape = env.input()(m_option_emulatorPrecisionShape, UQ_GPMSA_EMULATOR_PRECISION_SHAPE_ODV);
-  m_emulatorPrecisionScale = env.input()(m_option_emulatorPrecisionScale, UQ_GPMSA_EMULATOR_PRECISION_SCALE_ODV);
-  m_observationalPrecisionShape = env.input()(m_option_observationalPrecisionShape, UQ_GPMSA_OBSERVATIONAL_PRECISION_SHAPE_ODV);
-  m_observationalPrecisionScale = env.input()(m_option_observationalPrecisionScale, UQ_GPMSA_OBSERVATIONAL_PRECISION_SCALE_ODV);
-  m_emulatorCorrelationStrengthAlpha = env.input()(m_option_emulatorCorrelationStrengthAlpha, UQ_GPMSA_EMULATOR_CORRELATION_STRENGTH_ALPHA_ODV);
-  m_emulatorCorrelationStrengthBeta = env.input()(m_option_emulatorCorrelationStrengthBeta, UQ_GPMSA_EMULATOR_CORRELATION_STRENGTH_BETA_ODV);
-  m_discrepancyPrecisionShape = env.input()(m_option_discrepancyPrecisionShape, UQ_GPMSA_DISCREPANCY_PRECISION_SHAPE_ODV);
-  m_discrepancyPrecisionScale = env.input()(m_option_discrepancyPrecisionScale, UQ_GPMSA_DISCREPANCY_PRECISION_SCALE_ODV);
-  m_discrepancyCorrelationStrengthAlpha = env.input()(m_option_discrepancyCorrelationStrengthAlpha, UQ_GPMSA_DISCREPANCY_CORRELATION_STRENGTH_ALPHA_ODV);
-  m_discrepancyCorrelationStrengthBeta = env.input()(m_option_discrepancyCorrelationStrengthBeta, UQ_GPMSA_DISCREPANCY_CORRELATION_STRENGTH_BETA_ODV);
-  m_emulatorDataPrecisionShape = env.input()(m_option_emulatorDataPrecisionShape, UQ_GPMSA_EMULATOR_DATA_PRECISION_SHAPE_ODV);
-  m_emulatorDataPrecisionScale = env.input()(m_option_emulatorDataPrecisionScale, UQ_GPMSA_EMULATOR_DATA_PRECISION_SCALE_ODV);
+  m_emulatorPrecisionShape =
+    env.input()(m_option_emulatorPrecisionShape,
+                m_emulatorPrecisionShape);
+  m_emulatorPrecisionScale =
+    env.input()(m_option_emulatorPrecisionScale,
+                m_emulatorPrecisionScale);
+
+  m_observationalPrecisionShape =
+    env.input()(m_option_observationalPrecisionShape,
+                m_observationalPrecisionShape);
+  m_observationalPrecisionScale =
+    env.input()(m_option_observationalPrecisionScale,
+                m_observationalPrecisionScale);
+
+  m_emulatorCorrelationStrengthAlpha =
+    env.input()(m_option_emulatorCorrelationStrengthAlpha,
+                m_emulatorCorrelationStrengthAlpha);
+  m_emulatorCorrelationStrengthBeta =
+    env.input()(m_option_emulatorCorrelationStrengthBeta,
+                m_emulatorCorrelationStrengthBeta);
+
+  m_discrepancyPrecisionShape =
+    env.input()(m_option_discrepancyPrecisionShape,
+                m_discrepancyPrecisionShape);
+  m_discrepancyPrecisionScale =
+    env.input()(m_option_discrepancyPrecisionScale,
+                m_discrepancyPrecisionScale);
+
+  m_discrepancyCorrelationStrengthAlpha =
+    env.input()(m_option_discrepancyCorrelationStrengthAlpha,
+                m_discrepancyCorrelationStrengthAlpha);
+  m_discrepancyCorrelationStrengthBeta =
+    env.input()(m_option_discrepancyCorrelationStrengthBeta,
+                m_discrepancyCorrelationStrengthBeta);
+
+  m_emulatorDataPrecisionShape =
+    env.input()(m_option_emulatorDataPrecisionShape,
+                m_emulatorDataPrecisionShape);
+  m_emulatorDataPrecisionScale =
+    env.input()(m_option_emulatorDataPrecisionScale,
+                m_emulatorDataPrecisionScale);
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 
   checkOptions();

--- a/src/gp/src/GPMSAOptions.C
+++ b/src/gp/src/GPMSAOptions.C
@@ -48,44 +48,82 @@ namespace QUESO {
 GPMSAOptions::GPMSAOptions(
   const BaseEnvironment & env,
   const char * prefix)
-  :
-  m_prefix((std::string)(prefix) + "gpmsa_"),
-  m_help(UQ_GPMSA_HELP),
-  m_emulatorPrecisionShape(UQ_GPMSA_EMULATOR_PRECISION_SHAPE_ODV),
-  m_emulatorPrecisionScale(UQ_GPMSA_EMULATOR_PRECISION_SCALE_ODV),
-  m_observationalPrecisionShape(UQ_GPMSA_OBSERVATIONAL_PRECISION_SHAPE_ODV),
-  m_observationalPrecisionScale(UQ_GPMSA_OBSERVATIONAL_PRECISION_SCALE_ODV),
-  m_emulatorCorrelationStrengthAlpha(UQ_GPMSA_EMULATOR_CORRELATION_STRENGTH_ALPHA_ODV),
-  m_emulatorCorrelationStrengthBeta(UQ_GPMSA_EMULATOR_CORRELATION_STRENGTH_BETA_ODV),
-  m_discrepancyPrecisionShape(UQ_GPMSA_DISCREPANCY_PRECISION_SHAPE_ODV),
-  m_discrepancyPrecisionScale(UQ_GPMSA_DISCREPANCY_PRECISION_SCALE_ODV),
-  m_discrepancyCorrelationStrengthAlpha(UQ_GPMSA_DISCREPANCY_CORRELATION_STRENGTH_ALPHA_ODV),
-  m_discrepancyCorrelationStrengthBeta(UQ_GPMSA_DISCREPANCY_CORRELATION_STRENGTH_BETA_ODV),
-  m_emulatorDataPrecisionShape(UQ_GPMSA_EMULATOR_DATA_PRECISION_SHAPE_ODV),
-  m_emulatorDataPrecisionScale(UQ_GPMSA_EMULATOR_DATA_PRECISION_SCALE_ODV),
-  m_env(env),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
-  m_parser(new BoostInputOptionsParser(env.optionsInputFileName())),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
-  m_option_help(m_prefix + "help"),
-  m_option_emulatorPrecisionShape(m_prefix + "emulator_precision_shape"),
-  m_option_emulatorPrecisionScale(m_prefix + "emulator_precision_scale"),
-  m_option_observationalPrecisionShape(m_prefix + "observational_precision_shape"),
-  m_option_observationalPrecisionScale(m_prefix + "observational_precision_scale"),
-  m_option_emulatorCorrelationStrengthAlpha(m_prefix + "emulator_correlation_strength_alpha"),
-  m_option_emulatorCorrelationStrengthBeta(m_prefix + "emulator_correlation_strength_beta"),
-  m_option_discrepancyPrecisionShape(m_prefix + "discrepancy_precision_shape"),
-  m_option_discrepancyPrecisionScale(m_prefix + "discrepancy_precision_scale"),
-  m_option_discrepancyCorrelationStrengthAlpha(m_prefix + "discrepancy_correlation_strength_alpha"),
-  m_option_discrepancyCorrelationStrengthBeta(m_prefix + "discrepancy_correlation_strength_beta"),
-  m_option_emulatorDataPrecisionShape(m_prefix + "emulator_data_precision_shape"),
-  m_option_emulatorDataPrecisionScale(m_prefix + "emulator_data_precision_scale")
 {
-  if (m_env.optionsInputFileName() == "") {
+  this->set_defaults();
+  this->parse(env, prefix);
+}
+
+
+GPMSAOptions::GPMSAOptions()
+  :
+  m_env(NULL),
+#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+  m_parser(new BoostInputOptionsParser())
+#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+{
+  this->set_defaults();
+  this->set_prefix("");
+}
+
+
+void
+GPMSAOptions::set_prefix(const char * prefix)
+{
+  m_prefix = std::string(prefix) + "gpmsa_";
+
+  m_option_help = m_prefix + "help";
+  m_option_emulatorPrecisionShape = m_prefix + "emulator_precision_shape";
+  m_option_emulatorPrecisionScale = m_prefix + "emulator_precision_scale";
+  m_option_observationalPrecisionShape = m_prefix + "observational_precision_shape";
+  m_option_observationalPrecisionScale = m_prefix + "observational_precision_scale";
+  m_option_emulatorCorrelationStrengthAlpha = m_prefix + "emulator_correlation_strength_alpha";
+  m_option_emulatorCorrelationStrengthBeta = m_prefix + "emulator_correlation_strength_beta";
+  m_option_discrepancyPrecisionShape = m_prefix + "discrepancy_precision_shape";
+  m_option_discrepancyPrecisionScale = m_prefix + "discrepancy_precision_scale";
+  m_option_discrepancyCorrelationStrengthAlpha = m_prefix + "discrepancy_correlation_strength_alpha";
+  m_option_discrepancyCorrelationStrengthBeta = m_prefix + "discrepancy_correlation_strength_beta";
+  m_option_emulatorDataPrecisionShape = m_prefix + "emulator_data_precision_shape";
+  m_option_emulatorDataPrecisionScale = m_prefix + "emulator_data_precision_scale";
+}
+
+
+
+void
+GPMSAOptions::set_defaults()
+{
+  m_help = UQ_GPMSA_HELP;
+  m_emulatorPrecisionShape = UQ_GPMSA_EMULATOR_PRECISION_SHAPE_ODV;
+  m_emulatorPrecisionScale = UQ_GPMSA_EMULATOR_PRECISION_SCALE_ODV;
+  m_observationalPrecisionShape = UQ_GPMSA_OBSERVATIONAL_PRECISION_SHAPE_ODV;
+  m_observationalPrecisionScale = UQ_GPMSA_OBSERVATIONAL_PRECISION_SCALE_ODV;
+  m_emulatorCorrelationStrengthAlpha = UQ_GPMSA_EMULATOR_CORRELATION_STRENGTH_ALPHA_ODV;
+  m_emulatorCorrelationStrengthBeta = UQ_GPMSA_EMULATOR_CORRELATION_STRENGTH_BETA_ODV;
+  m_discrepancyPrecisionShape = UQ_GPMSA_DISCREPANCY_PRECISION_SHAPE_ODV;
+  m_discrepancyPrecisionScale = UQ_GPMSA_DISCREPANCY_PRECISION_SCALE_ODV;
+  m_discrepancyCorrelationStrengthAlpha = UQ_GPMSA_DISCREPANCY_CORRELATION_STRENGTH_ALPHA_ODV;
+  m_discrepancyCorrelationStrengthBeta = UQ_GPMSA_DISCREPANCY_CORRELATION_STRENGTH_BETA_ODV;
+  m_emulatorDataPrecisionShape = UQ_GPMSA_EMULATOR_DATA_PRECISION_SHAPE_ODV;
+  m_emulatorDataPrecisionScale = UQ_GPMSA_EMULATOR_DATA_PRECISION_SCALE_ODV;
+
+  checkOptions();
+}
+
+
+void
+GPMSAOptions::parse(const BaseEnvironment & env,
+                    const char * prefix)
+{
+  m_env = &env;
+
+  if (m_env->optionsInputFileName() == "") {
     queso_error_msg("Missing input file is required");
   }
 
+  this->set_prefix(prefix);
+
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+  m_parser.reset(new BoostInputOptionsParser(env.optionsInputFileName()));
+
   m_parser->registerOption<std::string>(m_option_help, UQ_GPMSA_HELP, "produce help message Gaussian process emulator");
   m_parser->registerOption<double>(m_option_emulatorPrecisionShape, UQ_GPMSA_EMULATOR_PRECISION_SHAPE_ODV, "shape hyperprior (Gamma) parameter for emulator precision");
   m_parser->registerOption<double>(m_option_emulatorPrecisionScale, UQ_GPMSA_EMULATOR_PRECISION_SCALE_ODV, "scale hyperprior (Gamma) parameter for emulator precision");
@@ -142,8 +180,8 @@ void
 GPMSAOptions::checkOptions()
 {
   if (m_help != "") {
-    if (m_env.subDisplayFile()) {
-      *m_env.subDisplayFile() << (*this) << std::endl;
+    if (m_env && m_env->subDisplayFile()) {
+      *m_env->subDisplayFile() << (*this) << std::endl;
     }
   }
 }


### PR DESCRIPTION
We can now default-construct a GPMSAOptions object (which then gets default parameter values), or parse a new input file with such an object (overriding any values found in the input file but leaving alone any values not found).

This should resolve #505