### PR TITLE
Observation error matrices

### DIFF
--- a/src/gp/inc/GPMSA.h
+++ b/src/gp/inc/GPMSA.h
@@ -62,7 +62,7 @@ public:
                 const std::vector<typename SharedPtr<V>::Type> & m_experimentOutputs,
                 const std::vector<typename SharedPtr<V>::Type> & m_discrepancyBases,
                 const std::vector<typename SharedPtr<M>::Type> & m_observationErrorMatrices,
-                const M & m_experimentErrors,
+                const typename SharedPtr<M>::Type & m_observationErrorMatrix,
                 const ConcatenatedVectorRV<V, M> & m_totalPrior,
                 const V & residual_in,
                 const M & BT_Wy_B_inv_in,
@@ -100,13 +100,13 @@ public:
 
   const std::vector<typename SharedPtr<M>::Type> & m_observationErrorMatrices;
 
+  // Block diagonal matrix; sacrificing efficiency for clarity
+  typename SharedPtr<M>::Type m_observationErrorMatrix;
+
   //
   // Intermediate calculations we can cache
   //
   unsigned int num_svd_terms;
-
-  // Total observation error covriance matrix
-  const M & m_experimentErrors;
 
   const ConcatenatedVectorRV<V, M> & m_totalPrior;
 
@@ -267,6 +267,9 @@ public:
    * Each experiment (\experimentOutputs[i]) is assumed to correspond to the
    * point \c expermientScenarios[i] in scenario space.  The observation error
    * covariance matrix is assumed to be stored in \c experimentErrors.
+   *
+   * This method is solely for backward compatibility.  Covariances
+   * between errors from different experiments will be ignored.
    */
   void addExperiments(const std::vector<typename SharedPtr<V>::Type> & experimentScenarios,
                       const std::vector<typename SharedPtr<V>::Type> & experimentOutputs,
@@ -344,9 +347,6 @@ public:
   std::vector<typename SharedPtr<V>::Type> m_discrepancyBases;
 
   std::vector<typename SharedPtr<M>::Type> m_observationErrorMatrices;
-
-  // Total observation error covriance matrix
-  typename SharedPtr<M>::Type m_experimentErrors;
 
   // Counter for the number of adds that happen
   unsigned int m_numSimulationAdds;
@@ -443,7 +443,7 @@ public:
   bool m_constructedGP;
 
   // Block diagonal matrix; sacrificing efficiency for clarity
-  typename ScopedPtr<M>::Type m_observationErrorMatrix;
+  typename SharedPtr<M>::Type m_observationErrorMatrix;
 
   //
   // Intermediate calculations we can cache

--- a/src/gp/inc/GPMSA.h
+++ b/src/gp/inc/GPMSA.h
@@ -272,6 +272,21 @@ public:
                       const std::vector<typename SharedPtr<V>::Type> & experimentOutputs,
                       const typename SharedPtr<M>::Type experimentErrors);
 
+  //! Add all experiments to \c this
+  /*!
+   * This method takes a vector of *all* the experimental data and associated
+   * observation errors/correlations and stores them.  This cannot be done
+   * piecemeal like the simulation data.
+   *
+   * Each experiment (\experimentOutputs[i]) is assumed to correspond to the
+   * point \c expermientScenarios[i] in scenario space.  Each
+   * experiment has a corresponding error covariance matrix stored in
+   * \c experimentErrors[i]
+   */
+  void addExperiments(const std::vector<typename SharedPtr<V>::Type> & experimentScenarios,
+                      const std::vector<typename SharedPtr<V>::Type> & experimentOutputs,
+                      const std::vector<typename SharedPtr<M>::Type> & experimentErrors);
+
   //! Add all discrepancy bases to \c this
   /*!
    * This method takes a vector of *all* the bases to use in the

--- a/src/gp/inc/GPMSA.h
+++ b/src/gp/inc/GPMSA.h
@@ -61,7 +61,7 @@ public:
                 const std::vector<typename SharedPtr<V>::Type> & m_experimentScenarios,
                 const std::vector<typename SharedPtr<V>::Type> & m_experimentOutputs,
                 const std::vector<typename SharedPtr<V>::Type> & m_discrepancyBases,
-                const std::vector<M>   & m_observationErrorMatrices,
+                const std::vector<typename SharedPtr<M>::Type> & m_observationErrorMatrices,
                 const M & m_experimentErrors,
                 const ConcatenatedVectorRV<V, M> & m_totalPrior,
                 const V & residual_in,
@@ -98,7 +98,7 @@ public:
 
         std::vector<typename SharedPtr<V>::Type>   m_discrepancyBases;
 
-  const std::vector<M> & m_observationErrorMatrices;
+  const std::vector<typename SharedPtr<M>::Type> & m_observationErrorMatrices;
 
   //
   // Intermediate calculations we can cache
@@ -328,7 +328,7 @@ public:
 
   std::vector<typename SharedPtr<V>::Type> m_discrepancyBases;
 
-  std::vector<M> m_observationErrorMatrices;
+  std::vector<typename SharedPtr<M>::Type> m_observationErrorMatrices;
 
   // Total observation error covriance matrix
   typename SharedPtr<M>::Type m_experimentErrors;

--- a/src/gp/src/GPMSA.C
+++ b/src/gp/src/GPMSA.C
@@ -43,7 +43,7 @@ GPMSAEmulator<V, M>::GPMSAEmulator(
     const std::vector<typename SharedPtr<V>::Type> & m_experimentScenarios,
     const std::vector<typename SharedPtr<V>::Type> & m_experimentOutputs,
     const std::vector<typename SharedPtr<V>::Type> & m_discrepancyBases,
-    const std::vector<M>   & m_observationErrorMatrices,
+    const std::vector<typename SharedPtr<M>::Type> & m_observationErrorMatrices,
     const M & m_experimentErrors,
     const ConcatenatedVectorRV<V, M> & m_totalPrior,
     const V & residual_in,
@@ -472,11 +472,11 @@ GPMSAFactory<V, M>::GPMSAFactory(
     m_discrepancyBases.push_back(all_ones_basis);
 
     // Set up the default observation error covariance matrix:
-
-    M identity_matrix(env, output_map, 1.0);
-
     for (unsigned int i = 0; i != numExperiments; ++i)
-      m_observationErrorMatrices.push_back(identity_matrix);
+      {
+        typename SharedPtr<M>::Type identity_matrix(new M(env, output_map, 1.0));
+        m_observationErrorMatrices.push_back(identity_matrix);
+      }
   }
 
   // DM: Not sure if the logic in these 3 if-blocks is correct
@@ -852,7 +852,7 @@ GPMSAFactory<V, M>::setUpEmulator()
               // No fancy perturbation here
               unsigned int j = ex*numOutputs+outj;
 
-              Wy(i,j) = m_observationErrorMatrices[ex](outi,outj);
+              Wy(i,j) = (*m_observationErrorMatrices[ex])(outi,outj);
             }
         }
     }
@@ -939,7 +939,7 @@ GPMSAFactory<V, M>::getObservationErrorCovariance
   queso_assert_less(simulationNumber, m_numSimulations);
   queso_assert_equal_to(m_observationErrorMatrices.size(), m_numSimulations);
 
-  return m_observationErrorMatrices[simulationNumber];
+  return *m_observationErrorMatrices[simulationNumber];
 }
 
 
@@ -951,7 +951,7 @@ GPMSAFactory<V, M>::getObservationErrorCovariance
   queso_assert_less(simulationNumber, m_numSimulations);
   queso_assert_equal_to(m_observationErrorMatrices.size(), m_numSimulations);
 
-  return m_observationErrorMatrices[simulationNumber];
+  return *m_observationErrorMatrices[simulationNumber];
 }
 
 

--- a/src/gp/src/GPMSA.C
+++ b/src/gp/src/GPMSA.C
@@ -920,6 +920,34 @@ GPMSAFactory<V, M>::addExperiments(
 
 template <class V, class M>
 void
+GPMSAFactory<V, M>::addExperiments(
+    const std::vector<typename SharedPtr<V>::Type> & experimentScenarios,
+    const std::vector<typename SharedPtr<V>::Type> & experimentOutputs,
+    const std::vector<typename SharedPtr<M>::Type> & experimentErrors)
+{
+  queso_require_less_equal_msg(experimentScenarios.size(), this->m_numExperiments, "too many experiments...");
+  queso_require_equal_to(experimentScenarios.size(),
+                         experimentOutputs.size());
+  queso_require_equal_to(experimentScenarios.size(),
+                         experimentErrors.size());
+
+  for (unsigned int i = 0; i < this->m_experimentScenarios.size(); i++) {
+    this->m_experimentScenarios[i] = experimentScenarios[i];
+    this->m_experimentOutputs[i] = experimentOutputs[i];
+    this->m_observationErrorMatrices[i] = experimentErrors[i];
+  }
+  this->m_numExperimentAdds += experimentScenarios.size();
+
+  if ((this->m_numSimulationAdds == this->m_numSimulations) &&
+      (this->m_numExperimentAdds == this->m_numExperiments) &&
+      (this->m_constructedGP == false)) {
+    this->setUpEmulator();
+  }
+}
+
+
+template <class V, class M>
+void
 GPMSAFactory<V, M>::setDiscrepancyBases(
     const std::vector<typename SharedPtr<V>::Type> & discrepancyBases)
 {

--- a/test/test_gpmsa/test_gpmsa_vector.C
+++ b/test/test_gpmsa/test_gpmsa_vector.C
@@ -273,8 +273,9 @@ int main(int argc, char ** argv) {
           // The "magic number" here will in practice be an estimate
           // of experimental error.  In this test example it is pulled
           // from our posterior.
-          (*experimentMat)(experimentSize*i+j, experimentSize*i+j) =
-            (0.025 / stdsim[j]) * (0.025 / stdsim[j]);
+          (*experimentMat)(experimentSize*i+j, experimentSize*i+j) = 1;
+//          (*experimentMat)(experimentSize*i+j, experimentSize*i+j) =
+//            (0.025 / stdsim[j]) * (0.025 / stdsim[j]);
         }
     }
 


### PR DESCRIPTION
* Get rid of the old observational error covariance matrix internally
* Use a common block-diagonal covariance format for both vector and scalar cases
* Add API shim for compatibility with users supplying the old matrix to the scalar case