### PR TITLE
Discourage GenericScalarFunction usage

### DIFF
--- a/examples/bimodal/src/bimodal_compute.C
+++ b/examples/bimodal/src/bimodal_compute.C
@@ -27,7 +27,6 @@
 #include <queso/GslMatrix.h>
 #include <queso/StatisticalInverseProblem.h>
 #include <queso/1D1DFunction.h>
-#include <queso/GenericScalarFunction.h>
 #include <queso/GenericVectorRV.h>
 #include <queso/UniformVectorRV.h>
 
@@ -55,15 +54,10 @@ void compute(const QUESO::FullEnvironment& env) {
   meanVector[0] = 10.;
   QUESO::GslMatrix* covMatrix = paramSpace.newMatrix();
   (*covMatrix)(0,0) = 1.;
-  likelihoodRoutine_DataType likelihoodRoutine_Data;
-  likelihoodRoutine_Data.meanVector = &meanVector;
-  likelihoodRoutine_Data.covMatrix  = covMatrix;
-  QUESO::GenericScalarFunction<QUESO::GslVector,QUESO::GslMatrix>
-    likelihoodFunctionObj("like_",
-                          paramDomain,
-                          likelihoodRoutine,
-                          (void *) &likelihoodRoutine_Data,
-                          true); // routine computes [-2.*ln(function)]
+
+  Likelihood<> likelihood("like_", paramDomain);
+  likelihood.meanVector = &meanVector;
+  likelihood.covMatrix  = covMatrix;
 
   //------------------------------------------------------
   // Step 4 of 5: Instantiate the inverse problem
@@ -73,7 +67,7 @@ void compute(const QUESO::FullEnvironment& env) {
   QUESO::GenericVectorRV<QUESO::GslVector,QUESO::GslMatrix>
     postRv("post_", paramSpace);
   QUESO::StatisticalInverseProblem<QUESO::GslVector,QUESO::GslMatrix>
-    ip("", NULL, priorRv, likelihoodFunctionObj, postRv);
+    ip("", NULL, priorRv, likelihood, postRv);
 
   //------------------------------------------------------
   // Step 5 of 5: Solve the inverse problem
@@ -157,7 +151,7 @@ void compute(const QUESO::FullEnvironment& env) {
   double integral = 0.;
   for (unsigned int i = 0; i < numGridPoints; ++i) {
     auxVec[0] = xMin + i*intervalSize;
-    integral += likelihoodFunctionObj.actualValue(auxVec,NULL,NULL,NULL,NULL);
+    integral += likelihood.actualValue(auxVec,NULL,NULL,NULL,NULL);
   }
   integral *= intervalSize;
   if (env.subDisplayFile()) {

--- a/examples/bimodal/src/bimodal_likelihood.C
+++ b/examples/bimodal/src/bimodal_likelihood.C
@@ -27,52 +27,41 @@
 
 static unsigned int likelihoodCounter = 0;
 
-double likelihoodRoutine(
-  const QUESO::GslVector& paramValues,
-  const QUESO::GslVector* paramDirection,
-  const void*             functionDataPtr,
-  QUESO::GslVector*       gradVector,
-  QUESO::GslMatrix*       hessianMatrix,
-  QUESO::GslVector*       hessianEffect)
+template <class V, class M>
+double
+Likelihood<V, M>::lnValue(const V & paramValues) const
 {
   likelihoodCounter++;
 
-  if (paramDirection  ||
-      functionDataPtr ||
-      gradVector      ||
-      hessianMatrix   ||
-      hessianEffect) {}; // just to remove compiler warning
+  double returnValue = 0.;
+  double x = paramValues[0];
+  double mean1  = 10.;
+  double sigma1 = 1.;
+  double y1 = (x-mean1)*(x-mean1)/(2.*sigma1*sigma1);
+  double z1 = (1./sigma1/sqrt(2*M_PI))*exp(-y1);
 
-    double returnValue = 0.;
-    double x = paramValues[0];
-    double mean1  = 10.;
-    double sigma1 = 1.;
-    double y1 = (x-mean1)*(x-mean1)/(2.*sigma1*sigma1);
-    double z1 = (1./sigma1/sqrt(2*M_PI))*exp(-y1);
+  double mean2  = 100.;
+  double sigma2 = 5.;
+  double y2 = (x-mean2)*(x-mean2)/(2.*sigma2*sigma2);
+  double z2 = (1./sigma2/sqrt(2*M_PI))*exp(-y2);
 
-    double mean2  = 100.;
-    double sigma2 = 5.;
-    double y2 = (x-mean2)*(x-mean2)/(2.*sigma2*sigma2);
-    double z2 = (1./sigma2/sqrt(2*M_PI))*exp(-y2);
+  double resultValue = -2*log((z1+2.*z2)/3.);
 
-    double resultValue = -2*log((z1+2.*z2)/3.);
+  if (resultValue == INFINITY) {
+    //std::cerr << "WARNING In likelihoodRoutine"
+    //          << ", fullRank "       << paramValues.env().fullRank()
+    //          << ", subEnvironment " << paramValues.env().subId()
+    //          << ", subRank "        << paramValues.env().subRank()
+    //          << ", inter0Rank "     << paramValues.env().inter0Rank()
+    //          << ": x = "            << x
+    //          << ", z1 = "           << z1
+    //          << ", z2 = "           << z2
+    //          << ", resultValue = "  << resultValue
+    //          << std::endl;
+    resultValue = 1040.;
+  }
 
-    if (resultValue == INFINITY) {
-      //std::cerr << "WARNING In likelihoodRoutine"
-      //          << ", fullRank "       << paramValues.env().fullRank()
-      //          << ", subEnvironment " << paramValues.env().subId()
-      //          << ", subRank "        << paramValues.env().subRank()
-      //          << ", inter0Rank "     << paramValues.env().inter0Rank()
-      //          << ": x = "            << x
-      //          << ", z1 = "           << z1
-      //          << ", z2 = "           << z2
-      //          << ", resultValue = "  << resultValue
-      //          << std::endl;
-      resultValue = 1040.;
-    }
-
-    returnValue = -.5*resultValue;
-
+  returnValue = -.5*resultValue;
 
   if (paramValues.env().exceptionalCircumstance()) {
     if ((paramValues.env().subDisplayFile()       ) &&
@@ -86,3 +75,5 @@ double likelihoodRoutine(
 
   return returnValue;
 }
+
+template class Likelihood<QUESO::GslVector, QUESO::GslMatrix>;

--- a/examples/bimodal/src/bimodal_likelihood.h
+++ b/examples/bimodal/src/bimodal_likelihood.h
@@ -26,20 +26,32 @@
 #define EX_LIKELIHOOD_H
 
 #include <queso/GslMatrix.h>
+#include <queso/ScalarFunction.h>
+#include <cmath>
 
-struct
-likelihoodRoutine_DataType
+template <class V = QUESO::GslVector, class M = QUESO::GslMatrix>
+class Likelihood : public QUESO::BaseScalarFunction<V, M>
 {
+public:
+  Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domainSet)
+    : QUESO::BaseScalarFunction<V, M>(prefix, domainSet)
+  {
+  }
+
+  virtual ~Likelihood() { }
+
+  virtual double lnValue(const V & paramValues) const;
+
+  virtual double actualValue(const V & paramValues,
+                             const V * paramDirection,
+                             V *       gradVector,
+                             M *       hessianMatrix,
+                             V *       hessianEffect) const
+  {
+    return std::exp(this->lnValue(paramValues));
+  }
+
   const QUESO::GslVector* meanVector;
   const QUESO::GslMatrix* covMatrix;
 };
-
-double likelihoodRoutine(
-  const QUESO::GslVector& paramValues,
-  const QUESO::GslVector* paramDirection,
-  const void*             functionDataPtr,
-  QUESO::GslVector*       gradVector,
-  QUESO::GslMatrix*       hessianMatrix,
-  QUESO::GslVector*       hessianEffect);
-
 #endif

--- a/examples/gravity/src/gravity_compute.C
+++ b/examples/gravity/src/gravity_compute.C
@@ -39,7 +39,6 @@
 #include <sys/time.h>
 
 #include <queso/GslMatrix.h>
-#include <queso/GenericScalarFunction.h>
 #include <queso/GenericVectorFunction.h>
 #include <queso/GaussianVectorRV.h>
 #include <queso/UniformVectorRV.h>

--- a/examples/gravity/src/gravity_likelihood.C
+++ b/examples/gravity/src/gravity_likelihood.C
@@ -24,7 +24,6 @@
 
 #include <cmath>
 
-#include <queso/GenericScalarFunction.h>
 #include <queso/GslVector.h>
 #include <queso/GslMatrix.h>
 #include <queso/UniformVectorRV.h>

--- a/examples/hysteretic/src/example_compute.C
+++ b/examples/hysteretic/src/example_compute.C
@@ -36,7 +36,6 @@
 #include <queso/StatisticalInverseProblem.h>
 #include <queso/ConcatenationSubset.h>
 #include <queso/ConcatenatedVectorRV.h>
-#include <queso/GenericScalarFunction.h>
 #include <queso/UniformVectorRV.h>
 #include <sys/time.h>
 #include <example_hyst.h>
@@ -51,12 +50,9 @@ void compute(const QUESO::FullEnvironment& env) {
   //------------------------------------------------------
   // Step 1 of 5: Instantiate the parameter space
   //------------------------------------------------------
-  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>
-    paramSpaceA(env, "paramA_", 1, NULL);
-  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>
-    paramSpaceB(env, "paramB_", 14, NULL);
-  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix>
-    paramSpace (env, "param_", 15, NULL);
+  QUESO::VectorSpace<> paramSpaceA(env, "paramA_", 1, NULL);
+  QUESO::VectorSpace<> paramSpaceB(env, "paramB_", 14, NULL);
+  QUESO::VectorSpace<> paramSpace (env, "param_", 15, NULL);
 
   //------------------------------------------------------
   // Step 2 of 5: Instantiate the parameter domain
@@ -65,18 +61,15 @@ void compute(const QUESO::FullEnvironment& env) {
   paramMinsA.cwSet(0);
   QUESO::GslVector paramMaxsA(paramSpaceA.zeroVector());
   paramMaxsA.cwSet(5);
-  QUESO::BoxSubset<QUESO::GslVector,QUESO::GslMatrix>
-    paramDomainA("paramA_",paramSpaceA,paramMinsA,paramMaxsA);
+  QUESO::BoxSubset<> paramDomainA("paramA_",paramSpaceA,paramMinsA,paramMaxsA);
 
   QUESO::GslVector paramMinsB(paramSpaceB.zeroVector());
   paramMinsB.cwSet(-INFINITY);
   QUESO::GslVector paramMaxsB(paramSpaceB.zeroVector());
   paramMaxsB.cwSet( INFINITY);
-  QUESO::BoxSubset<QUESO::GslVector,QUESO::GslMatrix>
-    paramDomainB("paramB_",paramSpaceB,paramMinsB,paramMaxsB);
+  QUESO::BoxSubset<> paramDomainB("paramB_",paramSpaceB,paramMinsB,paramMaxsB);
 
-  QUESO::ConcatenationSubset<QUESO::GslVector,QUESO::GslMatrix>
-    paramDomain("",paramSpace,paramDomainA,paramDomainB);
+  QUESO::ConcatenationSubset<> paramDomain("",paramSpace,paramDomainA,paramDomainB);
 
   //------------------------------------------------------
   // Step 3 of 5: Instantiate the likelihood function object
@@ -84,27 +77,28 @@ void compute(const QUESO::FullEnvironment& env) {
   std::cout << "\tInstantiating the Likelihood; calling internally the hysteretic model"
 	    << std::endl;
 
-  likelihoodRoutine_DataType likelihoodRoutine_Data;
-  likelihoodRoutine_Data.floor.resize(4,NULL);
+  Likelihood<> likelihood("like_", paramDomain);
+
+  likelihood.floor.resize(4,NULL);
   unsigned int numTimeSteps = 401;
   for (unsigned int i = 0; i < 4; ++i) {
-    likelihoodRoutine_Data.floor[i] = new std::vector<double>(numTimeSteps,0.);
+    likelihood.floor[i] = new std::vector<double>(numTimeSteps,0.);
   }
-  likelihoodRoutine_Data.accel.resize(numTimeSteps,0.);
+  likelihood.accel.resize(numTimeSteps,0.);
   FILE *inp;
   inp = fopen("an.txt","r");
   unsigned int numObservations = 0;
   double tmpA;
   while (fscanf(inp,"%lf",&tmpA) != EOF) {
-    likelihoodRoutine_Data.accel[numObservations] = tmpA;
+    likelihood.accel[numObservations] = tmpA;
     numObservations++;
   }
 
-  numObservations=0;
+  numObservations=1;
   FILE *inp1_1;
   inp1_1=fopen("measured_data1_1.txt","r");
   while (fscanf(inp1_1,"%lf",&tmpA) != EOF) {
-    (*likelihoodRoutine_Data.floor[0])[numObservations]=tmpA;
+    (*likelihood.floor[0])[numObservations]=tmpA;
      numObservations++;
   }
 
@@ -112,7 +106,7 @@ void compute(const QUESO::FullEnvironment& env) {
   FILE *inp1_2;
   inp1_2=fopen("measured_data1_2.txt","r");
   while (fscanf(inp1_2,"%lf",&tmpA) != EOF) {
-    (*likelihoodRoutine_Data.floor[1])[numObservations]=tmpA;
+    (*likelihood.floor[1])[numObservations]=tmpA;
     numObservations++;
   }
 
@@ -120,7 +114,7 @@ void compute(const QUESO::FullEnvironment& env) {
   FILE *inp1_3;
   inp1_3=fopen("measured_data1_3.txt","r");
   while (fscanf(inp1_3,"%lf",&tmpA) != EOF) {
-    (*likelihoodRoutine_Data.floor[2])[numObservations]=tmpA;
+    (*likelihood.floor[2])[numObservations]=tmpA;
     numObservations++;
   }
 
@@ -128,24 +122,17 @@ void compute(const QUESO::FullEnvironment& env) {
   FILE *inp1_4;
   inp1_4=fopen("measured_data1_4.txt","r");
   while (fscanf(inp1_4,"%lf",&tmpA) != EOF) {
-    (*likelihoodRoutine_Data.floor[3])[numObservations]=tmpA;
+    (*likelihood.floor[3])[numObservations]=tmpA;
     numObservations++;
   }
 
-  QUESO::GenericScalarFunction<QUESO::GslVector,QUESO::GslMatrix>
-    likelihoodFunctionObj("like_",
-                          paramDomain,
-                          likelihoodRoutine,
-                          (void *) &likelihoodRoutine_Data,
-                          true); // routine computes [ln(function)]
 
   //------------------------------------------------------
   // Step 4 of 5: Instantiate the inverse problem
   //------------------------------------------------------
   std::cout << "\tInstantiating the SIP" << std::endl;
 
-  QUESO::UniformVectorRV<QUESO::GslVector,QUESO::GslMatrix>
-    priorRvA("priorA_", paramDomainA);
+  QUESO::UniformVectorRV<> priorRvA("priorA_", paramDomainA);
 
   QUESO::GslVector meanVec(paramSpaceB.zeroVector());
   QUESO::GslVector diagVec(paramSpaceB.zeroVector());
@@ -154,17 +141,13 @@ void compute(const QUESO::FullEnvironment& env) {
 
   QUESO::GslMatrix covMatrix(diagVec);
 
-  QUESO::GaussianVectorRV<QUESO::GslVector,QUESO::GslMatrix>
-    priorRvB("priorB_", paramDomainB,meanVec,covMatrix);
+  QUESO::GaussianVectorRV<> priorRvB("priorB_", paramDomainB,meanVec,covMatrix);
 
-  QUESO::ConcatenatedVectorRV<QUESO::GslVector,QUESO::GslMatrix>
-    priorRv("prior_", priorRvA, priorRvB, paramDomain);
+  QUESO::ConcatenatedVectorRV<> priorRv("prior_", priorRvA, priorRvB, paramDomain);
 
-  QUESO::GenericVectorRV<QUESO::GslVector,QUESO::GslMatrix>
-    postRv("post_", paramSpace);
+  QUESO::GenericVectorRV<> postRv("post_", paramSpace);
 
-  QUESO::StatisticalInverseProblem<QUESO::GslVector,QUESO::GslMatrix>
-    ip("", NULL, priorRv, likelihoodFunctionObj, postRv);
+  QUESO::StatisticalInverseProblem<> ip("", NULL, priorRv, likelihood, postRv);
 
   //------------------------------------------------------
   // Step 5 of 5: Solve the inverse problem
@@ -204,7 +187,7 @@ void debug_hyst(const QUESO::FullEnvironment& env) {
                       "debug_hyst()",
                       "input file has a smaller number of observations than expected");
 
-  QUESO::VectorSpace<QUESO::GslVector, QUESO::GslMatrix> floorSpace(env, "floor_", numFloors, NULL);
+  QUESO::VectorSpace<> floorSpace(env, "floor_", numFloors, NULL);
 
   QUESO::GslVector kVec(floorSpace.zeroVector());
   kVec[0] = 2.20e+7;
@@ -228,11 +211,11 @@ void debug_hyst(const QUESO::FullEnvironment& env) {
   double gamma = 2.500e-3 ; //0.0038;
 
   std::vector<double> t(numTimeSteps,0.);
-  QUESO::SequenceOfVectors<QUESO::GslVector,QUESO::GslMatrix> u     (floorSpace,numTimeSteps,""); // absolute displacement
-  QUESO::SequenceOfVectors<QUESO::GslVector,QUESO::GslMatrix> ud    (floorSpace,numTimeSteps,""); // velocity
-  QUESO::SequenceOfVectors<QUESO::GslVector,QUESO::GslMatrix> udd   (floorSpace,numTimeSteps,""); // acceleration
-  QUESO::SequenceOfVectors<QUESO::GslVector,QUESO::GslMatrix> resfor(floorSpace,numTimeSteps,""); // restoring force
-  QUESO::SequenceOfVectors<QUESO::GslVector,QUESO::GslMatrix> ru    (floorSpace,numTimeSteps,""); // relative displacement
+  QUESO::SequenceOfVectors<> u     (floorSpace,numTimeSteps,""); // absolute displacement
+  QUESO::SequenceOfVectors<> ud    (floorSpace,numTimeSteps,""); // velocity
+  QUESO::SequenceOfVectors<> udd   (floorSpace,numTimeSteps,""); // acceleration
+  QUESO::SequenceOfVectors<> resfor(floorSpace,numTimeSteps,""); // restoring force
+  QUESO::SequenceOfVectors<> ru    (floorSpace,numTimeSteps,""); // relative displacement
 
   u.setPositionValues     (0,floorSpace.zeroVector());
   ud.setPositionValues    (0,floorSpace.zeroVector());

--- a/examples/hysteretic/src/example_likelihood.C
+++ b/examples/hysteretic/src/example_likelihood.C
@@ -33,24 +33,15 @@
 #include <example_likelihood.h>
 #include <example_hyst.h>
 
-double likelihoodRoutine(
-  const QUESO::GslVector& paramValues,
-  const QUESO::GslVector* paramDirection,
-  const void*             functionDataPtr,
-  QUESO::GslVector*       gradVector,
-  QUESO::GslMatrix*       hessianMatrix,
-  QUESO::GslVector*       hessianEffect)
+template <class V, class M>
+double
+Likelihood<V, M>::lnValue(const V & paramValues) const
 {
   const QUESO::BaseEnvironment& env = paramValues.env();
   UQ_FATAL_TEST_MACRO(paramValues.sizeLocal() != 15,
                       env.fullRank(),
                       "example_likelihood()",
                       "invalid parameter size");
-
-  const std::vector<std::vector<double>* >&
-    floor = ((likelihoodRoutine_DataType *) functionDataPtr)->floor;
-  const std::vector<double>&
-    accel = ((likelihoodRoutine_DataType *) functionDataPtr)->accel;
 
   unsigned int numFloors    = floor.size();
   unsigned int numTimeSteps = accel.size();
@@ -136,3 +127,5 @@ double likelihoodRoutine(
   double result = -0.5*((double) numFloors)*((double) numTimeSteps)*log(2.*M_PI*sigmaSq) - 0.5*sum/sigmaSq;
   return result;
 }
+
+template class Likelihood<QUESO::GslVector, QUESO::GslMatrix>;

--- a/examples/hysteretic/src/example_likelihood.h
+++ b/examples/hysteretic/src/example_likelihood.h
@@ -34,20 +34,32 @@
 #define __EX_LIKELIHOOD_H__
 
 #include <queso/GslMatrix.h>
+#include <queso/ScalarFunction.h>
+#include <cmath>
 
-struct
-likelihoodRoutine_DataType
+template <class V = QUESO::GslVector, class M = QUESO::GslMatrix>
+class Likelihood : public QUESO::BaseScalarFunction<V, M>
 {
+public:
+  Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domainSet)
+    : QUESO::BaseScalarFunction<V, M>(prefix, domainSet)
+  {
+  }
+
+  virtual ~Likelihood() { }
+
+  virtual double lnValue(const V & paramValues) const;
+  virtual double actualValue(const V & paramValues,
+                             const V * paramDirection,
+                             V *       gradVector,
+                             M *       hessianMatrix,
+                             V *       hessianEffect) const
+  {
+    return std::exp(this->lnValue(paramValues));
+  }
+
   std::vector<std::vector<double>* > floor;
               std::vector<double>    accel;
 };
-
-double likelihoodRoutine(
-  const QUESO::GslVector& paramValues,
-  const QUESO::GslVector* paramDirection,
-  const void*             functionDataPtr,
-  QUESO::GslVector*       gradVector,
-  QUESO::GslMatrix*       hessianMatrix,
-  QUESO::GslVector*       hessianEffect);
 
 #endif

--- a/examples/line2D_with_Sensitivity/slope_compute.C
+++ b/examples/line2D_with_Sensitivity/slope_compute.C
@@ -10,7 +10,6 @@
 
 #include <queso/GslVector.h>
 #include <queso/GslMatrix.h>
-#include <queso/GenericScalarFunction.h>
 #include <queso/GenericVectorFunction.h>
 #include <queso/GaussianVectorRV.h>
 #include <queso/UniformVectorRV.h>

--- a/examples/line2D_with_Sensitivity/slope_likelihood.C
+++ b/examples/line2D_with_Sensitivity/slope_likelihood.C
@@ -2,7 +2,6 @@
 #include <fstream>
 #include <iostream>
 
-#include <queso/GenericScalarFunction.h>
 #include <queso/GslVector.h>
 #include <queso/GslMatrix.h>
 #include <queso/UniformVectorRV.h>

--- a/examples/modal/src/example_compute.C
+++ b/examples/modal/src/example_compute.C
@@ -34,7 +34,6 @@
 #include <example_likelihood.h>
 #include <queso/GslMatrix.h>
 #include <queso/StatisticalInverseProblem.h>
-#include <queso/GenericScalarFunction.h>
 #include <queso/GenericVectorRV.h>
 #include <queso/UniformVectorRV.h>
 #include <queso/ConcatenatedVectorRV.h>
@@ -97,15 +96,8 @@ void compute(const QUESO::FullEnvironment& env, unsigned int numModes) {
   ////////////////////////////////////////////////////////
   // Step 3 of 5: Instantiate the likelihood function object
   ////////////////////////////////////////////////////////
-  likelihoodRoutine_DataType likelihoodRoutine_Data;
-
-  likelihoodRoutine_Data.numModes = numModes;
-  QUESO::GenericScalarFunction<QUESO::GslVector,QUESO::GslMatrix>
-    likelihoodFunctionObj("like_",
-                          paramDomain,
-                          likelihoodRoutine,
-                          (void *) &likelihoodRoutine_Data,
-                          true); // routine computes [-2.*ln(function)]
+  Likelihood<> likelihood("like_", paramDomain);
+  likelihood.numModes = numModes;
 
     ////////////////////////////////////////////////////////
   // Step 4 of 5: Instantiate the inverse problem
@@ -137,7 +129,7 @@ void compute(const QUESO::FullEnvironment& env, unsigned int numModes) {
     postRv("post_", paramSpace);
 
   QUESO::StatisticalInverseProblem<QUESO::GslVector,QUESO::GslMatrix>
-    ip("", NULL, priorRv, likelihoodFunctionObj, postRv);
+    ip("", NULL, priorRv, likelihood, postRv);
 
   ////////////////////////////////////////////////////////
   // Step 5 of 5: Solve the inverse problem

--- a/examples/modal/src/example_likelihood.C
+++ b/examples/modal/src/example_likelihood.C
@@ -32,19 +32,13 @@
 
 #include <example_likelihood.h>
 
-double likelihoodRoutine(
-  const QUESO::GslVector& paramValues,
-  const QUESO::GslVector* paramDirection,
-  const void*             functionDataPtr,
-  QUESO::GslVector*       gradVector,
-  QUESO::GslMatrix*       hessianMatrix,
-  QUESO::GslVector*       hessianEffect)
+template <class V, class M>
+double
+Likelihood<V, M>::lnValue(const V & paramValues) const
 {
   double theta1  = paramValues[0];
   double theta2  = paramValues[1];
   double sigmaSq = paramValues[2];
-
-  unsigned int numModes = ((likelihoodRoutine_DataType *) functionDataPtr)->numModes;
 
   double aux1 = theta1 + 2.*theta2;
   double aux2 = sqrt(theta1*theta1+4.*theta2*theta2);
@@ -93,3 +87,5 @@ double likelihoodRoutine(
 
   return result;
 }
+
+template class Likelihood<QUESO::GslVector, QUESO::GslMatrix>;

--- a/examples/modal/src/example_likelihood.h
+++ b/examples/modal/src/example_likelihood.h
@@ -33,19 +33,31 @@
 #define __EX_LIKELIHOOD_H__
 
 #include <queso/GslMatrix.h>
+#include <queso/ScalarFunction.h>
+#include <cmath>
 
-struct
-likelihoodRoutine_DataType
+template <class V = QUESO::GslVector, class M = QUESO::GslMatrix>
+class Likelihood : QUESO::BaseScalarFunction<V, M>
 {
+public:
+  Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domainSet)
+    : QUESO::BaseScalarFunction<V, M>(prefix, domainSet)
+  {
+  }
+
+  ~Likelihood() { }
+
+  virtual double lnValue(const V & paramValues) const;
+  virtual double actualValue(const V & paramValues,
+                             const V * paramDirection,
+                             const void * functionDataPtr,
+                             V *       gradVector,
+                             M *       hessianMatrix,
+                             V *       hessianEffect) const
+  {
+    return std::exp(this->lnValue(paramValues));
+  }
+
   unsigned int numModes;
 };
-
-double likelihoodRoutine(
-  const QUESO::GslVector& paramValues,
-  const QUESO::GslVector* paramDirection,
-  const void*             functionDataPtr,
-  QUESO::GslVector*       gradVector,
-  QUESO::GslMatrix*       hessianMatrix,
-  QUESO::GslVector*       hessianEffect);
-
 #endif

--- a/examples/simpleStatisticalInverseProblem/src/example_compute.C
+++ b/examples/simpleStatisticalInverseProblem/src/example_compute.C
@@ -24,7 +24,6 @@
 
 #include <example_compute.h>
 #include <example_likelihood.h>
-#include <queso/GenericScalarFunction.h>
 #include <queso/GslMatrix.h>
 #include <queso/UniformVectorRV.h>
 #include <queso/StatisticalInverseProblem.h>
@@ -51,24 +50,15 @@ void compute(const QUESO::FullEnvironment& env) {
   covMatrix(0,0) = 4.; covMatrix(0,1) = 0.;
   covMatrix(1,0) = 0.; covMatrix(1,1) = 1.;
 
-  likelihoodRoutine_DataType likelihoodRoutine_Data;
-  likelihoodRoutine_Data.meanVector = &meanVector;
-  likelihoodRoutine_Data.covMatrix  = &covMatrix;
+  Likelihood<> likelihood("like_", paramDomain);
+  likelihood.meanVector = &meanVector;
+  likelihood.covMatrix  = &covMatrix;
 
-  QUESO::GenericScalarFunction<QUESO::GslVector,QUESO::GslMatrix>
-    likelihoodFunctionObj("like_",
-                          paramDomain,
-                          likelihoodRoutine,
-                          (void *) &likelihoodRoutine_Data,
-                          true); // routine computes [ln(function)]
 
   // Step 4 of 5: Instantiate the inverse problem
-  QUESO::UniformVectorRV<QUESO::GslVector,QUESO::GslMatrix>
-    priorRv("prior_", paramDomain);
-  QUESO::GenericVectorRV<QUESO::GslVector,QUESO::GslMatrix>
-    postRv("post_", paramSpace);
-  QUESO::StatisticalInverseProblem<QUESO::GslVector,QUESO::GslMatrix>
-    ip("", NULL, priorRv, likelihoodFunctionObj, postRv);
+  QUESO::UniformVectorRV<> priorRv("prior_", paramDomain);
+  QUESO::GenericVectorRV<> postRv("post_", paramSpace);
+  QUESO::StatisticalInverseProblem<> ip("", NULL, priorRv, likelihood, postRv);
 
   // Step 5 of 5: Solve the inverse problem
   QUESO::GslVector paramInitials(paramSpace.zeroVector());

--- a/examples/simpleStatisticalInverseProblem/src/example_likelihood.C
+++ b/examples/simpleStatisticalInverseProblem/src/example_likelihood.C
@@ -24,22 +24,10 @@
 
 #include <example_likelihood.h>
 
-double likelihoodRoutine(
-  const QUESO::GslVector& paramValues,
-  const QUESO::GslVector* paramDirection,
-  const void*             functionDataPtr,
-  QUESO::GslVector*       gradVector,
-  QUESO::GslMatrix*       hessianMatrix,
-  QUESO::GslVector*       hessianEffect)
+template <class V, class M>
+double
+Likelihood<V, M>::lnValue(const V & paramValues) const
 {
-  // Logic just to avoid warnings from INTEL compiler
-  const QUESO::GslVector* aux1 = paramDirection;
-  if (aux1) {};
-  aux1 = gradVector;
-  aux1 = hessianEffect;
-  QUESO::GslMatrix* aux2 = hessianMatrix;
-  if (aux2) {};
-
   // Just checking: the user, at the application level, expects
   // vector 'paramValues' to have size 2.
   UQ_FATAL_TEST_MACRO(paramValues.sizeGlobal() != 2,
@@ -60,14 +48,10 @@ double likelihoodRoutine(
   double result = 0.;
   const QUESO::BaseEnvironment& env = paramValues.env();
   if (env.subRank() == 0) {
-    const QUESO::GslVector& meanVector =
-      *((likelihoodRoutine_DataType *) functionDataPtr)->meanVector;
-    const QUESO::GslMatrix& covMatrix  =
-      *((likelihoodRoutine_DataType *) functionDataPtr)->covMatrix;
 
-    QUESO::GslVector diffVec(paramValues - meanVector);
+    QUESO::GslVector diffVec(paramValues - *meanVector);
 
-    result= scalarProduct(diffVec,covMatrix.invertMultiply(diffVec));
+    result= scalarProduct(diffVec,covMatrix->invertMultiply(diffVec));
   }
   else {
     // Do nothing;
@@ -75,3 +59,5 @@ double likelihoodRoutine(
 
   return -.5*result;
 }
+
+template class Likelihood<QUESO::GslVector, QUESO::GslMatrix>;

--- a/examples/simpleStatisticalInverseProblem/src/example_likelihood.h
+++ b/examples/simpleStatisticalInverseProblem/src/example_likelihood.h
@@ -26,20 +26,31 @@
 #define EX_LIKELIHOOD_H
 
 #include <queso/GslMatrix.h>
+#include <queso/ScalarFunction.h>
+#include <cmath>
 
-struct
-likelihoodRoutine_DataType
+template <class V = QUESO::GslVector, class M = QUESO::GslMatrix>
+class Likelihood : public QUESO::BaseScalarFunction<V, M>
 {
+public:
+  Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domainSet)
+    : QUESO::BaseScalarFunction<V, M>(prefix, domainSet)
+  {}
+
+  ~Likelihood() {};
+
+  virtual double lnValue(const V & paramValues) const;
+  virtual double actualValue(const V & paramValues,
+                             const V * paramDirection,
+                             V * gradVector,
+                             M * hessianMatrix,
+                             V * hessianEffect) const
+  {
+    return std::exp(this->lnValue(paramValues));
+  }
+
   const QUESO::GslVector* meanVector;
   const QUESO::GslMatrix* covMatrix;
 };
-
-double likelihoodRoutine(
-  const QUESO::GslVector& paramValues,
-  const QUESO::GslVector* paramDirection,
-  const void*             functionDataPtr,
-  QUESO::GslVector*       gradVector,
-  QUESO::GslMatrix*       hessianMatrix,
-  QUESO::GslVector*       hessianEffect);
 
 #endif

--- a/examples/statisticalInverseProblem/src/exStatisticalInverseProblem_appl.h
+++ b/examples/statisticalInverseProblem/src/exStatisticalInverseProblem_appl.h
@@ -85,16 +85,11 @@ uqAppl(const QUESO::BaseEnvironment& env)
   P_M* covMatrix        = paramSpace.newMatrix();
   QUESO::CovCond(condNumber,direction,*covMatrix,*covMatrixInverse);
 
-  likelihoodRoutine_DataType<P_V,P_M> likelihoodRoutine_Data;
-  likelihoodRoutine_Data.paramMeans        = &paramMeans;
-  likelihoodRoutine_Data.matrix            = covMatrixInverse;
-  likelihoodRoutine_Data.applyMatrixInvert = false;
+  Likelihood likelihood("like_", paramDomain);
 
-  QUESO::GenericScalarFunction<P_V,P_M> likelihoodFunctionObj("like_",
-                                                              paramDomain,
-                                                              likelihoodRoutine<P_V,P_M>,
-                                                              (void *) &likelihoodRoutine_Data,
-                                                              true); // the routine computes [ln(function)]
+  likelihood.paramMeans = &paramMeans;
+  likelihood.matrix = covMatrixInverse;
+  likelihood.applyMatrixInvert = false;
 
   //******************************************************
   // Step 4 of 5: Instantiate the inverse problem

--- a/examples/statisticalInverseProblem/src/exStatisticalInverseProblem_likelihood.h
+++ b/examples/statisticalInverseProblem/src/exStatisticalInverseProblem_likelihood.h
@@ -27,42 +27,43 @@
 #ifndef EX_STATISTICAL_INVERSE_PROBLEM_LIKELIHOOD_H
 #define EX_STATISTICAL_INVERSE_PROBLEM_LIKELIHOOD_H
 
-//********************************************************
-// The likelihood routine: provided by user and called by QUESO
-//********************************************************
-template<class P_V,class P_M>
-struct
-likelihoodRoutine_DataType
+template<class P_V, class P_M>
+class Likelihood : public QUESO::BaseScalarFunction<P_V, P_M>
 {
+public:
+  Likelihood(const char * prefix, const QUESO::VectorSet<P_V, P_M> domainSet)
+    : QUESO::BaseScalarFunction<P_V, P_M>(prefix, domainSet)
+  {
+    // Do nothing
+  }
+
+  virtual ~Likelihood()
+  {
+    // Do nothing
+  }
+
+  virtual double lnValue(const P_V & paramValues) const
+  {
+    double result = 0.0;
+
+    const P_V& paramMeans        = *paramMeans;
+    const P_M& matrix            = *matrix;
+    bool       applyMatrixInvert =  applyMatrixInvert;
+
+    P_V diffVec(paramValues - paramMeans);
+    if (applyMatrixInvert) {
+      result = scalarProduct(diffVec, matrix.invertMultiply(diffVec));
+    }
+    else {
+      result = scalarProduct(diffVec, matrix * diffVec);
+    }
+
+    return -.5*result;
+  }
+
   const P_V* paramMeans;
   const P_M* matrix;
   bool       applyMatrixInvert;
-};
-
-template<class P_V,class P_M>
-double
-likelihoodRoutine(
-  const P_V&  paramValues,
-  const P_V*  paramDirection,
-  const void* functionDataPtr,
-  P_V*        gradVector,
-  P_M*        hessianMatrix,
-  P_V*        hessianEffect)
-{
-  double result = 0.;
-
-  const P_V& paramMeans        = *((likelihoodRoutine_DataType<P_V,P_M> *) functionDataPtr)->paramMeans;
-  const P_M& matrix            = *((likelihoodRoutine_DataType<P_V,P_M> *) functionDataPtr)->matrix;
-  bool       applyMatrixInvert =  ((likelihoodRoutine_DataType<P_V,P_M> *) functionDataPtr)->applyMatrixInvert;
-
-  P_V diffVec(paramValues - paramMeans);
-  if (applyMatrixInvert) {
-    result = scalarProduct(diffVec, matrix.invertMultiply(diffVec));
-  }
-  else {
-    result = scalarProduct(diffVec, matrix * diffVec);
-  }
-
-  return -.5*result;
 }
+
 #endif // EX_STATISTICAL_INVERSE_PROBLEM_LIKELIHOOD_H

--- a/examples/statisticalInverse_Fortran/exStatisticalInverseProblem1_appl.h
+++ b/examples/statisticalInverse_Fortran/exStatisticalInverseProblem1_appl.h
@@ -28,7 +28,6 @@
 
 #include <exStatisticalInverseProblem1_likelihood.h>
 
-#include <queso/GenericScalarFunction.h>
 #include <queso/StatisticalInverseProblem.h>
 #include <queso/CovCond.h>
 
@@ -86,16 +85,11 @@ uqAppl(const QUESO::BaseEnvironment& env)
   P_M* covMatrix        = paramSpace.newMatrix();
   QUESO::CovCond(condNumber,direction,*covMatrix,*covMatrixInverse);
 
-  likelihoodRoutine_DataType<P_V,P_M> likelihoodRoutine_Data;
-  likelihoodRoutine_Data.paramMeans        = &paramMeans;
-  likelihoodRoutine_Data.matrix            = covMatrixInverse;
-  likelihoodRoutine_Data.applyMatrixInvert = false;
+  Likelihood<> likelihood("like_", paramDomain);
+  likelihood.paramMeans        = &paramMeans;
+  likelihood.matrix            = covMatrixInverse;
+  likelihood.applyMatrixInvert = false;
 
-  QUESO::GenericScalarFunction<P_V,P_M> likelihoodFunctionObj("like_",
-                                                              paramDomain,
-                                                              likelihoodRoutine<P_V,P_M>,
-                                                              (void *) &likelihoodRoutine_Data,
-                                                              true); // the routine computes [ln(function)]
 
   //******************************************************
   // Step 4 of 5: Instantiate the inverse problem
@@ -114,7 +108,7 @@ uqAppl(const QUESO::BaseEnvironment& env)
   QUESO::StatisticalInverseProblem<P_V,P_M> ip("", // No extra prefix before the default "ip_" prefix
                                                NULL,
                                                priorRv,
-                                               likelihoodFunctionObj,
+                                               likelihood,
                                                postRv);
 
   //******************************************************

--- a/examples/statisticalInverse_Fortran/exStatisticalInverseProblem1_likelihood.h
+++ b/examples/statisticalInverse_Fortran/exStatisticalInverseProblem1_likelihood.h
@@ -29,6 +29,7 @@
 #include <stdlib.h>
 #include <iostream>
 #include <queso/Environment.h>
+#include <cmath>
 
 #define FORTRAN_WRAPPER_VERSION
 
@@ -42,95 +43,99 @@ extern "C" double f_likelihood(int num_params, const double *parameter_values,
 // The likelihood routine: provided by user and called by QUESO
 //-------------------------------------------------------------
 
-template<class P_V,class P_M>
-struct
-likelihoodRoutine_DataType
+template<class V = QUESO::GslVector, class M = QUESO::GslMatrix>
+class Likelihood : public QUESO::BaseScalarFunction<V, M>
 {
-  const P_V* paramMeans;
-  const P_M* matrix;
-  bool       applyMatrixInvert;
-};
+public:
+  Likelihood(const char * prefix, const QUESO::VectorSet<V, M> & domainSet)
+    : QUESO::BaseScalarFunction<V, M>(prefix, domainSet)
+  {
+  }
 
-template<class P_V,class P_M>
-double
-likelihoodRoutine(
-  const P_V&  paramValues,
-  const P_V*  paramDirection,
-  const void* functionDataPtr,
-  P_V*        gradVector,
-  P_M*        hessianMatrix,
-  P_V*        hessianEffect)
-{
+  virtual ~Likelihood() { }
 
-  const P_V& paramMeans        = *((likelihoodRoutine_DataType<P_V,P_M> *) functionDataPtr)->paramMeans;
-  const P_M& matrix            = *((likelihoodRoutine_DataType<P_V,P_M> *) functionDataPtr)->matrix;
-
+  virtual double lnValue(const V &  paramValues) const
+  {
 #ifdef FORTRAN_WRAPPER_VERSION
 
-  // grab data in a form that we can pass to fortran
+    // grab data in a form that we can pass to fortran
 
-  const double *params      = gsl_vector_const_ptr(paramValues.data(),0);
-  const double *param_means = gsl_vector_const_ptr(paramMeans.data(),0);
+    const double *params      = gsl_vector_const_ptr(paramValues.data(),0);
+    const double *param_means = gsl_vector_const_ptr(paramMeans->data(),0);
 
-  static double *matrix_to_fortran;
-  static bool first_entry=true;
+    static double *matrix_to_fortran;
+    static bool first_entry=true;
 
-  // Initialization to perform on first entry only
+    // Initialization to perform on first entry only
 
-  static int num_procs, num_local;
-  static int subId;
-  static MPI_Comm Local_MPI_Comm;
+    static int num_procs, num_local;
+    static int subId;
+    static MPI_Comm Local_MPI_Comm;
 
-  if(first_entry)
+    if(first_entry)
+      {
+        matrix_to_fortran = (double *)calloc(matrix->numRowsGlobal()*matrix->numCols(),sizeof(double));
+
+        for(unsigned int row=0;row<matrix->numRowsGlobal();row++)
+    for(unsigned int col=0;col<matrix->numCols();col++)
+      {
+        matrix_to_fortran[col+row*matrix->numCols()] = (*matrix)(row,col);
+      }
+
+        // determine local MPI environment info
+
+        const QUESO::BaseEnvironment &env = paramMeans->env();
+        subId                             = (int)env.subId();
+        Local_MPI_Comm                    = env.subComm().Comm();
+        int num_global_procs;
+
+        MPI_Comm_size (Local_MPI_Comm, &num_procs);
+        MPI_Comm_rank (Local_MPI_Comm, &num_local);
+
+        if(paramMeans->env().worldRank() == 0)
     {
-      matrix_to_fortran = (double *)calloc(matrix.numRowsGlobal()*matrix.numCols(),sizeof(double));
-
-      for(unsigned int row=0;row<matrix.numRowsGlobal();row++)
-	for(unsigned int col=0;col<matrix.numCols();col++)
-	  {
-	    matrix_to_fortran[col+row*matrix.numCols()] = matrix(row,col);
-	  }
-
-      // determine local MPI environment info
-
-      const QUESO::BaseEnvironment &env = paramMeans.env();
-      subId                             = (int)env.subId();
-      Local_MPI_Comm                    = env.subComm().Comm();
-      int num_global_procs;
-
-      MPI_Comm_size (Local_MPI_Comm, &num_procs);
-      MPI_Comm_rank (Local_MPI_Comm, &num_local);
-
-      if(paramMeans.env().worldRank() == 0)
-	{
-	  MPI_Comm_size (MPI_COMM_WORLD, &num_global_procs);
-	  printf("\nLikelihood parallel environment (C++): \n");
-	  printf("--> Total # of MPI processors available    = %i\n",  num_global_procs);
-	  printf("--> Total # of SubEnvironments requested   = %i\n",  paramMeans.env().numSubEnvironments());
-	  printf("--> Number of MPI tasks per SubEnvironment = %i\n\n",num_procs);
-	}
-
-      first_entry=false;
+      MPI_Comm_size (MPI_COMM_WORLD, &num_global_procs);
+      printf("\nLikelihood parallel environment (C++): \n");
+      printf("--> Total # of MPI processors available    = %i\n",  num_global_procs);
+      printf("--> Total # of SubEnvironments requested   = %i\n",  paramMeans->env().numSubEnvironments());
+      printf("--> Number of MPI tasks per SubEnvironment = %i\n\n",num_procs);
     }
 
-  // Transfer program to Fortran likelihood function - note that rank 0
-  // for each subcommunicator is responsible for computing the final
-  // likelihood value.
+        first_entry=false;
+      }
 
-  double result = f_likelihood(paramValues.sizeGlobal(),params,param_means,matrix_to_fortran,subId,
-			       MPI_Comm_c2f(Local_MPI_Comm));
+    // Transfer program to Fortran likelihood function - note that rank 0
+    // for each subcommunicator is responsible for computing the final
+    // likelihood value.
 
-  return(result);
+    double result = f_likelihood(paramValues.sizeGlobal(),params,param_means,matrix_to_fortran,subId,
+               MPI_Comm_c2f(Local_MPI_Comm));
+
+    return(result);
 
 #else
 
-  double result = 0.;
+    double result = 0.;
 
-  P_V diffVec(paramValues - paramMeans);
-  result = scalarProduct(diffVec, matrix * diffVec);
+    V diffVec(paramValues - *paramMeans);
+    result = scalarProduct(diffVec, *matrix * diffVec);
 
-  return(result);
+    return(result);
 #endif
+  }
 
-}
+  virtual double actualValue(const V &  paramValues,
+                             const V *  paramDirection,
+                             V *        gradVector,
+                             M *        hessianMatrix,
+                             V *        hessianEffect) const
+  {
+    return std::exp(this->lnValue(paramValues));
+  }
+
+  const V* paramMeans;
+  const M* matrix;
+  bool     applyMatrixInvert;
+};
+
 #endif // EX_STATISTICAL_INVERSE_PROBLEM_1_LIKELIHOOD_H

--- a/examples/template_example/template_example.cpp
+++ b/examples/template_example/template_example.cpp
@@ -1,4 +1,3 @@
-#include <queso/GenericScalarFunction.h>
 #include <queso/GslVector.h>
 #include <queso/GslMatrix.h>
 #include <queso/UniformVectorRV.h>

--- a/examples/validationCycle/src/exTgaValidationCycle_appl.h
+++ b/examples/validationCycle/src/exTgaValidationCycle_appl.h
@@ -34,17 +34,16 @@
 #include <queso/ValidationCycle.h>
 #include <queso/VectorSubset.h>
 #include <queso/UniformVectorRV.h>
-#include <queso/GenericScalarFunction.h>
 #include <gsl/gsl_errno.h>
 #include <gsl/gsl_odeiv.h>
 
 //Just declaration: actual code is below
 template<class P_V,class P_M,class Q_V,class Q_M>
-void 
+void
 uqAppl_LocalComparisonStage(QUESO::ValidationCycle<P_V,P_M,Q_V,Q_M>& cycle);
 
 template<class P_V,class P_M,class Q_V,class Q_M>
-void 
+void
 uqAppl_UnifiedComparisonStage(QUESO::ValidationCycle<P_V,P_M,Q_V,Q_M>& cycle);
 
 //********************************************************
@@ -58,7 +57,7 @@ uqAppl_UnifiedComparisonStage(QUESO::ValidationCycle<P_V,P_M,Q_V,Q_M>& cycle);
 // Tasks 2, 3 and 4 constitute the actual validation cycle.
 //********************************************************
 template<class P_V,class P_M,class Q_V,class Q_M>
-void 
+void
 uqAppl(const QUESO::BaseEnvironment& env)
 {
   if (env.fullRank() == 0) {
@@ -120,16 +119,11 @@ uqAppl(const QUESO::BaseEnvironment& env)
     paramDomain);
 
   // Inverse problem: instantiate the likelihood function object (data + routine)
-  likelihoodRoutine_Data<P_V,P_M> calLikelihoodRoutine_Data(env,
-                                                                 "scenario_5_K_min.dat",
-                                                                 "scenario_25_K_min.dat",
-                                                                 "scenario_50_K_min.dat");
-
-  QUESO::GenericScalarFunction<P_V,P_M> calLikelihoodFunctionObj("cal_like_",
-                                                                 paramDomain,
-                                                                 likelihoodRoutine<P_V,P_M>,
-                                                                 (void *) &calLikelihoodRoutine_Data,
-                                                                 true); // the routine computes [ln(function)]
+  Likelihood<> calLikelihoodFunctionObj("cal_like_",
+                                        paramDomain,
+                                        "scenario_5_K_min.dat",
+                                        "scenario_25_K_min.dat",
+                                        "scenario_50_K_min.dat");
 
   // Inverse problem: instantiate it (posterior rv is instantiated internally)
   QUESO::SipOptionsValues* calIpOptionsValues = NULL;
@@ -273,7 +267,7 @@ uqAppl(const QUESO::BaseEnvironment& env)
 
   ssOptionsValues3.m_initialDiscardedPortions.resize(1);
   ssOptionsValues3.m_initialDiscardedPortions[0] = 0.;
-  
+
   ssOptionsValues3.m_kdeCompute                  = true;
   ssOptionsValues3.m_kdeNumEvalPositions         = 250;
   ssOptionsValues3.m_covMatrixCompute            = true;
@@ -336,18 +330,12 @@ uqAppl(const QUESO::BaseEnvironment& env)
   }
 
   // Inverse problem: no need to instantiate the prior rv (= posterior rv of calibration inverse problem)
-
   // Inverse problem: instantiate the likelihood function object (data + routine)
-  likelihoodRoutine_Data<P_V,P_M> valLikelihoodRoutine_Data(env,
-                                                                 "scenario_100_K_min.dat",
-                                                                 NULL,
-                                                                 NULL);
-
-  QUESO::GenericScalarFunction<P_V,P_M> valLikelihoodFunctionObj("val_like_",
-                                                                 paramDomain,
-                                                                 likelihoodRoutine<P_V,P_M>,
-                                                                 (void *) &valLikelihoodRoutine_Data,
-                                                                 true); // the routine computes [ln(function)]
+  Likelihood<> valLikelihoodFunctionObj("val_like_",
+                                        paramDomain,
+                                        "scenario_100_K_min.dat",
+                                        NULL,
+                                        NULL);
 
   // Inverse problem: instantiate it (posterior rv is instantiated internally)
   QUESO::SipOptionsValues* valIpOptionsValues = NULL;
@@ -365,14 +353,14 @@ uqAppl(const QUESO::BaseEnvironment& env)
   // Inverse problem: solve it, that is, set 'pdf' and 'realizer' of the posterior rv
   QUESO::MhOptionsValues* valIpMhOptionsValues = NULL;
 
-  const QUESO::SequentialVectorRealizer<P_V,P_M>* 
+  const QUESO::SequentialVectorRealizer<P_V,P_M>*
   	tmpRealizer = dynamic_cast< const QUESO::SequentialVectorRealizer<P_V,P_M>* >(&(cycle.calIP().postRv().realizer()));
-  
+
   // Use 'realizer()' because the post. rv was computed with Metr. Hast.
   P_M* valProposalCovMatrix = cycle.calIP().postRv().imageSet().vectorSpace().newProposalMatrix(
-    	    &tmpRealizer->unifiedSampleVarVector(),  
+    	    &tmpRealizer->unifiedSampleVarVector(),
     	    &tmpRealizer->unifiedSampleExpVector()); // Use these values as the initial values
-  	
+
 #ifdef UQ_EXAMPLES_USES_QUESO_INPUT_FILE
 #else
   QUESO::SsOptionsValues ssOptionsValues5;
@@ -454,7 +442,7 @@ uqAppl(const QUESO::BaseEnvironment& env)
   delete valProposalCovMatrix;
   delete valIpMhOptionsValues;
 
-  // Forward problem: instantiate it (parameter rv = posterior rv of inverse problem; 
+  // Forward problem: instantiate it (parameter rv = posterior rv of inverse problem;
   // qoi rv is instantiated internally)
   qoiRoutine_Data<P_V,P_M,Q_V,Q_M> valQoiRoutine_Data;
   valQoiRoutine_Data.m_beta         = beta_prediction;
@@ -578,7 +566,7 @@ uqAppl(const QUESO::BaseEnvironment& env)
 // The 'local comparison stage' of the driving routine "uqAppl()"
 //********************************************************
 template<class P_V,class P_M,class Q_V,class Q_M>
-void 
+void
 uqAppl_LocalComparisonStage(QUESO::ValidationCycle<P_V,P_M,Q_V,Q_M>& cycle)
 {
   if (cycle.calFP().computeSolutionFlag() &&
@@ -592,7 +580,7 @@ uqAppl_LocalComparisonStage(QUESO::ValidationCycle<P_V,P_M,Q_V,Q_M>& cycle)
 // The 'unified comparison stage' of the driving routine "uqAppl()"
 //********************************************************
 template<class P_V,class P_M,class Q_V,class Q_M>
-void 
+void
 uqAppl_UnifiedComparisonStage(QUESO::ValidationCycle<P_V,P_M,Q_V,Q_M>& cycle)
 {
   if (cycle.calFP().computeSolutionFlag() &&

--- a/examples/validationCycle/src/exTgaValidationCycle_likelihood.h
+++ b/examples/validationCycle/src/exTgaValidationCycle_likelihood.h
@@ -32,6 +32,9 @@
 #include <gsl/gsl_errno.h>
 #include <gsl/gsl_odeiv.h>
 #include <cmath>
+#include <queso/GslVector.h>
+#include <queso/GslMatrix.h>
+#include <queso/ScalarFunction.h>
 
 #define R_CONSTANT 8.314472
 
@@ -54,15 +57,353 @@ int func(double t, const double Mass[], double f[], void *info)
 // The (user defined) data class that carries the data
 // needed by the (user defined) likelihood routine
 //********************************************************
-template<class P_V, class P_M>
-struct
-likelihoodRoutine_Data
+template<class P_V = QUESO::GslVector, class P_M = QUESO::GslMatrix>
+class Likelihood : public QUESO::BaseScalarFunction<P_V, P_M>
 {
-  likelihoodRoutine_Data(const QUESO::BaseEnvironment& env,
-                              const char* inpName1,
-                              const char* inpName2,
-                              const char* inpName3);
- ~likelihoodRoutine_Data();
+public:
+  Likelihood(const char * prefix,
+             const QUESO::VectorSet<P_V, P_M> & domainSet,
+             const char* inpName1,
+             const char* inpName2,
+             const char* inpName3)
+    : QUESO::BaseScalarFunction<P_V, P_M>(prefix, domainSet),
+      m_beta1    (0.),
+      m_variance1(0.),
+      m_Te1      (0),
+      m_Me1      (0),
+      m_beta2    (0.),
+      m_variance2(0.),
+      m_Te2      (0),
+      m_Me2      (0),
+      m_beta3    (0.),
+      m_variance3(0.),
+      m_Te3      (0),
+      m_Me3      (0),
+      m_env      (domainSet.env())
+  {
+    // Read experimental data
+    if (inpName1) {
+      m_Te1.resize(11,0.);
+      m_Me1.resize(11,0.);
+
+      // Open input file on experimental data
+      FILE *inp;
+      inp = fopen(inpName1,"r");
+
+      // Read kinetic parameters and convert heating rate to K/s
+      int aux1 = fscanf(inp,"%lf %lf",&m_beta1,&m_variance1);
+      m_beta1 /= 60.;
+
+      if(aux1) {}; // just to eliminate warnings
+
+      unsigned int numObservations = 0;
+      double tmpTe;
+      double tmpMe;
+      while (fscanf(inp,"%lf %lf",&tmpTe,&tmpMe) != EOF) {
+        UQ_FATAL_TEST_MACRO((numObservations >= m_Te1.size()),
+                            m_env.fullRank(),
+                            "uqAppl(), in uqTgaEx4.h",
+                            "input file 1 has too many observations");
+        m_Te1[numObservations] = tmpTe;
+        m_Me1[numObservations] = tmpMe;
+        numObservations++;
+      }
+      UQ_FATAL_TEST_MACRO((numObservations != m_Te1.size()),
+                          m_env.fullRank(),
+                          "uqAppl(), in uqTgaEx4.h",
+                          "input file 1 has a smaller number of observations than expected");
+
+      // Close input file on experimental data
+      fclose(inp);
+    }
+
+    // Read experimental data
+    if (inpName2) {
+      m_Te2.resize(11,0.);
+      m_Me2.resize(11,0.);
+
+      // Open input file on experimental data
+      FILE *inp;
+      inp = fopen(inpName2,"r");
+
+      // Read kinetic parameters and convert heating rate to K/s
+      int aux2 = fscanf(inp,"%lf %lf",&m_beta2,&m_variance2);
+      m_beta2 /= 60.;
+
+      if(aux2) {}; // just to eliminate warnings
+
+      unsigned int numObservations = 0;
+      double tmpTe;
+      double tmpMe;
+      while (fscanf(inp,"%lf %lf",&tmpTe,&tmpMe) != EOF) {
+        UQ_FATAL_TEST_MACRO((numObservations >= m_Te2.size()),
+                            m_env.fullRank(),
+                            "uqAppl(), in uqTgaEx4.h",
+                            "input file 2 has too many observations");
+        m_Te2[numObservations] = tmpTe;
+        m_Me2[numObservations] = tmpMe;
+        numObservations++;
+      }
+      UQ_FATAL_TEST_MACRO((numObservations != m_Te2.size()),
+                          m_env.fullRank(),
+                          "uqAppl(), in uqTgaEx4.h",
+                          "input file 2 has a smaller number of observations than expected");
+
+      // Close input file on experimental data
+      fclose(inp);
+    }
+
+    // Read experimental data
+    if (inpName3) {
+      m_Te3.resize(11,0.);
+      m_Me3.resize(11,0.);
+
+      // Open input file on experimental data
+      FILE *inp;
+      inp = fopen(inpName3,"r");
+
+      // Read kinetic parameters and convert heating rate to K/s
+      int aux3 = fscanf(inp,"%lf %lf",&m_beta3,&m_variance3);
+      m_beta3 /= 60.;
+
+      if(aux3) {}; // just to eliminate warnings
+
+      unsigned int numObservations = 0;
+      double tmpTe;
+      double tmpMe;
+      while (fscanf(inp,"%lf %lf",&tmpTe,&tmpMe) != EOF) {
+        UQ_FATAL_TEST_MACRO((numObservations >= m_Te3.size()),
+                            m_env.fullRank(),
+                            "uqAppl(), in uqTgaEx4.h",
+                            "input file 3 has too many observations");
+        m_Te3[numObservations] = tmpTe;
+        m_Me3[numObservations] = tmpMe;
+        numObservations++;
+      }
+      UQ_FATAL_TEST_MACRO((numObservations != m_Te3.size()),
+                          m_env.fullRank(),
+                          "uqAppl(), in uqTgaEx4.h",
+                          "input file 3 has a smaller number of observations than expected");
+
+      // Close input file on experimental data
+      fclose(inp);
+
+
+    }
+  }
+
+  virtual ~Likelihood() { }
+
+  virtual double lnValue(const P_V&  paramValues) const
+  {
+    double resultValue = 0.;
+
+    m_env.subComm().Barrier();
+    //env.syncPrintDebugMsg("Entering likelihoodRoutine()",1,env.fullComm());
+
+    // Compute likelihood for scenario 1
+    double betaTest = m_beta1;
+    if (betaTest) {
+      double A                       = paramValues[0];
+      double E                       = paramValues[1];
+      double beta                    = m_beta1;
+      double variance                = m_variance1;
+      const std::vector<double>& Te  = m_Te1;
+      const std::vector<double>& Me  = m_Me1;
+      std::vector<double> Mt(Me.size(),0.);
+
+      double params[]={A,E,beta};
+
+      // integration
+      const gsl_odeiv_step_type *T   = gsl_odeiv_step_rkf45; //rkf45; //gear1;
+            gsl_odeiv_step      *s   = gsl_odeiv_step_alloc(T,1);
+            gsl_odeiv_control   *c   = gsl_odeiv_control_y_new(1e-6,0.0);
+            gsl_odeiv_evolve    *e   = gsl_odeiv_evolve_alloc(1);
+            gsl_odeiv_system     sys = {func, NULL, 1, (void *)params};
+
+      double t = 0.1, t_final = 1900.;
+      double h = 1e-3;
+      double Mass[1];
+      Mass[0]=1.;
+
+      unsigned int i = 0;
+      double t_old = 0.;
+      double M_old[1];
+      M_old[0]=1.;
+
+      double misfit=0.;
+      //unsigned int loopSize = 0;
+      while ((t < t_final) && (i < Me.size())) {
+        int status = gsl_odeiv_evolve_apply(e, c, s, &sys, &t, t_final, &h, Mass);
+        UQ_FATAL_TEST_MACRO((status != GSL_SUCCESS),
+                            paramValues.env().fullRank(),
+                            "likelihoodRoutine()",
+                            "gsl_odeiv_evolve_apply() failed");
+        //printf("t = %6.1lf, mass = %10.4lf\n",t,Mass[0]);
+        //loopSize++;
+
+        while ( (i < Me.size()) && (t_old <= Te[i]) && (Te[i] <= t) ) {
+          Mt[i] = (Te[i]-t_old)*(Mass[0]-M_old[0])/(t-t_old) + M_old[0];
+          misfit += (Me[i]-Mt[i])*(Me[i]-Mt[i]);
+          //printf("%i %lf %lf %lf %lf\n",i,Te[i],Me[i],Mt[i],misfit);
+          i++;
+        }
+
+        t_old=t;
+        M_old[0]=Mass[0];
+      }
+      resultValue += misfit/variance;
+
+      //printf("loopSize = %d\n",loopSize);
+      if ((paramValues.env().displayVerbosity() >= 10) && (paramValues.env().fullRank() == 0)) {
+        printf("In likelihoodRoutine(), A = %g, E = %g, beta = %.3lf: misfit = %lf, likelihood = %lf.\n",A,E,beta,misfit,resultValue);
+      }
+
+      gsl_odeiv_evolve_free (e);
+      gsl_odeiv_control_free(c);
+      gsl_odeiv_step_free   (s);
+    }
+
+    // Compute likelihood for scenario 2
+    betaTest = m_beta2;
+    if (betaTest > 0.) {
+      double A                       = paramValues[0];
+      double E                       = paramValues[1];
+      double beta                    = m_beta2;
+      double variance                = m_variance2;
+      const std::vector<double>& Te  = m_Te2;
+      const std::vector<double>& Me  = m_Me2;
+      std::vector<double> Mt(Me.size(),0.);
+
+      double params[]={A,E,beta};
+
+      // integration
+      const gsl_odeiv_step_type *T   = gsl_odeiv_step_rkf45; //rkf45; //gear1;
+            gsl_odeiv_step      *s   = gsl_odeiv_step_alloc(T,1);
+            gsl_odeiv_control   *c   = gsl_odeiv_control_y_new(1e-6,0.0);
+            gsl_odeiv_evolve    *e   = gsl_odeiv_evolve_alloc(1);
+            gsl_odeiv_system     sys = {func, NULL, 1, (void *)params};
+
+      double t = 0.1, t_final = 1900.;
+      double h = 1e-3;
+      double Mass[1];
+      Mass[0]=1.;
+
+      unsigned int i = 0;
+      double t_old = 0.;
+      double M_old[1];
+      M_old[0]=1.;
+
+      double misfit=0.;
+      //unsigned int loopSize = 0;
+      while ((t < t_final) && (i < Me.size())) {
+        int status = gsl_odeiv_evolve_apply(e, c, s, &sys, &t, t_final, &h, Mass);
+        UQ_FATAL_TEST_MACRO((status != GSL_SUCCESS),
+                            paramValues.env().fullRank(),
+                            "likelihoodRoutine()",
+                            "gsl_odeiv_evolve_apply() failed");
+        //printf("t = %6.1lf, mass = %10.4lf\n",t,Mass[0]);
+        //loopSize++;
+
+        while ( (i < Me.size()) && (t_old <= Te[i]) && (Te[i] <= t) ) {
+          Mt[i] = (Te[i]-t_old)*(Mass[0]-M_old[0])/(t-t_old) + M_old[0];
+          misfit += (Me[i]-Mt[i])*(Me[i]-Mt[i]);
+          //printf("%i %lf %lf %lf %lf\n",i,Te[i],Me[i],Mt[i],misfit);
+          i++;
+        }
+
+        t_old=t;
+        M_old[0]=Mass[0];
+      }
+      resultValue += misfit/variance;
+
+      //printf("loopSize = %d\n",loopSize);
+      if ((paramValues.env().displayVerbosity() >= 10) && (paramValues.env().fullRank() == 0)) {
+        printf("In likelihoodRoutine(), A = %g, E = %g, beta = %.3lf: misfit = %lf, likelihood = %lf.\n",A,E,beta,misfit,resultValue);
+      }
+
+      gsl_odeiv_evolve_free (e);
+      gsl_odeiv_control_free(c);
+      gsl_odeiv_step_free   (s);
+    }
+
+    // Compute likelihood for scenario 3
+    betaTest = m_beta3;
+    if (betaTest > 0.) {
+      double A                       = paramValues[0];
+      double E                       = paramValues[1];
+      double beta                    = m_beta3;
+      double variance                = m_variance3;
+      const std::vector<double>& Te  = m_Te3;
+      const std::vector<double>& Me  = m_Me3;
+      std::vector<double> Mt(Me.size(),0.);
+
+      double params[]={A,E,beta};
+
+      // integration
+      const gsl_odeiv_step_type *T   = gsl_odeiv_step_rkf45; //rkf45; //gear1;
+            gsl_odeiv_step      *s   = gsl_odeiv_step_alloc(T,1);
+            gsl_odeiv_control   *c   = gsl_odeiv_control_y_new(1e-6,0.0);
+            gsl_odeiv_evolve    *e   = gsl_odeiv_evolve_alloc(1);
+            gsl_odeiv_system     sys = {func, NULL, 1, (void *)params};
+
+      double t = 0.1, t_final = 1900.;
+      double h = 1e-3;
+      double Mass[1];
+      Mass[0]=1.;
+
+      unsigned int i = 0;
+      double t_old = 0.;
+      double M_old[1];
+      M_old[0]=1.;
+
+      double misfit=0.;
+      //unsigned int loopSize = 0;
+      while ((t < t_final) && (i < Me.size())) {
+        int status = gsl_odeiv_evolve_apply(e, c, s, &sys, &t, t_final, &h, Mass);
+        UQ_FATAL_TEST_MACRO((status != GSL_SUCCESS),
+                            paramValues.env().fullRank(),
+                            "likelihoodRoutine()",
+                            "gsl_odeiv_evolve_apply() failed");
+        //printf("t = %6.1lf, mass = %10.4lf\n",t,Mass[0]);
+        //loopSize++;
+
+        while ( (i < Me.size()) && (t_old <= Te[i]) && (Te[i] <= t) ) {
+          Mt[i] = (Te[i]-t_old)*(Mass[0]-M_old[0])/(t-t_old) + M_old[0];
+          misfit += (Me[i]-Mt[i])*(Me[i]-Mt[i]);
+          //printf("%i %lf %lf %lf %lf\n",i,Te[i],Me[i],Mt[i],misfit);
+          i++;
+        }
+
+        t_old=t;
+        M_old[0]=Mass[0];
+      }
+      resultValue += misfit/variance;
+
+      //printf("loopSize = %d\n",loopSize);
+      if ((paramValues.env().displayVerbosity() >= 10) && (paramValues.env().fullRank() == 0)) {
+        printf("In likelihoodRoutine(), A = %g, E = %g, beta = %.3lf: misfit = %lf, likelihood = %lf.\n",A,E,beta,misfit,resultValue);
+      }
+
+      gsl_odeiv_evolve_free (e);
+      gsl_odeiv_control_free(c);
+      gsl_odeiv_step_free   (s);
+    }
+
+    m_env.subComm().Barrier();
+    //env.syncPrintDebugMsg("Leaving likelihoodRoutine()",1,env.fullComm());
+
+    return -.5*resultValue;
+  }
+
+  virtual double actualValue(const P_V&  paramValues,
+                             const P_V*  paramDirection,
+                             P_V*        gradVector,
+                             P_M*        hessianMatrix,
+                             P_V*        hessianEffect) const
+  {
+    return std::exp(this->lnValue(paramValues));
+  }
 
   double              m_beta1;
   double              m_variance1;
@@ -79,359 +420,7 @@ likelihoodRoutine_Data
   std::vector<double> m_Te3; // temperatures
   std::vector<double> m_Me3; // relative masses
 
-  const QUESO::BaseEnvironment* m_env;
+  const QUESO::BaseEnvironment & m_env;
 };
-
-template<class P_V, class P_M>
-likelihoodRoutine_Data<P_V,P_M>::likelihoodRoutine_Data(
-  const QUESO::BaseEnvironment& env,
-  const char* inpName1,
-  const char* inpName2,
-  const char* inpName3)
-  :
-  m_beta1    (0.),
-  m_variance1(0.),
-  m_Te1      (0),
-  m_Me1      (0),
-  m_beta2    (0.),
-  m_variance2(0.),
-  m_Te2      (0),
-  m_Me2      (0),
-  m_beta3    (0.),
-  m_variance3(0.),
-  m_Te3      (0),
-  m_Me3      (0),
-  m_env      (&env)
-{
-  // Read experimental data
-  if (inpName1) {
-    m_Te1.resize(11,0.);
-    m_Me1.resize(11,0.);
-
-    // Open input file on experimental data
-    FILE *inp;
-    inp = fopen(inpName1,"r");
-
-    // Read kinetic parameters and convert heating rate to K/s
-    int aux1 = fscanf(inp,"%lf %lf",&m_beta1,&m_variance1);
-    m_beta1 /= 60.;
-  
-    if(aux1) {}; // just to eliminate warnings
-
-    unsigned int numObservations = 0;
-    double tmpTe;
-    double tmpMe;
-    while (fscanf(inp,"%lf %lf",&tmpTe,&tmpMe) != EOF) {
-      UQ_FATAL_TEST_MACRO((numObservations >= m_Te1.size()),
-                          env.fullRank(),
-                          "uqAppl(), in uqTgaEx4.h",
-                          "input file 1 has too many observations");
-      m_Te1[numObservations] = tmpTe;
-      m_Me1[numObservations] = tmpMe;
-      numObservations++;
-    }
-    UQ_FATAL_TEST_MACRO((numObservations != m_Te1.size()),
-                        env.fullRank(),
-                        "uqAppl(), in uqTgaEx4.h",
-                        "input file 1 has a smaller number of observations than expected");
-
-    // Close input file on experimental data
-    fclose(inp);
-  }
-
-  // Read experimental data
-  if (inpName2) {
-    m_Te2.resize(11,0.);
-    m_Me2.resize(11,0.);
-
-    // Open input file on experimental data
-    FILE *inp;
-    inp = fopen(inpName2,"r");
-
-    // Read kinetic parameters and convert heating rate to K/s
-    int aux2 = fscanf(inp,"%lf %lf",&m_beta2,&m_variance2);
-    m_beta2 /= 60.;
-  
-    if(aux2) {}; // just to eliminate warnings
-
-    unsigned int numObservations = 0;
-    double tmpTe;
-    double tmpMe;
-    while (fscanf(inp,"%lf %lf",&tmpTe,&tmpMe) != EOF) {
-      UQ_FATAL_TEST_MACRO((numObservations >= m_Te2.size()),
-                          env.fullRank(),
-                          "uqAppl(), in uqTgaEx4.h",
-                          "input file 2 has too many observations");
-      m_Te2[numObservations] = tmpTe;
-      m_Me2[numObservations] = tmpMe;
-      numObservations++;
-    }
-    UQ_FATAL_TEST_MACRO((numObservations != m_Te2.size()),
-                        env.fullRank(),
-                        "uqAppl(), in uqTgaEx4.h",
-                        "input file 2 has a smaller number of observations than expected");
-
-    // Close input file on experimental data
-    fclose(inp);
-  }
-
-  // Read experimental data
-  if (inpName3) {
-    m_Te3.resize(11,0.);
-    m_Me3.resize(11,0.);
-
-    // Open input file on experimental data
-    FILE *inp;
-    inp = fopen(inpName3,"r");
-
-    // Read kinetic parameters and convert heating rate to K/s
-    int aux3 = fscanf(inp,"%lf %lf",&m_beta3,&m_variance3);
-    m_beta3 /= 60.;
-    
-    if(aux3) {}; // just to eliminate warnings
-  
-    unsigned int numObservations = 0;
-    double tmpTe;
-    double tmpMe;
-    while (fscanf(inp,"%lf %lf",&tmpTe,&tmpMe) != EOF) {
-      UQ_FATAL_TEST_MACRO((numObservations >= m_Te3.size()),
-                          env.fullRank(),
-                          "uqAppl(), in uqTgaEx4.h",
-                          "input file 3 has too many observations");
-      m_Te3[numObservations] = tmpTe;
-      m_Me3[numObservations] = tmpMe;
-      numObservations++;
-    }
-    UQ_FATAL_TEST_MACRO((numObservations != m_Te3.size()),
-                        env.fullRank(),
-                        "uqAppl(), in uqTgaEx4.h",
-                        "input file 3 has a smaller number of observations than expected");
-
-    // Close input file on experimental data
-    fclose(inp);
-    
-    
-  }
-}
-
-template<class P_V, class P_M>
-likelihoodRoutine_Data<P_V,P_M>::~likelihoodRoutine_Data()
-{
-}
-
-//********************************************************
-// The actual (user defined) likelihood routine
-//********************************************************
-template<class P_V,class P_M>
-double
-likelihoodRoutine(
-  const P_V&  paramValues,
-  const P_V*  paramDirection,
-  const void* functionDataPtr,
-  P_V*        gradVector,
-  P_M*        hessianMatrix,
-  P_V*        hessianEffect)
-{
-  double resultValue = 0.;
-
-  const QUESO::BaseEnvironment& env = *(((likelihoodRoutine_Data<P_V,P_M> *) functionDataPtr)->m_env);
-
-  env.subComm().Barrier();
-  //env.syncPrintDebugMsg("Entering likelihoodRoutine()",1,env.fullComm());
-
-  // Compute likelihood for scenario 1
-  double betaTest = ((likelihoodRoutine_Data<P_V,P_M> *) functionDataPtr)->m_beta1;
-  if (betaTest) {
-    double A                       = paramValues[0];
-    double E                       = paramValues[1];
-    double beta                    = ((likelihoodRoutine_Data<P_V,P_M> *) functionDataPtr)->m_beta1;
-    double variance                = ((likelihoodRoutine_Data<P_V,P_M> *) functionDataPtr)->m_variance1;
-    const std::vector<double>& Te  = ((likelihoodRoutine_Data<P_V,P_M> *) functionDataPtr)->m_Te1;
-    const std::vector<double>& Me  = ((likelihoodRoutine_Data<P_V,P_M> *) functionDataPtr)->m_Me1;
-    std::vector<double> Mt(Me.size(),0.);
-
-    double params[]={A,E,beta};
-      	
-    // integration
-    const gsl_odeiv_step_type *T   = gsl_odeiv_step_rkf45; //rkf45; //gear1;
-          gsl_odeiv_step      *s   = gsl_odeiv_step_alloc(T,1);
-          gsl_odeiv_control   *c   = gsl_odeiv_control_y_new(1e-6,0.0);
-          gsl_odeiv_evolve    *e   = gsl_odeiv_evolve_alloc(1);
-          gsl_odeiv_system     sys = {func, NULL, 1, (void *)params}; 
-
-    double t = 0.1, t_final = 1900.;
-    double h = 1e-3;
-    double Mass[1];
-    Mass[0]=1.;
-  
-    unsigned int i = 0;
-    double t_old = 0.;
-    double M_old[1];
-    M_old[0]=1.;
-	
-    double misfit=0.;
-    //unsigned int loopSize = 0;
-    while ((t < t_final) && (i < Me.size())) {
-      int status = gsl_odeiv_evolve_apply(e, c, s, &sys, &t, t_final, &h, Mass);
-      UQ_FATAL_TEST_MACRO((status != GSL_SUCCESS),
-                          paramValues.env().fullRank(),
-                          "likelihoodRoutine()",
-                          "gsl_odeiv_evolve_apply() failed");
-      //printf("t = %6.1lf, mass = %10.4lf\n",t,Mass[0]);
-      //loopSize++;
-		
-      while ( (i < Me.size()) && (t_old <= Te[i]) && (Te[i] <= t) ) {
-        Mt[i] = (Te[i]-t_old)*(Mass[0]-M_old[0])/(t-t_old) + M_old[0];
-        misfit += (Me[i]-Mt[i])*(Me[i]-Mt[i]);
-        //printf("%i %lf %lf %lf %lf\n",i,Te[i],Me[i],Mt[i],misfit);
-        i++;
-      }
-		
-      t_old=t;
-      M_old[0]=Mass[0];
-    }
-    resultValue += misfit/variance;
-	
-    //printf("loopSize = %d\n",loopSize);
-    if ((paramValues.env().displayVerbosity() >= 10) && (paramValues.env().fullRank() == 0)) {
-      printf("In likelihoodRoutine(), A = %g, E = %g, beta = %.3lf: misfit = %lf, likelihood = %lf.\n",A,E,beta,misfit,resultValue);
-    }
-
-    gsl_odeiv_evolve_free (e);
-    gsl_odeiv_control_free(c);
-    gsl_odeiv_step_free   (s);
-  }
-
-  // Compute likelihood for scenario 2
-  betaTest = ((likelihoodRoutine_Data<P_V,P_M> *) functionDataPtr)->m_beta2;
-  if (betaTest > 0.) {
-    double A                       = paramValues[0];
-    double E                       = paramValues[1];
-    double beta                    = ((likelihoodRoutine_Data<P_V,P_M> *) functionDataPtr)->m_beta2;
-    double variance                = ((likelihoodRoutine_Data<P_V,P_M> *) functionDataPtr)->m_variance2;
-    const std::vector<double>& Te  = ((likelihoodRoutine_Data<P_V,P_M> *) functionDataPtr)->m_Te2;
-    const std::vector<double>& Me  = ((likelihoodRoutine_Data<P_V,P_M> *) functionDataPtr)->m_Me2;
-    std::vector<double> Mt(Me.size(),0.);
-
-    double params[]={A,E,beta};
-      	
-    // integration
-    const gsl_odeiv_step_type *T   = gsl_odeiv_step_rkf45; //rkf45; //gear1;
-          gsl_odeiv_step      *s   = gsl_odeiv_step_alloc(T,1);
-          gsl_odeiv_control   *c   = gsl_odeiv_control_y_new(1e-6,0.0);
-          gsl_odeiv_evolve    *e   = gsl_odeiv_evolve_alloc(1);
-          gsl_odeiv_system     sys = {func, NULL, 1, (void *)params}; 
-
-    double t = 0.1, t_final = 1900.;
-    double h = 1e-3;
-    double Mass[1];
-    Mass[0]=1.;
-  
-    unsigned int i = 0;
-    double t_old = 0.;
-    double M_old[1];
-    M_old[0]=1.;
-	
-    double misfit=0.;
-    //unsigned int loopSize = 0;
-    while ((t < t_final) && (i < Me.size())) {
-      int status = gsl_odeiv_evolve_apply(e, c, s, &sys, &t, t_final, &h, Mass);
-      UQ_FATAL_TEST_MACRO((status != GSL_SUCCESS),
-                          paramValues.env().fullRank(),
-                          "likelihoodRoutine()",
-                          "gsl_odeiv_evolve_apply() failed");
-      //printf("t = %6.1lf, mass = %10.4lf\n",t,Mass[0]);
-      //loopSize++;
-		
-      while ( (i < Me.size()) && (t_old <= Te[i]) && (Te[i] <= t) ) {
-        Mt[i] = (Te[i]-t_old)*(Mass[0]-M_old[0])/(t-t_old) + M_old[0];
-        misfit += (Me[i]-Mt[i])*(Me[i]-Mt[i]);
-        //printf("%i %lf %lf %lf %lf\n",i,Te[i],Me[i],Mt[i],misfit);
-        i++;
-      }
-		
-      t_old=t;
-      M_old[0]=Mass[0];
-    }
-    resultValue += misfit/variance;
-	
-    //printf("loopSize = %d\n",loopSize);
-    if ((paramValues.env().displayVerbosity() >= 10) && (paramValues.env().fullRank() == 0)) {
-      printf("In likelihoodRoutine(), A = %g, E = %g, beta = %.3lf: misfit = %lf, likelihood = %lf.\n",A,E,beta,misfit,resultValue);
-    }
-
-    gsl_odeiv_evolve_free (e);
-    gsl_odeiv_control_free(c);
-    gsl_odeiv_step_free   (s);
-  }
-
-  // Compute likelihood for scenario 3
-  betaTest = ((likelihoodRoutine_Data<P_V,P_M> *) functionDataPtr)->m_beta3;
-  if (betaTest > 0.) {
-    double A                       = paramValues[0];
-    double E                       = paramValues[1];
-    double beta                    = ((likelihoodRoutine_Data<P_V,P_M> *) functionDataPtr)->m_beta3;
-    double variance                = ((likelihoodRoutine_Data<P_V,P_M> *) functionDataPtr)->m_variance3;
-    const std::vector<double>& Te  = ((likelihoodRoutine_Data<P_V,P_M> *) functionDataPtr)->m_Te3;
-    const std::vector<double>& Me  = ((likelihoodRoutine_Data<P_V,P_M> *) functionDataPtr)->m_Me3;
-    std::vector<double> Mt(Me.size(),0.);
-
-    double params[]={A,E,beta};
-      	
-    // integration
-    const gsl_odeiv_step_type *T   = gsl_odeiv_step_rkf45; //rkf45; //gear1;
-          gsl_odeiv_step      *s   = gsl_odeiv_step_alloc(T,1);
-          gsl_odeiv_control   *c   = gsl_odeiv_control_y_new(1e-6,0.0);
-          gsl_odeiv_evolve    *e   = gsl_odeiv_evolve_alloc(1);
-          gsl_odeiv_system     sys = {func, NULL, 1, (void *)params}; 
-
-    double t = 0.1, t_final = 1900.;
-    double h = 1e-3;
-    double Mass[1];
-    Mass[0]=1.;
-  
-    unsigned int i = 0;
-    double t_old = 0.;
-    double M_old[1];
-    M_old[0]=1.;
-	
-    double misfit=0.;
-    //unsigned int loopSize = 0;
-    while ((t < t_final) && (i < Me.size())) {
-      int status = gsl_odeiv_evolve_apply(e, c, s, &sys, &t, t_final, &h, Mass);
-      UQ_FATAL_TEST_MACRO((status != GSL_SUCCESS),
-                          paramValues.env().fullRank(),
-                          "likelihoodRoutine()",
-                          "gsl_odeiv_evolve_apply() failed");
-      //printf("t = %6.1lf, mass = %10.4lf\n",t,Mass[0]);
-      //loopSize++;
-		
-      while ( (i < Me.size()) && (t_old <= Te[i]) && (Te[i] <= t) ) {
-        Mt[i] = (Te[i]-t_old)*(Mass[0]-M_old[0])/(t-t_old) + M_old[0];
-        misfit += (Me[i]-Mt[i])*(Me[i]-Mt[i]);
-        //printf("%i %lf %lf %lf %lf\n",i,Te[i],Me[i],Mt[i],misfit);
-        i++;
-      }
-		
-      t_old=t;
-      M_old[0]=Mass[0];
-    }
-    resultValue += misfit/variance;
-	
-    //printf("loopSize = %d\n",loopSize);
-    if ((paramValues.env().displayVerbosity() >= 10) && (paramValues.env().fullRank() == 0)) {
-      printf("In likelihoodRoutine(), A = %g, E = %g, beta = %.3lf: misfit = %lf, likelihood = %lf.\n",A,E,beta,misfit,resultValue);
-    }
-
-    gsl_odeiv_evolve_free (e);
-    gsl_odeiv_control_free(c);
-    gsl_odeiv_step_free   (s);
-  }
-
-  env.subComm().Barrier();
-  //env.syncPrintDebugMsg("Leaving likelihoodRoutine()",1,env.fullComm());
-
-  return -.5*resultValue;
-}
 
 #endif // EX_TGA_VALIDATION_CYCLE_LIKELIHOOD_H

--- a/examples/validationCycle2/src/tga2_appl.C
+++ b/examples/validationCycle2/src/tga2_appl.C
@@ -92,22 +92,18 @@ uqAppl(const QUESO::BaseEnvironment& env)
   QUESO::UniformVectorRV<QUESO::GslVector,QUESO::GslMatrix> calPriorRv("cal_prior_", // Extra prefix before the default "rv_" prefix
                                                                        paramDomain);
 
-  // Inverse problem: instantiate the likelihood function object (data + routine)
-  likelihoodRoutine_Data calLikelihoodRoutine_Data(env,
-                                                        "inputData/scenario_5_K_min.dat",
-                                                        "inputData/scenario_25_K_min.dat",
-                                                        "inputData/scenario_50_K_min.dat");
+  // Inverse problem: instantiate the likelihood
+  Likelihood<> calLikelihood("cal_like_",
+                           paramDomain,
+                           "inputData/scenario_5_K_min.dat",
+                           "inputData/scenario_25_K_min.dat",
+                           "inputData/scenario_50_K_min.dat");
 
-  QUESO::GenericScalarFunction<QUESO::GslVector,QUESO::GslMatrix> calLikelihoodFunctionObj("cal_like_",
-                                                                                           paramDomain,
-                                                                                           likelihoodRoutine,
-                                                                                           (void *) &calLikelihoodRoutine_Data,
-                                                                                           true); // the routine computes [ln(function)]
 
   // Inverse problem: instantiate it (posterior rv is instantiated internally)
   cycle.instantiateCalIP(NULL,
                          calPriorRv,
-                         calLikelihoodFunctionObj);
+                         calLikelihood);
 
   // Inverse problem: solve it, that is, set 'pdf' and 'realizer' of the posterior rv
   QUESO::GslVector paramInitialValues(paramSpace.zeroVector());
@@ -162,20 +158,15 @@ uqAppl(const QUESO::BaseEnvironment& env)
 
   // Inverse problem: no need to instantiate the prior rv (= posterior rv of calibration inverse problem)
 
-  // Inverse problem: instantiate the likelihood function object (data + routine)
-  likelihoodRoutine_Data valLikelihoodRoutine_Data(env,
-                                                        "inputData/scenario_100_K_min.dat",
-                                                        NULL,
-                                                        NULL);
-
-  QUESO::GenericScalarFunction<QUESO::GslVector,QUESO::GslMatrix> valLikelihoodFunctionObj("val_like_",
-                                                                                           paramDomain,
-                                                                                           likelihoodRoutine,
-                                                                                           (void *) &valLikelihoodRoutine_Data,
-                                                                                           true); // the routine computes [ln(function)]
+  // Inverse problem: instantiate the likelihood function object
+  Likelihood<> valLikelihood("val_like_",
+                             paramDomain,
+                             "inputData/scenario_100_K_min.dat",
+                             NULL,
+                             NULL);
 
   // Inverse problem: instantiate it (posterior rv is instantiated internally)
-  cycle.instantiateValIP(NULL,valLikelihoodFunctionObj);
+  cycle.instantiateValIP(NULL,valLikelihood);
 
   // Inverse problem: solve it, that is, set 'pdf' and 'realizer' of the posterior rv
   const QUESO::SequentialVectorRealizer<QUESO::GslVector,QUESO::GslMatrix>* tmpRealizer = dynamic_cast< const QUESO::SequentialVectorRealizer<QUESO::GslVector,QUESO::GslMatrix>* >(&(cycle.calIP().postRv().realizer()));

--- a/examples/validationCycle2/src/tga2_likelihood.h
+++ b/examples/validationCycle2/src/tga2_likelihood.h
@@ -28,19 +28,21 @@
 #define __TGA2_LIKELIHOOD_H__
 
 #include <queso/GslMatrix.h>
+#include <queso/ScalarFunction.h>
 
-//********************************************************
-// The (user defined) data class that carries the data
-// needed by the (user defined) likelihood routine
-//********************************************************
-struct
-likelihoodRoutine_Data
+#include <cmath>
+
+template <class V = QUESO::GslVector, class M = QUESO::GslMatrix>
+class Likelihood : public QUESO::BaseScalarFunction<V, M>
 {
-  likelihoodRoutine_Data(const QUESO::BaseEnvironment& env,
-                              const char* inpName1,
-                              const char* inpName2,
-                              const char* inpName3);
- ~likelihoodRoutine_Data();
+public:
+  Likelihood(const char * prefix,
+             const QUESO::VectorSet<V, M> & domainSet,
+             const char* inpName1,
+             const char* inpName2,
+             const char* inpName3);
+
+  virtual ~Likelihood();
 
   double              m_beta1;
   double              m_variance1;
@@ -56,17 +58,15 @@ likelihoodRoutine_Data
   double              m_variance3;
   std::vector<double> m_Te3; // temperatures
   std::vector<double> m_Me3; // relative masses
+  const QUESO::BaseEnvironment & m_env;
 
-  const QUESO::BaseEnvironment* m_env;
+  virtual double lnValue(const QUESO::GslVector & paramValues) const;
+
+  virtual double actualValue(const V & domainVector, const V * domainDirection,
+          V * gradVector, M * hessianMatrix, V * hessianEffect) const
+  {
+    return std::exp(this->lnValue(domainVector));
+  }
 };
-
-double
-likelihoodRoutine(
-  const QUESO::GslVector&  paramValues,
-  const QUESO::GslVector*  paramDirection,
-  const void*              functionDataPtr,
-  QUESO::GslVector*        gradVector,
-  QUESO::GslMatrix*        hessianMatrix,
-  QUESO::GslVector*        hessianEffect);
 
 #endif // __TGA2_LIKELIHOOD_H__


### PR DESCRIPTION
Just updates example to discourage its usage, and to instead encourage subclassing `BaseScalarFunction` and implement `lnValue`.