### PR TITLE
Better bounds checking for interpolation datasets

### DIFF
--- a/src/surrogates/inc/InterpolationSurrogateData.h
+++ b/src/surrogates/inc/InterpolationSurrogateData.h
@@ -103,6 +103,9 @@ namespace QUESO
     //! Helper function for sizing m_values
     void init_values( const std::vector<unsigned int>& n_points );
 
+    //! Helper function for checking domain extent
+    void check_domain_bounds() const;
+
     //! Parameter domain over which we use surrogate
     const BoxSubset<V,M>& m_domain;
 

--- a/src/surrogates/src/InterpolationSurrogateData.C
+++ b/src/surrogates/src/InterpolationSurrogateData.C
@@ -29,6 +29,7 @@
 #include <queso/MpiComm.h>
 #include <queso/GslVector.h>
 #include <queso/GslMatrix.h>
+#include <queso/math_macros.h>
 
 // C++
 #include <sstream>
@@ -46,6 +47,9 @@ namespace QUESO
 
     // Size m_values
     this->init_values(this->m_n_points);
+
+    // Check the domain is bounded
+    this->check_domain_bounds();
   }
 
   template<class V, class M>
@@ -78,6 +82,17 @@ namespace QUESO
       }
 
     this->m_values.resize(n_total_points);
+  }
+
+  template<class V, class M>
+  void InterpolationSurrogateData<V,M>::check_domain_bounds() const
+  {
+    for (unsigned int i = 0; i < m_domain.vectorSpace().dimLocal(); i++) {
+      queso_require_msg(queso_isfinite(m_domain.minValues()[i]),
+          "Interpolation with an unbounded domain is unsupported");
+      queso_require_msg(queso_isfinite(m_domain.maxValues()[i]),
+          "Interpolation with an unbounded domain is unsupported");
+    }
   }
 
   template<class V, class M>


### PR DESCRIPTION
We now throw an exception when the user tries to construct an interpolation surrogate on an unbounded domain.

Fixes #427.