### PR TITLE
Fix compiler errors when disabling program options

### DIFF
--- a/src/core/inc/Defines.h
+++ b/src/core/inc/Defines.h
@@ -54,6 +54,9 @@
 // Use GSL inline functions
 #define HAVE_INLINE
 
+// So we don't clash with other getpots
+#define GETPOT_NAMESPACE QUESO
+
 // And only do GSL range-checking if we're really debugging
 #ifndef DEBUG
 #define GSL_RANGE_CHECK_OFF

--- a/src/core/inc/InfiniteDimensionalMCMCSamplerOptions.h
+++ b/src/core/inc/InfiniteDimensionalMCMCSamplerOptions.h
@@ -28,6 +28,8 @@
 
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
 #include <queso/BoostInputOptionsParser.h>
+#else
+#include <queso/getpot.h>
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 
 namespace QUESO {

--- a/src/core/src/Environment.C
+++ b/src/core/src/Environment.C
@@ -22,15 +22,15 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/Environment.h>
+
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 
-#define GETPOT_NAMESPACE QUESO
 #include <queso/getpot.h>
 
 #include <queso/config_queso.h>
-#include <queso/Environment.h>
 #include <queso/EnvironmentOptions.h>
 #include <queso/RngGsl.h>
 #include <queso/RngBoost.h>

--- a/src/core/src/EnvironmentOptions.C
+++ b/src/core/src/EnvironmentOptions.C
@@ -22,8 +22,12 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/Defines.h>
+
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
+#else
+#include <queso/getpot.h>
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 
 #include <queso/EnvironmentOptions.h>

--- a/src/core/src/OptimizerOptions.C
+++ b/src/core/src/OptimizerOptions.C
@@ -24,7 +24,13 @@
 
 #include <queso/Defines.h>
 #include <queso/Environment.h>
+
+#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
 #include <queso/BoostInputOptionsParser.h>
+#else
+#include <queso/getpot.h>
+#endif
+
 #include <queso/OptimizerOptions.h>
 
 namespace QUESO {

--- a/src/gp/src/ExperimentModelOptions.C
+++ b/src/gp/src/ExperimentModelOptions.C
@@ -22,8 +22,12 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/Defines.h>
+
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
+#else
+#include <queso/getpot.h>
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 
 #include <queso/ExperimentModelOptions.h>

--- a/src/gp/src/GPMSAOptions.C
+++ b/src/gp/src/GPMSAOptions.C
@@ -22,8 +22,12 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/Defines.h>
+
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
+#else
+#include <queso/getpot.h>
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 
 #include <queso/GPMSAOptions.h>
@@ -56,9 +60,9 @@ GPMSAOptions::GPMSAOptions(
 
 GPMSAOptions::GPMSAOptions()
   :
-  m_env(NULL),
+  m_env(NULL)
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
-  m_parser(new BoostInputOptionsParser())
+  ,m_parser(new BoostInputOptionsParser())
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 {
   this->set_defaults();

--- a/src/gp/src/GpmsaComputerModelOptions.C
+++ b/src/gp/src/GpmsaComputerModelOptions.C
@@ -22,8 +22,12 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/Defines.h>
+
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
+#else
+#include <queso/getpot.h>
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 
 #include <queso/GpmsaComputerModelOptions.h>

--- a/src/gp/src/SimulationModelOptions.C
+++ b/src/gp/src/SimulationModelOptions.C
@@ -22,8 +22,12 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/Defines.h>
+
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
+#else
+#include <queso/getpot.h>
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 
 #include <queso/SimulationModelOptions.h>

--- a/src/stats/inc/MLSamplingLevelOptions.h
+++ b/src/stats/inc/MLSamplingLevelOptions.h
@@ -29,7 +29,13 @@
 
 #include <queso/Environment.h>
 #include <queso/SequenceStatisticalOptions.h>
+
+#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
 #include <queso/BoostInputOptionsParser.h>
+#else
+#include <queso/getpot.h>
+#endif
+
 #define UQ_ML_SAMPLING_L_FILENAME_FOR_NO_FILE "."
 
 // _ODV = option default value

--- a/src/stats/src/MetropolisHastingsSGOptions.C
+++ b/src/stats/src/MetropolisHastingsSGOptions.C
@@ -22,11 +22,14 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/Environment.h>
+
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
+#else
+#include <queso/getpot.h>
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 
-#include <queso/Environment.h>
 #include <queso/MetropolisHastingsSGOptions.h>
 #include <queso/Miscellaneous.h>
 

--- a/src/stats/src/MonteCarloSGOptions.C
+++ b/src/stats/src/MonteCarloSGOptions.C
@@ -22,8 +22,12 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/Defines.h>
+
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
+#else
+#include <queso/getpot.h>
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 
 #include <queso/MonteCarloSGOptions.h>

--- a/src/stats/src/StatisticalForwardProblemOptions.C
+++ b/src/stats/src/StatisticalForwardProblemOptions.C
@@ -22,11 +22,14 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/Defines.h>
+
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
+#else
+#include <queso/getpot.h>
 #endif
 
-#include <queso/Defines.h>
 #include <queso/StatisticalForwardProblemOptions.h>
 #include <queso/Miscellaneous.h>
 

--- a/src/stats/src/StatisticalInverseProblemOptions.C
+++ b/src/stats/src/StatisticalInverseProblemOptions.C
@@ -22,11 +22,14 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/Defines.h>
+
 #ifndef DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
+#else
+#include <queso/getpot.h>
 #endif  // DISABLE_BOOST_PROGRAM_OPTIONS
 
-#include <queso/Defines.h>
 #include <queso/StatisticalInverseProblemOptions.h>
 #include <queso/Miscellaneous.h>
 


### PR DESCRIPTION
Fixes some compiler errors when `--disable-boost-program-options` was passed to configure.

Fixes #517.