### PR TITLE
Fix up dregs of old lnValue API usage

### DIFF
--- a/examples/gravity/src/gravity_likelihood.C
+++ b/examples/gravity/src/gravity_likelihood.C
@@ -66,8 +66,7 @@ Likelihood<V, M>::~Likelihood()
 
 template<class V, class M>
 double
-Likelihood<V, M>::lnValue(const V & domainVector, const V * domainDirection,
-    V * gradVector, M * hessianMatrix, V * hessianEffect) const
+Likelihood<V, M>::lnValue(const V & domainVector) const
 {
   double g = domainVector[0];
 
@@ -87,8 +86,7 @@ Likelihood<V, M>::actualValue(const V & domainVector,
     const V * domainDirection, V * gradVector, M * hessianMatrix,
     V * hessianEffect) const
 {
-  return std::exp(this->lnValue(domainVector, domainDirection, gradVector,
-        hessianMatrix, hessianEffect));
+  return std::exp(this->lnValue(domainVector));
 }
 
 template class Likelihood<QUESO::GslVector, QUESO::GslMatrix>;

--- a/examples/gravity/src/gravity_likelihood.h
+++ b/examples/gravity/src/gravity_likelihood.h
@@ -34,8 +34,7 @@ class Likelihood : public QUESO::BaseScalarFunction<V, M>
 public:
   Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domain);
   virtual ~Likelihood();
-  virtual double lnValue(const V & domainVector, const V * domainDirection,
-      V * gradVector, M * hessianMatrix, V * hessianEffect) const;
+  virtual double lnValue(const V & domainVector) const;
   virtual double actualValue(const V & domainVector, const V * domainDirection,
       V * gradVector, M * hessianMatrix, V * hessianEffect) const;
 

--- a/examples/line2D_with_Sensitivity/slope_likelihood.C
+++ b/examples/line2D_with_Sensitivity/slope_likelihood.C
@@ -51,8 +51,7 @@ Likelihood<V, M>::~Likelihood()
 
 template<class V, class M>
 double
-Likelihood<V, M>::lnValue(const V & domainVector, const V * domainDirection,
-    V * gradVector, M * hessianMatrix, V * hessianEffect) const
+Likelihood<V, M>::lnValue(const V & domainVector) const
 {
   double m = domainVector[0];
   double c = domainVector[1];
@@ -74,8 +73,7 @@ Likelihood<V, M>::actualValue(const V & domainVector,
     const V * domainDirection, V * gradVector, M * hessianMatrix,
     V * hessianEffect) const
 {
-  return std::exp(this->lnValue(domainVector, domainDirection, gradVector,
-        hessianMatrix, hessianEffect));
+  return std::exp(this->lnValue(domainVector));
 }
 
 template class Likelihood<QUESO::GslVector, QUESO::GslMatrix>;

--- a/examples/line2D_with_Sensitivity/slope_likelihood.h
+++ b/examples/line2D_with_Sensitivity/slope_likelihood.h
@@ -10,8 +10,7 @@ class Likelihood : public QUESO::BaseScalarFunction<V, M>
 public:
   Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domain);
   virtual ~Likelihood();
-  virtual double lnValue(const V &domainVector, const V * domainDirection,
-	V * gradVector, M * hessianMatrix, V * hessianEffect) const;
+  virtual double lnValue(const V & domainVector) const;
   virtual double actualValue(const V & domainVector, const V * domainDirection,
       V * gradVector, M * hessianMatrix, V * hessianEffect) const;  
 

--- a/examples/template_example/template_example.cpp
+++ b/examples/template_example/template_example.cpp
@@ -6,7 +6,7 @@
 #include <queso/ScalarFunction.h>
 #include <queso/VectorSet.h>
 
-template<class V, class M>
+template<class V = QUESO::GslVector, class M = QUESO::GslMatrix>
 class Likelihood : public QUESO::BaseScalarFunction<V, M>
 {
 public:
@@ -22,8 +22,7 @@ public:
     // Deconstruct here
   }
 
-  virtual double lnValue(const V & domainVector, const V * domainDirection,
-      V * gradVector, M * hessianMatrix, V * hessianEffect) const
+  virtual double lnValue(const V & domainVector) const
   {
     // 1) Run the forward code at the point domainVector
     //    domainVector[0] is the first element of the parameter vector
@@ -44,8 +43,7 @@ public:
   virtual double actualValue(const V & domainVector, const V * domainDirection,
       V * gradVector, M * hessianMatrix, V * hessianEffect) const
   {
-    return std::exp(this->lnValue(domainVector, domainDirection, gradVector,
-          hessianMatrix, hessianEffect));
+    return std::exp(this->lnValue(domainVector));
   }
 
 private:
@@ -59,8 +57,7 @@ int main(int argc, char ** argv) {
   QUESO::FullEnvironment env(MPI_COMM_WORLD, argv[1], "", NULL);
 
   // Step 1 of 5: Instantiate the parameter space
-  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> paramSpace(env,
-      "param_", 1, NULL);
+  QUESO::VectorSpace<> paramSpace(env, "param_", 1, NULL);
 
   double min_val = 0.0;
   double max_val = 1.0;
@@ -71,22 +68,18 @@ int main(int argc, char ** argv) {
   QUESO::GslVector paramMaxs(paramSpace.zeroVector());
   paramMaxs.cwSet(max_val);
 
-  QUESO::BoxSubset<QUESO::GslVector, QUESO::GslMatrix> paramDomain("param_",
-      paramSpace, paramMins, paramMaxs);
+  QUESO::BoxSubset<> paramDomain("param_", paramSpace, paramMins, paramMaxs);
 
   // Uniform prior here.  Could be a different prior.
-  QUESO::UniformVectorRV<QUESO::GslVector, QUESO::GslMatrix> priorRv("prior_",
-      paramDomain);
+  QUESO::UniformVectorRV<> priorRv("prior_", paramDomain);
 
   // Step 3 of 5: Set up the likelihood using the class above
-  Likelihood<QUESO::GslVector, QUESO::GslMatrix> lhood("llhd_", paramDomain);
+  Likelihood<> lhood("llhd_", paramDomain);
 
   // Step 4 of 5: Instantiate the inverse problem
-  QUESO::GenericVectorRV<QUESO::GslVector, QUESO::GslMatrix>
-    postRv("post_", paramSpace);
+  QUESO::GenericVectorRV<> postRv("post_", paramSpace);
 
-  QUESO::StatisticalInverseProblem<QUESO::GslVector, QUESO::GslMatrix>
-    ip("", NULL, priorRv, lhood, postRv);
+  QUESO::StatisticalInverseProblem<> ip("", NULL, priorRv, lhood, postRv);
 
   // Step 5 of 5: Solve the inverse problem
   QUESO::GslVector paramInitials(paramSpace.zeroVector());

--- a/src/basic/inc/ScalarFunctionSynchronizer.h
+++ b/src/basic/inc/ScalarFunctionSynchronizer.h
@@ -77,6 +77,10 @@ public:
                             V* hessianEffect,
                             double* extraOutput1,
                             double* extraOutput2) const;
+
+  double callFunction(const V* vecValues,
+                      double* extraOutput1,
+                      double* extraOutput2) const;
   //@}
 private:
   const BaseEnvironment&         m_env;

--- a/src/basic/src/ScalarFunctionSynchronizer.C
+++ b/src/basic/src/ScalarFunctionSynchronizer.C
@@ -263,6 +263,196 @@ double ScalarFunctionSynchronizer<V,M>::callFunction(const V* vecValues,
   return result;
 }
 
+// Sync methods
+template <class V,class M>
+double ScalarFunctionSynchronizer<V,M>::callFunction(const V* vecValues,
+    double* extraOutput1,
+    double* extraOutput2) const
+{
+  double result = 0.;
+
+  if ((m_env.numSubEnvironments() < (unsigned int) m_env.fullComm().NumProc()) &&
+      (m_auxVec.numOfProcsForStorage() == 1                                  )) {
+    bool stayInRoutine = true;
+    do {
+      const V* internalValues    = NULL;
+      const V* internalDirection = NULL;
+            V* internalGrad      = NULL;
+            M* internalHessian   = NULL;
+            V* internalEffect    = NULL;
+
+      /////////////////////////////////////////////////
+      // Broadcast 1 of 3
+      /////////////////////////////////////////////////
+      // bufferChar[0] = '0' or '1' (vecValues     is NULL or not)
+      // bufferChar[1] = '0' or '1' (vecDirection  is NULL or not)
+      // bufferChar[2] = '0' or '1' (gradVector    is NULL or not)
+      // bufferChar[3] = '0' or '1' (hessianMatrix is NULL or not)
+      // bufferChar[4] = '0' or '1' (hessianEffect is NULL or not)
+      std::vector<char> bufferChar(5,'0');
+
+      if (m_env.subRank() == 0) {
+        internalValues    = vecValues;
+
+        if (internalValues    != NULL) bufferChar[0] = '1';
+        if (internalDirection != NULL) bufferChar[1] = '1';
+        if (internalGrad      != NULL) bufferChar[2] = '1';
+        if (internalHessian   != NULL) bufferChar[3] = '1';
+        if (internalEffect    != NULL) bufferChar[4] = '1';
+      }
+
+      m_env.subComm().syncPrintDebugMsg("In ScalarFunctionSynchronizer<V,M>::callFunction(), just before char Bcast()",3,3000000);
+      //if (m_env.subId() != 0) while (true) sleep(1);
+
+      int count = (int) bufferChar.size();
+      m_env.subComm().Bcast((void *) &bufferChar[0], count, RawValue_MPI_CHAR, 0,
+                            "ScalarFunctionSynchronizer<V,M>::callFunction()",
+                            "failed broadcast 1 of 3");
+
+      m_env.subComm().syncPrintDebugMsg("In ScalarFunctionSynchronizer<V,M>::callFunction(), just after char Bcast()",3,3000000);
+      //std::cout << "char contents = " << bufferChar[0] << " " << bufferChar[1] << " " << bufferChar[2] << " " << bufferChar[3] << " " << bufferChar[4]
+      //          << std::endl;
+
+      if (bufferChar[0] == '1') {
+        ///////////////////////////////////////////////
+        // Broadcast 2 of 3
+        ///////////////////////////////////////////////
+
+        // bufferDouble[0...] = contents for (eventual) vecValues
+        std::vector<double> bufferDouble(m_auxVec.sizeLocal(),0.);
+
+        if (m_env.subRank() == 0) {
+          for (unsigned int i = 0; i < internalValues->sizeLocal(); ++i) {
+            bufferDouble[i] = (*internalValues)[i];
+          }
+        }
+
+        //m_env.fullComm().Barrier();
+        //for (int i = 0; i < m_env.fullComm().NumProc(); ++i) {
+        //  if (i == m_env.fullRank()) {
+        //    std::cout << " In ScalarFunctionSynchronizer<V,M>::callFunction(), just before double Bcast()"
+        //              << ": fullRank "       << m_env.fullRank()
+        //              << ", subEnvironment " << m_env.subId()
+        //              << ", subRank "        << m_env.subRank()
+        //              << ": buffer related to first double Bcast() is ready to be broadcasted"
+        //              << " and has size "      << bufferDouble.size()
+        //              << std::endl;
+        //    if (m_env.subRank() == 0) {
+  //      std::cout << "Buffer contents are";
+        //      for (unsigned int i = 0; i < bufferDouble.size(); ++i) {
+  //        std::cout << " " << bufferDouble[i];
+        //    }
+  //      std::cout << std::endl;
+        //    }
+        //  }
+        //  m_env.fullComm().Barrier();
+        //}
+        //if (m_env.fullRank() == 0) std::cout << "Sleeping 3 seconds..."
+        //                                 << std::endl;
+        //sleep(3);
+
+        count = (int) bufferDouble.size();
+        m_env.subComm().Bcast((void *) &bufferDouble[0], count, RawValue_MPI_DOUBLE, 0,
+                              "ScalarFunctionSynchronizer<V,M>::callFunction()",
+                              "failed broadcast 2 of 3");
+
+        if (m_env.subRank() != 0) {
+          V tmpVec(m_auxVec);
+          for (unsigned int i = 0; i < tmpVec.sizeLocal(); ++i) {
+            tmpVec[i] = bufferDouble[i];
+          }
+          internalValues = new V(tmpVec);
+          //if (vecValues) *vecValues = tmpVec; // prudencio 2010-08-01
+        }
+
+        if (bufferChar[1] == '1') {
+          /////////////////////////////////////////////
+          // Broadcast 3 of 3
+          /////////////////////////////////////////////
+          // bufferDouble[0...] = contents for (eventual) vecDirection
+
+          if (m_env.subRank() == 0) {
+            for (unsigned int i = 0; i < internalDirection->sizeLocal(); ++i) {
+              bufferDouble[i] = (*internalDirection)[i];
+            }
+          }
+
+          count = (int) bufferDouble.size();
+          m_env.subComm().Bcast((void *) &bufferDouble[0], count, RawValue_MPI_DOUBLE, 0,
+                                "ScalarFunctionSynchronizer<V,M>::callFunction()",
+                                "failed broadcast 3 of 3");
+
+          if (m_env.subRank() != 0) {
+            V tmpVec(m_auxVec);
+            for (unsigned int i = 0; i < tmpVec.sizeLocal(); ++i) {
+              tmpVec[i] = bufferDouble[i];
+            }
+            internalDirection = new V(tmpVec);
+          }
+        }
+
+        ///////////////////////////////////////////////
+        // All processors now call 'scalarFunction()'
+        ///////////////////////////////////////////////
+        if (m_env.subRank() != 0) {
+          if (bufferChar[2] == '1') internalGrad    = new V(m_auxVec);
+          if (bufferChar[3] == '1') internalHessian = new M(m_auxVec);
+          if (bufferChar[4] == '1') internalEffect  = new V(m_auxVec);
+        }
+
+        m_env.subComm().syncPrintDebugMsg("In ScalarFunctionSynchronizer<V,M>::callFunction(), just before actual lnValue()",3,3000000);
+        m_env.subComm().Barrier();
+        result = m_scalarFunction.lnValue(*internalValues);
+        if (extraOutput1) {
+          if (m_bayesianJointPdfPtr) {
+            *extraOutput1 = m_bayesianJointPdfPtr->lastComputedLogPrior();
+          }
+        }
+        if (extraOutput2) {
+          if (m_bayesianJointPdfPtr) {
+            *extraOutput2 = m_bayesianJointPdfPtr->lastComputedLogLikelihood();
+          }
+        }
+      } // if (bufferChar[0] == '1')
+
+      /////////////////////////////////////////////////
+      // Prepare to exit routine or to stay in it
+      /////////////////////////////////////////////////
+      if (m_env.subRank() == 0) {
+        stayInRoutine = false; // Always for processor 0
+      }
+      else {
+        if (internalValues    != NULL) delete internalValues;
+        if (internalDirection != NULL) delete internalDirection;
+        if (internalGrad      != NULL) delete internalGrad;
+        if (internalHessian   != NULL) delete internalHessian;
+        if (internalEffect    != NULL) delete internalEffect;
+
+        stayInRoutine = (vecValues == NULL) && (bufferChar[0] == '1');
+        //if (!stayInRoutine) std::cout << "Fullrank " << m_env.fullRank() << " is leaving scalarFunctionSync()" << std::endl;
+      }
+    } while (stayInRoutine);
+  }
+  else {
+    queso_require_msg(vecValues, "vecValues should not be NULL");
+
+    m_env.subComm().Barrier();
+    result = m_scalarFunction.lnValue(*vecValues);
+    if (extraOutput1) {
+      if (m_bayesianJointPdfPtr) {
+        *extraOutput1 = m_bayesianJointPdfPtr->lastComputedLogPrior();
+      }
+    }
+    if (extraOutput2) {
+      if (m_bayesianJointPdfPtr) {
+        *extraOutput2 = m_bayesianJointPdfPtr->lastComputedLogLikelihood();
+      }
+    }
+  }
+
+  return result;
+}
+
 }  // End namespace QUESO
 
 template class QUESO::ScalarFunctionSynchronizer<QUESO::GslVector, QUESO::GslMatrix>;

--- a/src/core/src/GslOptimizer.C
+++ b/src/core/src/GslOptimizer.C
@@ -57,10 +57,8 @@ extern "C" {
       return GSL_NAN;
     }
 
-    // Should cache derivative here so we don't a) segfault in the user's code
-    // and b) so we don't recompute stuff
-    double result = -optimizer->objectiveFunction().lnValue(state, NULL, NULL,
-        NULL, NULL);
+    // Should cache derivative here so we don't recompute stuff
+    double result = -optimizer->objectiveFunction().lnValue(state);
 
     return result;
   }
@@ -93,8 +91,7 @@ extern "C" {
     }
     else {
       // We should cache the return value here so we don't recompute stuff
-      double fx = -optimizer->objectiveFunction().lnValue(state, NULL, &deriv,
-          NULL, NULL);
+      double fx = -optimizer->objectiveFunction().lnValue(state, deriv);
 
       // Decide whether or not we need to do a finite difference based on
       // whether the user actually filled deriv with values that are not
@@ -129,8 +126,7 @@ extern "C" {
 
           // User didn't provide a derivative, so we don't bother passing in
           // the derivative vector again
-          double fxph = -optimizer->objectiveFunction().lnValue(state, NULL,
-              NULL, NULL, NULL);
+          double fxph = -optimizer->objectiveFunction().lnValue(state);
 
           // Reset the state back to what it was before
           state[i] = tempState;

--- a/src/stats/inc/BayesianJointPdf.h
+++ b/src/stats/inc/BayesianJointPdf.h
@@ -74,7 +74,8 @@ public:
    * (likelihoodExponent) is zero then the Logarithm of the value of the function is the logarithm of
    * the value of the prior PDF; otherwise, the value is scaled (added) by a power of the value of the
    * likelihood function.*/
-  double lnValue                  (const V& domainVector, const V* domainDirection, V* gradVector, M* hessianMatrix, V* hessianEffect) const;
+  virtual double lnValue(const V & domainVector) const;
+  virtual double lnValue(const V & domainVector, V & gradVector) const;
 
   //! Mean value of the underlying random variable.
   virtual void   distributionMean (V & meanVector) const { queso_not_implemented(); }

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -1408,7 +1408,7 @@ MetropolisHastingsSG<P_V,P_M>::generateFullChain(
       iRC = gettimeofday(&timevalTarget, NULL);
       queso_require_equal_to_msg(iRC, 0, "gettimeofday called failed");
     }
-    logTarget = m_targetPdfSynchronizer->callFunction(&valuesOf1stPosition,NULL,NULL,NULL,NULL,&logPrior,&logLikelihood); // Might demand parallel environment // KEY
+    logTarget = m_targetPdfSynchronizer->callFunction(&valuesOf1stPosition,&logPrior,&logLikelihood); // Might demand parallel environment // KEY
     if (m_optionsObj->m_rawChainMeasureRunTimes) {
       m_rawChainInfo.targetRunTime += MiscGetEllapsedSeconds(&timevalTarget);
     }
@@ -1534,10 +1534,6 @@ MetropolisHastingsSG<P_V,P_M>::generateFullChain(
     double aux = 0.;
     aux = m_targetPdfSynchronizer->callFunction(NULL,
                                                 NULL,
-                                                NULL,
-                                                NULL,
-                                                NULL,
-                                                NULL,
                                                 NULL);
     if (aux) {}; // just to remove compiler warning
     for (unsigned int positionId = 1; positionId < workingChain.subSequenceSize(); ++positionId) {
@@ -1655,7 +1651,7 @@ MetropolisHastingsSG<P_V,P_M>::generateFullChain(
         iRC = gettimeofday(&timevalTarget, NULL);
         queso_require_equal_to_msg(iRC, 0, "gettimeofday called failed");
       }
-      logTarget = m_targetPdfSynchronizer->callFunction(&tmpVecValues,NULL,NULL,NULL,NULL,&logPrior,&logLikelihood); // Might demand parallel environment
+      logTarget = m_targetPdfSynchronizer->callFunction(&tmpVecValues,&logPrior,&logLikelihood); // Might demand parallel environment
       if (m_optionsObj->m_rawChainMeasureRunTimes) m_rawChainInfo.targetRunTime += MiscGetEllapsedSeconds(&timevalTarget);
       m_rawChainInfo.numTargetCalls++;
       if ((m_env.subDisplayFile()                   ) &&
@@ -1892,10 +1888,6 @@ MetropolisHastingsSG<P_V,P_M>::generateFullChain(
     // subRank == 0 --> Tell all other processors to exit barrier now that the chain has been fully generated
     double aux = 0.;
     aux = m_targetPdfSynchronizer->callFunction(NULL,
-                                                NULL,
-                                                NULL,
-                                                NULL,
-                                                NULL,
                                                 NULL,
                                                 NULL);
     if (aux) {}; // just to remove compiler warning
@@ -2365,7 +2357,7 @@ MetropolisHastingsSG<P_V, P_M>::delayedRejection(unsigned int positionId,
         iRC = gettimeofday(&timevalTarget, NULL);
         queso_require_equal_to_msg(iRC, 0, "gettimeofday call failed");
       }
-      logTarget = m_targetPdfSynchronizer->callFunction(&tmpVecValues,NULL,NULL,NULL,NULL,&logPrior,&logLikelihood); // Might demand parallel environment
+      logTarget = m_targetPdfSynchronizer->callFunction(&tmpVecValues,&logPrior,&logLikelihood); // Might demand parallel environment
       if (m_optionsObj->m_rawChainMeasureRunTimes) m_rawChainInfo.targetRunTime += MiscGetEllapsedSeconds(&timevalTarget);
       m_rawChainInfo.numTargetCalls++;
       if ((m_env.subDisplayFile()                   ) &&

--- a/test/test_optimizer/test_gsloptimizer.C
+++ b/test/test_optimizer/test_gsloptimizer.C
@@ -21,21 +21,19 @@ public:
 
   virtual double actualValue(const V & domainVector, const V * domainDirection,
       V * gradVector, M * hessianMatrix, V * hessianEffect) const {
-    return std::exp(this->lnValue(domainVector, domainDirection,
-          gradVector, hessianMatrix, hessianEffect));
+    return std::exp(this->lnValue(domainVector));
   }
 
-  virtual double lnValue(const V & domainVector, const V * domainDirection,
-      V * gradVector, M * hessianMatrix, V * hessianEffect) const {
+  virtual double lnValue(const V & domainVector, V & gradVector) const {
+    gradVector[0] = -2.0 * (domainVector[0]-1);
+    gradVector[1] = -2.0 * (domainVector[1]-2);
+    gradVector[2] = -2.0 * (domainVector[2]-3);
 
-    // Need to check if NULL because QUESO will somtimes call this with a
-    // NULL pointer
-    if (gradVector != NULL) {
-      (*gradVector)[0] = -2.0 * (domainVector[0]-1);
-      (*gradVector)[1] = -2.0 * (domainVector[1]-2);
-      (*gradVector)[2] = -2.0 * (domainVector[2]-3);
-    }
+    // Mean = (1,2)
+    return this->lnValue(domainVector);
+  }
 
+  virtual double lnValue(const V & domainVector) const {
     // Mean = (1,2)
     return -( (domainVector[0]-1)*(domainVector[0]-1) +
               (domainVector[1]-2)*(domainVector[1]-2) +

--- a/test/test_optimizer/test_optimizer_options.C
+++ b/test/test_optimizer/test_optimizer_options.C
@@ -24,20 +24,17 @@ public:
 
   virtual double actualValue(const V & domainVector, const V * domainDirection,
       V * gradVector, M * hessianMatrix, V * hessianEffect) const {
-    return std::exp(this->actualValue(domainVector, domainDirection,
-          gradVector, hessianMatrix, hessianEffect));
+    return std::exp(this->lnValue(domainVector));
   }
 
-  virtual double lnValue(const V & domainVector, const V * domainDirection,
-      V * gradVector, M * hessianMatrix, V * hessianEffect) const {
+  virtual double lnValue(const V & domainVector) const {
+    return -domainVector[0] * domainVector[0];
+  }
 
-    // Need to check if NULL because QUESO will somtimes call this with a
-    // NULL pointer
-    if (gradVector != NULL) {
-      (*gradVector)[0] = -2.0 * domainVector[0];
-    }
+  virtual double lnValue(const V & domainVector, V & gradVector) const {
+    gradVector[0] = -2.0 * domainVector[0];
 
-    return -(domainVector[0] * domainVector[0]);
+    return this->lnValue(domainVector);
   }
 };
 

--- a/test/test_optimizer/test_seedwithmap.C
+++ b/test/test_optimizer/test_seedwithmap.C
@@ -22,20 +22,19 @@ public:
 
   virtual double actualValue(const V & domainVector, const V * domainDirection,
       V * gradVector, M * hessianMatrix, V * hessianEffect) const {
-    return std::exp(this->actualValue(domainVector, domainDirection,
-          gradVector, hessianMatrix, hessianEffect));
+    return std::exp(this->lnValue(domainVector));
   }
 
-  virtual double lnValue(const V & domainVector, const V * domainDirection,
-      V * gradVector, M * hessianMatrix, V * hessianEffect) const {
+  virtual double lnValue(const V & domainVector) const {
+    return -domainVector[0] * domainVector[0];
+  }
 
+  virtual double lnValue(const V & domainVector, V & gradVector) const {
     // Need to check if NULL because QUESO will somtimes call this with a
     // NULL pointer
-    if (gradVector != NULL) {
-      (*gradVector)[0] = -2.0 * domainVector[0];
-    }
+    gradVector[0] = -2.0 * domainVector[0];
 
-    return -(domainVector[0] * domainVector[0]);
+    return this->lnValue(domainVector);
   }
 };
 

--- a/test/test_optimizer/test_seedwithmap_fd.C
+++ b/test/test_optimizer/test_seedwithmap_fd.C
@@ -57,6 +57,7 @@ int main(int argc, char ** argv) {
   QUESO::UniformVectorRV<QUESO::GslVector, QUESO::GslMatrix> prior("", domain);
 
   Likelihood<QUESO::GslVector, QUESO::GslMatrix> likelihood("", domain);
+  likelihood.setFiniteDifferenceStepSize(1e-4);
 
   QUESO::GenericVectorRV<QUESO::GslVector, QUESO::GslMatrix> posterior("",
       domain);

--- a/test/test_optimizer/test_sip_gslopt_options.C
+++ b/test/test_optimizer/test_sip_gslopt_options.C
@@ -22,7 +22,7 @@ public:
 
   virtual double actualValue(const V & domainVector, const V * domainDirection,
       V * gradVector, M * hessianMatrix, V * hessianEffect) const {
-    return std::exp(this->actualValue(domainVector, domainDirection,
+    return std::exp(this->lnValue(domainVector, domainDirection,
           gradVector, hessianMatrix, hessianEffect));
   }
 
@@ -63,6 +63,7 @@ int main(int argc, char ** argv) {
   QUESO::UniformVectorRV<QUESO::GslVector, QUESO::GslMatrix> prior("", domain);
 
   Likelihood<QUESO::GslVector, QUESO::GslMatrix> likelihood("", domain);
+  likelihood.setFiniteDifferenceStepSize(1e-4);
 
   QUESO::GenericVectorRV<QUESO::GslVector, QUESO::GslMatrix> posterior("",
       domain);


### PR DESCRIPTION
Mainly in BayesianJointPdf and in ScalarFunctionSynchronizer.

I had to update some of the tests too.  It turns out that users who were
already providing gradients with the old API all of a sudden had their
implementations replaced with a finite difference.

There's a way around this behaviour that's hacky, but it's probably not
worth it unless there are serious complaints.