### PR TITLE
Fixes for Gauss-Hermite Quadrature, Actually Test Gauss-Hermite Quadrature

### DIFF
--- a/src/misc/src/1DQuadrature.C
+++ b/src/misc/src/1DQuadrature.C
@@ -22,6 +22,8 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <sstream>
+
 #include <queso/1DQuadrature.h>
 
 namespace QUESO {
@@ -601,15 +603,12 @@ GaussianHermite1DQuadrature::GaussianHermite1DQuadrature(
     break;
 
     default:
-      std::cerr << "In GaussianHermite1DQuadrature::constructor()"
-                << ": m_order = " << m_order
-                << std::endl;
-      queso_error_msg("order not supported");
+      std::stringstream ss;
+      ss << "In GaussianHermite1DQuadrature::constructor()"
+         << ": m_order = " << m_order
+         << std::endl;
+      queso_error_msg(ss.str());
     break;
-  }
-  for (unsigned int j = 0; j < (m_order+1); ++j) {
-    m_weights  [j] *= sqrt(2.);
-    m_positions[j] *= sqrt(2.);
   }
 }
 

--- a/src/misc/src/1DQuadrature.C
+++ b/src/misc/src/1DQuadrature.C
@@ -433,10 +433,10 @@ GaussianHermite1DQuadrature::GaussianHermite1DQuadrature(
     break;
 
     case 3:
-      m_weights  [0] =  sqrt(M_PI)/4./(3.-sqrt(6.));
-      m_weights  [1] =  sqrt(M_PI)/4./(3.+sqrt(6.));
-      m_weights  [2] =  sqrt(M_PI)/4./(3.+sqrt(6.));
-      m_weights  [3] =  sqrt(M_PI)/4./(3.-sqrt(6.));
+      m_weights  [0] =  sqrt(M_PI)/4./(3.+sqrt(6.));
+      m_weights  [1] =  sqrt(M_PI)/4./(3.-sqrt(6.));
+      m_weights  [2] =  sqrt(M_PI)/4./(3.-sqrt(6.));
+      m_weights  [3] =  sqrt(M_PI)/4./(3.+sqrt(6.));
 
       m_positions[0] = -sqrt(1.5+sqrt(1.5));
       m_positions[1] = -sqrt(1.5-sqrt(1.5));

--- a/test/unit/quadrature_1d.C
+++ b/test/unit/quadrature_1d.C
@@ -127,7 +127,80 @@ namespace QUESOTesting
     }
   };
 
+  class HermiteQuadrature1DTest : public Quadrature1DTestBase,
+                                  public HermiteQuadratureTestingHelper
+  {
+  public:
+    CPPUNIT_TEST_SUITE( HermiteQuadrature1DTest );
+
+    CPPUNIT_TEST( test_1d_hermite_quadrature_erf );
+    CPPUNIT_TEST( test_1d_hermite_quadrature_x2erf );
+    CPPUNIT_TEST( test_1d_hermite_quadrature_x4erf );
+
+    CPPUNIT_TEST_SUITE_END();
+
+    // yes, this is necessary
+  public:
+
+    void test_1d_hermite_quadrature_erf()
+    {
+      Erf func;
+      std::vector<unsigned int> testing_orders;
+      this->testing_orders(testing_orders);
+
+      double tol = std::numeric_limits<double>::epsilon()*50000;
+
+      this->test_1d_hermite_quadrature(func,testing_orders,tol);
+    }
+
+    void test_1d_hermite_quadrature_x2erf()
+    {
+      X2Erf func;
+      std::vector<unsigned int> testing_orders;
+      this->testing_orders(testing_orders);
+
+      double tol = 1.0e-10;
+
+      this->test_1d_hermite_quadrature(func,testing_orders,tol);
+    }
+
+    void test_1d_hermite_quadrature_x4erf()
+    {
+      std::cout << std::endl << "Beginning Hermite X4Erf test!" << std::endl;
+      X4Erf func;
+      std::vector<unsigned int> testing_orders;
+      this->testing_orders(testing_orders);
+
+      // We need at least a 3-point rule, so get rid of the first entry
+      testing_orders.erase(testing_orders.begin());
+
+      double tol = 2.0e-10;
+
+      this->test_1d_hermite_quadrature(func,testing_orders,tol);
+    }
+
+  private:
+
+    void test_1d_hermite_quadrature(OneDQuadratureFunction & func,
+                                    const std::vector<unsigned int> & testing_orders,
+                                    double tol)
+    {
+      for( std::vector<unsigned int>::const_iterator it = testing_orders.begin();
+           it < testing_orders.end(); ++it )
+      {
+        unsigned int quad_order = *it;
+
+        // 0 mean, unit variance
+        QUESO::GaussianHermite1DQuadrature quad_rule(0.0,1.0,quad_order);
+
+        this->test_quadrature_rule( quad_rule, func,
+                                    -INFINITY, INFINITY, tol );
+      }
+    }
+  };
+
   CPPUNIT_TEST_SUITE_REGISTRATION( LegendreQuadrature1DTest );
+  CPPUNIT_TEST_SUITE_REGISTRATION( HermiteQuadrature1DTest );
 
 } // end namespace QUESOTesting
 

--- a/test/unit/quadrature_1d.C
+++ b/test/unit/quadrature_1d.C
@@ -42,11 +42,8 @@ namespace QUESOTesting
   {
   public:
 
-    virtual double f( double x ) =0;
-
-    virtual double int_f( double lower, double upper ) =0;
-
     void test_quadrature_rule( QUESO::Base1DQuadrature & quad_rule,
+                               OneDQuadratureFunction & func,
                                double min_domain_value, double max_domain_value,
                                double tol )
     {
@@ -59,9 +56,9 @@ namespace QUESOTesting
 
       double int_value = 0.0;
       for( unsigned int q = 0; q < n_points; q++ )
-        int_value += this->f(x[q])*w[q];
+        int_value += func.f(x[q])*w[q];
 
-      double exact_int_value = this->int_f(min_domain_value,max_domain_value);
+      double exact_int_value = func.int_f(min_domain_value,max_domain_value);
 
       double rel_error = std::abs( (int_value-exact_int_value)/exact_int_value );
 
@@ -101,39 +98,7 @@ namespace QUESOTesting
       this->test_1d_legendre_quadrature(min_domain_value,max_domain_value);
     }
 
-    // e.g. 4*x^3 + 3*x^2 + 2*x + 1
-    virtual double f( double x )
-    {
-      CPPUNIT_ASSERT(_order>=0);
-      double value = 0.0;
-
-      for( int i = 0; i <= _order; i++ )
-        value += (i+1)*std::pow( x, i );
-
-      return value;
-    }
-
-    // Integral of the function in f()
-    virtual double int_f( double lower, double upper )
-    {
-      CPPUNIT_ASSERT(_order>=0);
-      double value = 0.0;
-
-      for( int i = 0; i <= _order; i++ )
-        value += (std::pow(upper,i+1.0) - std::pow(lower,i+1.0) );
-
-      return value;
-    }
-
-    void setUp()
-    {
-      // Setup for error checking, in order to make sure this gets reset later.
-      _order = -1;
-    }
-
   private:
-
-    int _order;
 
     void test_1d_legendre_quadrature(double min_domain_value, double max_domain_value)
     {
@@ -148,7 +113,7 @@ namespace QUESOTesting
 
         // We should be able to integrate polynomials of order 2*n-1 exactly
         // order = quad_order + 1 by QUESO convention
-        _order = 2*(quad_rule.order()+1)-1;
+        PolynomialFunction func( 2*(quad_rule.order()+1)-1 );
 
         double tol = std::numeric_limits<double>::epsilon()*20;
 
@@ -156,7 +121,8 @@ namespace QUESOTesting
         if( quad_order == 7 )
           tol = 1.0e-7;
 
-        this->test_quadrature_rule( quad_rule, min_domain_value, max_domain_value, tol );
+        this->test_quadrature_rule( quad_rule, func,
+                                    min_domain_value, max_domain_value, tol );
       }
     }
   };

--- a/test/unit/quadrature_testing_helper.h
+++ b/test/unit/quadrature_testing_helper.h
@@ -59,6 +59,29 @@ namespace QUESOTesting
 
   };
 
+  class HermiteQuadratureTestingHelper
+  {
+  public:
+
+    void testing_orders( std::vector<unsigned int> & orders )
+    {
+      // These are the valid listed orders for Legendre quadrature in QUESO;
+      // TODO: With C++11, we can initialize this with array syntax
+      orders.resize(10);
+      orders[0] = 1;
+      orders[1] = 2;
+      orders[2] = 3;
+      orders[3] = 4;
+      orders[4] = 5;
+      orders[5] = 6;
+      orders[6] = 7;
+      orders[7] = 8;
+      orders[8] = 9;
+      orders[9] = 19;
+    }
+
+  };
+
   class OneDQuadratureFunction
   {
   public:

--- a/test/unit/quadrature_testing_helper.h
+++ b/test/unit/quadrature_testing_helper.h
@@ -59,6 +59,52 @@ namespace QUESOTesting
 
   };
 
+  class OneDQuadratureFunction
+  {
+  public:
+
+    virtual double f( double x ) =0;
+
+    virtual double int_f( double lower, double upper ) =0;
+  };
+
+  class PolynomialFunction : public OneDQuadratureFunction
+  {
+  public:
+    PolynomialFunction(int order )
+      : _order(order)
+    {}
+
+    // e.g. 4*x^3 + 3*x^2 + 2*x + 1
+    virtual double f( double x )
+    {
+      CPPUNIT_ASSERT(_order>=0);
+      double value = 0.0;
+
+      for( int i = 0; i <= _order; i++ )
+        value += (i+1)*std::pow( x, i );
+
+      return value;
+    }
+
+    // Integral of the function in f()
+    virtual double int_f( double lower, double upper )
+    {
+      CPPUNIT_ASSERT(_order>=0);
+      double value = 0.0;
+
+      for( int i = 0; i <= _order; i++ )
+        value += (std::pow(upper,i+1.0) - std::pow(lower,i+1.0) );
+
+      return value;
+    }
+
+  private:
+
+    int _order;
+  };
+
+
   template <class V, class M>
   class MultiDQuadratureFunction
   {

--- a/test/unit/quadrature_testing_helper.h
+++ b/test/unit/quadrature_testing_helper.h
@@ -128,6 +128,57 @@ namespace QUESOTesting
   };
 
 
+  // For integrating -\infty,\infty using Gauss-Hermite
+  // The weighting function is not included in the function evaluation
+  class Erf : public OneDQuadratureFunction
+  {
+  public:
+
+    virtual double f( double /*x*/ )
+    {
+      return 1.0;
+    }
+
+    virtual double int_f( double /*lower*/, double /*upper*/ )
+    {
+      return std::sqrt(M_PI);
+    }
+  };
+
+  // For integrating -\infty,\infty using Gauss-Hermite
+  // The weighting function is not included in the function evaluation
+  class X2Erf : public OneDQuadratureFunction
+  {
+  public:
+
+    virtual double f( double x )
+    {
+      return x*x;
+    }
+
+    virtual double int_f( double /*lower*/, double /*upper*/ )
+    {
+      return std::sqrt(M_PI)/2.0;
+    }
+  };
+
+  // For integrating -\infty,\infty using Gauss-Hermite
+  // The weighting function is not included in the function evaluation
+  class X4Erf : public OneDQuadratureFunction
+  {
+  public:
+
+    virtual double f( double x )
+    {
+      return x*x*x*x;
+    }
+
+    virtual double int_f( double /*lower*/, double /*upper*/ )
+    {
+      return 3.0*std::sqrt(M_PI)/4.0;
+    }
+  };
+
   template <class V, class M>
   class MultiDQuadratureFunction
   {


### PR DESCRIPTION
In the process of adding unit tests for the Gauss-Hermite quadrature, I found two errors there (fb187e0 ac2eab6). Those errors are fixed and we have testing for Gauss-Hermite now.