### PR TITLE
Increase coverage

### DIFF
--- a/src/core/src/BasicPdfsBoost.C
+++ b/src/core/src/BasicPdfsBoost.C
@@ -23,6 +23,8 @@
 //-----------------------------------------------------------------------el-
 
 #include <queso/BasicPdfsBoost.h>
+#include <boost/math/distributions/gamma.hpp>
+#include <boost/math/distributions/beta.hpp>
 
 namespace QUESO {
 
@@ -43,14 +45,16 @@ BasicPdfsBoost::~BasicPdfsBoost()
 double
 BasicPdfsBoost::betaPdfActualValue(double x, double alpha, double beta) const
 {
-  queso_not_implemented();
+  boost::math::beta_distribution<> beta_dist(alpha, beta);
+  return boost::math::pdf(beta_dist, x);
 }
 
 // --------------------------------------------------
 double
 BasicPdfsBoost::gammaPdfActualValue(double x, double a, double b) const
 {
-  queso_not_implemented();
+  boost::math::gamma_distribution<> gamma_dist(a, b);
+  return boost::math::pdf(gamma_dist, x);
 }
 
 }  // End namespace QUESO

--- a/src/core/src/BasicPdfsCXX11.C
+++ b/src/core/src/BasicPdfsCXX11.C
@@ -72,7 +72,7 @@ BasicPdfsCXX11::betaPdfActualValue(double x, double alpha, double beta) const
       ln_gamma_b = std::lgamma(beta);
 
       return std::exp(ln_gamma_apb - ln_gamma_a - ln_gamma_b +
-          (alpha - 1) + std::log(x) + (beta - 1) * std::log1p(-x));
+          (alpha - 1) * std::log(x) + (beta - 1) * std::log1p(-x));
     }
   }
 }

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -128,6 +128,7 @@ unit_driver_SOURCES += unit/sequence_of_vectors.C
 unit_driver_SOURCES += unit/tensor_product_quadrature.C
 unit_driver_SOURCES += unit/monte_carlo_quadrature.C
 unit_driver_SOURCES += unit/rng_gsl.C
+unit_driver_SOURCES += unit/rng_cxx11.C
 
 test_boxsubset_centroid_SOURCES = test_centroids/test_boxsubset_centroid.C
 test_concatenation_centroid_SOURCES = test_centroids/test_concatenation_centroid.C

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -127,6 +127,7 @@ unit_driver_SOURCES += unit/base_vector_sequence.C
 unit_driver_SOURCES += unit/sequence_of_vectors.C
 unit_driver_SOURCES += unit/tensor_product_quadrature.C
 unit_driver_SOURCES += unit/monte_carlo_quadrature.C
+unit_driver_SOURCES += unit/rng_gsl.C
 
 test_boxsubset_centroid_SOURCES = test_centroids/test_boxsubset_centroid.C
 test_concatenation_centroid_SOURCES = test_centroids/test_concatenation_centroid.C

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -130,6 +130,7 @@ unit_driver_SOURCES += unit/monte_carlo_quadrature.C
 unit_driver_SOURCES += unit/rng_gsl.C
 unit_driver_SOURCES += unit/rng_cxx11.C
 unit_driver_SOURCES += unit/rng_boost.C
+unit_driver_SOURCES += unit/basic_pdfs_cxx11.C
 
 test_boxsubset_centroid_SOURCES = test_centroids/test_boxsubset_centroid.C
 test_concatenation_centroid_SOURCES = test_centroids/test_concatenation_centroid.C

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -129,6 +129,7 @@ unit_driver_SOURCES += unit/tensor_product_quadrature.C
 unit_driver_SOURCES += unit/monte_carlo_quadrature.C
 unit_driver_SOURCES += unit/rng_gsl.C
 unit_driver_SOURCES += unit/rng_cxx11.C
+unit_driver_SOURCES += unit/rng_boost.C
 
 test_boxsubset_centroid_SOURCES = test_centroids/test_boxsubset_centroid.C
 test_concatenation_centroid_SOURCES = test_centroids/test_concatenation_centroid.C

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -131,6 +131,7 @@ unit_driver_SOURCES += unit/rng_gsl.C
 unit_driver_SOURCES += unit/rng_cxx11.C
 unit_driver_SOURCES += unit/rng_boost.C
 unit_driver_SOURCES += unit/basic_pdfs_cxx11.C
+unit_driver_SOURCES += unit/basic_pdfs_boost.C
 
 test_boxsubset_centroid_SOURCES = test_centroids/test_boxsubset_centroid.C
 test_concatenation_centroid_SOURCES = test_centroids/test_concatenation_centroid.C

--- a/test/unit/basic_pdfs_boost.C
+++ b/test/unit/basic_pdfs_boost.C
@@ -1,0 +1,80 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2017 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "config_queso.h"
+
+#ifdef QUESO_HAVE_CPPUNIT
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+
+#include <queso/Environment.h>
+
+#include <queso/BasicPdfsBoost.h>
+#include <cmath>
+
+namespace QUESOTesting
+{
+
+class BasicPdfsBoostTest : public CppUnit::TestCase
+{
+public:
+  CPPUNIT_TEST_SUITE(BasicPdfsBoostTest);
+  CPPUNIT_TEST(test_beta);
+  CPPUNIT_TEST(test_gamma);
+  CPPUNIT_TEST_SUITE_END();
+
+  // yes, this is necessary
+public:
+  void setUp()
+  {
+    _env.reset(new QUESO::FullEnvironment("","",NULL));
+  }
+
+  void test_beta()
+  {
+    QUESO::BasicPdfsBoost pdf_boost(0);
+
+    double value = pdf_boost.betaPdfActualValue(0.5, 2.0, 2.0);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(1.5, value, 1e-14);
+  }
+
+  void test_gamma()
+  {
+    QUESO::BasicPdfsBoost pdf_boost(0);
+
+    double value = pdf_boost.gammaPdfActualValue(1.5, 4.0, 0.5);
+    double actualValue = 1.5 * 1.5 * 1.5 * std::exp(-3.0) / (3.0 * 0.5 * 0.5 * 0.5);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(actualValue, value, 1e-14);
+  }
+
+private:
+  typename QUESO::ScopedPtr<QUESO::BaseEnvironment>::Type _env;
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(BasicPdfsBoostTest);
+
+} // end namespace QUESOTesting
+
+#endif // QUESO_HAVE_CPPUNIT

--- a/test/unit/basic_pdfs_cxx11.C
+++ b/test/unit/basic_pdfs_cxx11.C
@@ -38,10 +38,10 @@
 namespace QUESOTesting
 {
 
-class BasicPdfsCXX11 : public CppUnit::TestCase
+class BasicPdfsCXX11Test : public CppUnit::TestCase
 {
 public:
-  CPPUNIT_TEST_SUITE(BasicPdfsCXX11);
+  CPPUNIT_TEST_SUITE(BasicPdfsCXX11Test);
   CPPUNIT_TEST(test_beta);
   CPPUNIT_TEST(test_gamma);
   CPPUNIT_TEST_SUITE_END();
@@ -59,6 +59,15 @@ public:
 
     double value = pdf_cxx11.betaPdfActualValue(0.5, 2.0, 2.0);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(1.5, value, 1e-14);
+
+    value = pdf_cxx11.betaPdfActualValue(-1.0, 2.0, 2.0);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, value, 1e-14);
+
+    value = pdf_cxx11.betaPdfActualValue(0.0, 2.0, 2.0);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, value, 1e-14);
+
+    value = pdf_cxx11.betaPdfActualValue(0.0, 0.5, 0.5);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(INFINITY, (float)value, 1e-14);
   }
 
   void test_gamma()
@@ -66,16 +75,26 @@ public:
     QUESO::BasicPdfsCXX11 pdf_cxx11(0);
 
     double value = pdf_cxx11.gammaPdfActualValue(1.5, 4.0, 0.5);
-
     double actualValue = 1.5 * 1.5 * 1.5 * std::exp(-3.0) / (3.0 * 0.5 * 0.5 * 0.5);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(actualValue, value, 1e-14);
+
+    value = pdf_cxx11.gammaPdfActualValue(-1.0, 4.0, 0.5);
+    actualValue = 0.0;
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(actualValue, value, 1e-14);
+
+    value = pdf_cxx11.gammaPdfActualValue(0.0, 4.0, 0.5);
+    actualValue = 0.0;
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(actualValue, value, 1e-14);
+
+    value = pdf_cxx11.gammaPdfActualValue(0.0, 0.5, 0.5);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(INFINITY, (float)value, 1e-14);
   }
 
 private:
   typename QUESO::ScopedPtr<QUESO::BaseEnvironment>::Type _env;
 };
 
-CPPUNIT_TEST_SUITE_REGISTRATION(BasicPdfsCXX11);
+CPPUNIT_TEST_SUITE_REGISTRATION(BasicPdfsCXX11Test);
 
 } // end namespace QUESOTesting
 

--- a/test/unit/basic_pdfs_cxx11.C
+++ b/test/unit/basic_pdfs_cxx11.C
@@ -1,0 +1,83 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2017 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "config_queso.h"
+
+#ifdef QUESO_HAVE_CPPUNIT
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+
+#include <queso/Environment.h>
+
+#ifdef QUESO_HAVE_CXX11
+#include <queso/BasicPdfsCXX11.h>
+#include <cmath>
+
+namespace QUESOTesting
+{
+
+class BasicPdfsCXX11 : public CppUnit::TestCase
+{
+public:
+  CPPUNIT_TEST_SUITE(BasicPdfsCXX11);
+  CPPUNIT_TEST(test_beta);
+  CPPUNIT_TEST(test_gamma);
+  CPPUNIT_TEST_SUITE_END();
+
+  // yes, this is necessary
+public:
+  void setUp()
+  {
+    _env.reset(new QUESO::FullEnvironment("","",NULL));
+  }
+
+  void test_beta()
+  {
+    QUESO::BasicPdfsCXX11 pdf_cxx11(0);
+
+    double value = pdf_cxx11.betaPdfActualValue(0.5, 2.0, 2.0);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(1.5, value, 1e-14);
+  }
+
+  void test_gamma()
+  {
+    QUESO::BasicPdfsCXX11 pdf_cxx11(0);
+
+    double value = pdf_cxx11.gammaPdfActualValue(1.5, 4.0, 0.5);
+
+    double actualValue = 1.5 * 1.5 * 1.5 * std::exp(-3.0) / (3.0 * 0.5 * 0.5 * 0.5);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(actualValue, value, 1e-14);
+  }
+
+private:
+  typename QUESO::ScopedPtr<QUESO::BaseEnvironment>::Type _env;
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(BasicPdfsCXX11);
+
+} // end namespace QUESOTesting
+
+#endif // QUESO_HAVE_CXX11
+#endif // QUESO_HAVE_CPPUNIT

--- a/test/unit/gsl_matrix.C
+++ b/test/unit/gsl_matrix.C
@@ -45,6 +45,7 @@ namespace QUESOTesting
     CPPUNIT_TEST( test_power_method );
     CPPUNIT_TEST( test_multiple_rhs_matrix_solve );
     CPPUNIT_TEST( test_cw_extract );
+    CPPUNIT_TEST( test_svd );
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -231,6 +232,67 @@ namespace QUESOTesting
       CPPUNIT_ASSERT_DOUBLES_EQUAL(6.0, mat2(0,1), 1.0e-14);
       CPPUNIT_ASSERT_DOUBLES_EQUAL(9.0, mat2(1,0), 1.0e-14);
       CPPUNIT_ASSERT_DOUBLES_EQUAL(10.0, mat2(1,1), 1.0e-14);
+    }
+
+    void test_svd()
+    {
+      QUESO::VectorSpace<> space(*_env, "", 2, NULL);
+      QUESO::GslMatrix M(space.zeroVector());
+      QUESO::GslMatrix U(space.zeroVector());
+      QUESO::GslMatrix Vs(space.zeroVector());
+      QUESO::GslVector S(space.zeroVector());
+
+      M(0,0) = 1.0;
+      M(0,1) = 2.0;
+      M(1,0) = -2.0;
+      M(1,1) = 1.0;
+
+      M.svd(U, S, Vs);
+
+      // Sanity check the decomposition
+      QUESO::GslMatrix M_computed(space.zeroVector());
+      QUESO::GslMatrix temp(space.zeroVector());
+      QUESO::GslMatrix S_matrix(S);
+
+      U.multiply(S_matrix, temp);
+      temp.multiply(Vs, M_computed);
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(M(0,0), M_computed(0,0), 1.0e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(M(0,1), M_computed(0,1), 1.0e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(M(1,0), M_computed(1,0), 1.0e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(M(1,1), M_computed(1,1), 1.0e-14);
+
+      // Check solves
+      QUESO::GslMatrix X(space.zeroVector());
+      QUESO::GslMatrix X_computed(space.zeroVector());
+      QUESO::GslMatrix B(space.zeroVector());
+
+      B(0,0) = 11.0;
+      B(0,1) = 17.0;
+      B(1,0) = -2.0;
+      B(1,1) = -4.0;
+
+      X(0,0) = 3.0;
+      X(0,1) = 5.0;
+      X(1,0) = 4.0;
+      X(1,1) = 6.0;
+
+      M.svdSolve(B, X_computed);
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(X(0,0), X_computed(0,0), 1.0e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(X(0,1), X_computed(0,1), 1.0e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(X(1,0), X_computed(1,0), 1.0e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(X(1,1), X_computed(1,1), 1.0e-14);
+
+      // Test getters
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(U(0,0), M.svdMatU()(0,0), 1.0e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(U(0,1), M.svdMatU()(0,1), 1.0e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(U(1,0), M.svdMatU()(1,0), 1.0e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(U(1,1), M.svdMatU()(1,1), 1.0e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(Vs(0,0), M.svdMatV()(0,0), 1.0e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(Vs(0,1), M.svdMatV()(0,1), 1.0e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(Vs(1,0), M.svdMatV()(1,0), 1.0e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(Vs(1,1), M.svdMatV()(1,1), 1.0e-14);
     }
 
   private:

--- a/test/unit/gsl_matrix.C
+++ b/test/unit/gsl_matrix.C
@@ -46,6 +46,11 @@ namespace QUESOTesting
     CPPUNIT_TEST( test_multiple_rhs_matrix_solve );
     CPPUNIT_TEST( test_cw_extract );
     CPPUNIT_TEST( test_svd );
+    CPPUNIT_TEST( test_fill_diag );
+    CPPUNIT_TEST( test_fill_horiz );
+    CPPUNIT_TEST( test_fill_vert );
+    CPPUNIT_TEST( test_fill_tensor_product );
+    CPPUNIT_TEST( test_fill_transpose );
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -293,6 +298,248 @@ namespace QUESOTesting
       CPPUNIT_ASSERT_DOUBLES_EQUAL(Vs(0,1), M.svdMatV()(0,1), 1.0e-14);
       CPPUNIT_ASSERT_DOUBLES_EQUAL(Vs(1,0), M.svdMatV()(1,0), 1.0e-14);
       CPPUNIT_ASSERT_DOUBLES_EQUAL(Vs(1,1), M.svdMatV()(1,1), 1.0e-14);
+    }
+
+    void test_fill_diag()
+    {
+      QUESO::VectorSpace<> space2(*_env, "", 2, NULL);
+      QUESO::GslMatrix m1(space2.zeroVector());
+      QUESO::GslMatrix m2(space2.zeroVector());
+
+      m1(0,0) = 1.0;
+      m1(0,1) = 2.0;
+      m1(1,0) = 3.0;
+      m1(1,1) = 4.0;
+      m2(0,0) = 5.0;
+      m2(0,1) = 6.0;
+      m2(1,0) = 7.0;
+      m2(1,1) = 8.0;
+
+      QUESO::VectorSpace<> space4(*_env, "", 4, NULL);
+      QUESO::GslMatrix m(space4.zeroVector());
+
+      std::vector<const QUESO::GslMatrix *> ms;
+      ms.push_back(&m1);
+      ms.push_back(&m2);
+
+      m.fillWithBlocksDiagonally(0, 0, ms, true, true);
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(0,0), m(0,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(0,1), m(0,1), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(1,0), m(1,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(1,1), m(1,1), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(0,0), m(2,2), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(0,1), m(2,3), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(1,0), m(3,2), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(1,1), m(3,3), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, m(0,2), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, m(0,3), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, m(1,2), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, m(1,3), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, m(2,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, m(2,1), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, m(3,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, m(3,1), 1e-14);
+
+      m.cwSet(0.0);
+      std::vector<QUESO::GslMatrix *> ms2;
+      ms2.push_back(&m1);
+      ms2.push_back(&m2);
+
+      m.fillWithBlocksDiagonally(0, 0, ms2, true, true);
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(0,0), m(0,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(0,1), m(0,1), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(1,0), m(1,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(1,1), m(1,1), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(0,0), m(2,2), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(0,1), m(2,3), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(1,0), m(3,2), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(1,1), m(3,3), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, m(0,2), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, m(0,3), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, m(1,2), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, m(1,3), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, m(2,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, m(2,1), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, m(3,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, m(3,1), 1e-14);
+    }
+
+    void test_fill_horiz()
+    {
+      QUESO::Map map(2, 0, _env->fullComm());
+      QUESO::GslMatrix m1(*_env, map, (unsigned int)2);  // 2 x 2 matrix
+      QUESO::GslMatrix m2(*_env, map, (unsigned int)2);  // 2 x 2 matrix
+      QUESO::GslMatrix m(*_env, map, (unsigned int)4);  // 2 x 4 matrix
+
+      m1(0,0) = 1.0;
+      m1(0,1) = 2.0;
+      m1(1,0) = 3.0;
+      m1(1,1) = 4.0;
+      m2(0,0) = 5.0;
+      m2(0,1) = 6.0;
+      m2(1,0) = 7.0;
+      m2(1,1) = 8.0;
+
+      std::vector<const QUESO::GslMatrix *> ms;
+      ms.push_back(&m1);
+      ms.push_back(&m2);
+
+      m.fillWithBlocksHorizontally(0, 0, ms, true, true);
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(0,0), m(0,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(0,1), m(0,1), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(1,0), m(1,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(1,1), m(1,1), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(0,0), m(0,2), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(0,1), m(0,3), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(1,0), m(1,2), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(1,1), m(1,3), 1e-14);
+
+      m.cwSet(0.0);
+      std::vector<QUESO::GslMatrix *> ms2;
+      ms2.push_back(&m1);
+      ms2.push_back(&m2);
+
+      m.fillWithBlocksHorizontally(0, 0, ms2, true, true);
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(0,0), m(0,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(0,1), m(0,1), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(1,0), m(1,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(1,1), m(1,1), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(0,0), m(0,2), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(0,1), m(0,3), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(1,0), m(1,2), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(1,1), m(1,3), 1e-14);
+    }
+
+    void test_fill_vert()
+    {
+      QUESO::Map map(4, 0, _env->fullComm());
+      QUESO::GslMatrix m(*_env, map, (unsigned int)2);  // 4 x 2 matrix
+
+      QUESO::VectorSpace<> space(*_env, "", 2, NULL);
+      QUESO::GslMatrix m1(space.zeroVector());  // 2 x 2 matrix
+      QUESO::GslMatrix m2(space.zeroVector());  // 2 x 2 matrix
+
+      m1(0,0) = 1.0;
+      m1(0,1) = 2.0;
+      m1(1,0) = 3.0;
+      m1(1,1) = 4.0;
+      m2(0,0) = 5.0;
+      m2(0,1) = 6.0;
+      m2(1,0) = 7.0;
+      m2(1,1) = 8.0;
+
+      std::vector<const QUESO::GslMatrix *> ms;
+      ms.push_back(&m1);
+      ms.push_back(&m2);
+
+      m.fillWithBlocksVertically(0, 0, ms, true, true);
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(0,0), m(0,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(0,1), m(0,1), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(1,0), m(1,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(1,1), m(1,1), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(0,0), m(2,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(0,1), m(2,1), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(1,0), m(3,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(1,1), m(3,1), 1e-14);
+
+      m.cwSet(0.0);
+      std::vector<QUESO::GslMatrix *> ms2;
+      ms2.push_back(&m1);
+      ms2.push_back(&m2);
+
+      m.fillWithBlocksVertically(0, 0, ms2, true, true);
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(0,0), m(0,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(0,1), m(0,1), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(1,0), m(1,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(1,1), m(1,1), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(0,0), m(2,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(0,1), m(2,1), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(1,0), m(3,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(1,1), m(3,1), 1e-14);
+    }
+
+    void test_fill_tensor_product()
+    {
+      QUESO::VectorSpace<> space4(*_env, "", 4, NULL);
+      QUESO::GslMatrix m(space4.zeroVector());
+
+      QUESO::VectorSpace<> space2(*_env, "", 2, NULL);
+      QUESO::GslMatrix m1(space2.zeroVector());
+      QUESO::GslMatrix m2(space2.zeroVector());
+
+      m1(0,0) = 1.0;
+      m1(0,1) = 2.0;
+      m1(1,0) = 3.0;
+      m1(1,1) = 4.0;
+      m2(0,0) = 1.0;
+      m2(0,1) = 1.0;
+      m2(1,0) = 1.0;
+      m2(1,1) = 1.0;
+
+      m.fillWithTensorProduct(0, 0, m1, m2, true, true);
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(0,0) * m2(0,0), m(0,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(0,0) * m2(0,1), m(0,1), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(0,0) * m2(1,0), m(1,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(0,0) * m2(1,1), m(1,1), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(0,1) * m2(0,0), m(0,2), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(0,1) * m2(0,1), m(0,3), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(0,1) * m2(1,0), m(1,2), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(0,1) * m2(1,1), m(1,3), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(1,0) * m2(0,0), m(2,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(1,0) * m2(0,1), m(2,1), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(1,0) * m2(1,0), m(3,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(1,0) * m2(1,1), m(3,1), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(1,1) * m2(0,0), m(2,2), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(1,1) * m2(0,1), m(2,3), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(1,1) * m2(1,0), m(3,2), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(1,1) * m2(1,1), m(3,3), 1e-14);
+
+      QUESO::Map map(4, 0, _env->fullComm());
+      QUESO::GslMatrix mv(*_env, map, (unsigned int)2);  // 4 x 2 matrix
+
+      QUESO::GslVector v(space2.zeroVector());
+      v[0] = 1.0;
+      v[1] = 1.0;
+
+      mv.fillWithTensorProduct(0, 0, m1, v, true, true);
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(0,0) * v[0], mv(0,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(0,0) * v[1], mv(1,0), 1e-14);
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(0,1) * v[0], mv(0,1), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(0,1) * v[1], mv(1,1), 1e-14);
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(1,0) * v[0], mv(2,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(1,0) * v[1], mv(3,0), 1e-14);
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(1,1) * v[0], mv(2,1), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1(1,1) * v[1], mv(3,1), 1e-14);
+    }
+
+    void test_fill_transpose()
+    {
+      QUESO::VectorSpace<> space2(*_env, "", 2, NULL);
+      QUESO::GslMatrix m1(space2.zeroVector());
+      QUESO::GslMatrix m2(space2.zeroVector());
+
+      m1(0,0) = 1.0;
+      m1(0,1) = 2.0;
+      m1(1,0) = 3.0;
+      m1(1,1) = 4.0;
+
+      m2.fillWithTranspose(0, 0, m1, true, true);
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1.transpose()(0,0), m2(0,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1.transpose()(0,1), m2(0,1), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1.transpose()(1,0), m2(1,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m1.transpose()(1,1), m2(1,1), 1e-14);
     }
 
   private:

--- a/test/unit/gsl_matrix.C
+++ b/test/unit/gsl_matrix.C
@@ -51,6 +51,7 @@ namespace QUESOTesting
     CPPUNIT_TEST( test_fill_vert );
     CPPUNIT_TEST( test_fill_tensor_product );
     CPPUNIT_TEST( test_fill_transpose );
+    CPPUNIT_TEST( test_write_read );
 
     CPPUNIT_TEST_SUITE_END();
 
@@ -540,6 +541,42 @@ namespace QUESOTesting
       CPPUNIT_ASSERT_DOUBLES_EQUAL(m1.transpose()(0,1), m2(0,1), 1e-14);
       CPPUNIT_ASSERT_DOUBLES_EQUAL(m1.transpose()(1,0), m2(1,0), 1e-14);
       CPPUNIT_ASSERT_DOUBLES_EQUAL(m1.transpose()(1,1), m2(1,1), 1e-14);
+    }
+
+    void test_write_read()
+    {
+      QUESO::VectorSpace<> space(*_env, "", 2, NULL);
+      QUESO::GslMatrix m(space.zeroVector());
+
+      m(0,0) = 1.0;
+      m(0,1) = 2.0;
+      m(1,0) = 3.0;
+      m(1,1) = 4.0;
+
+      std::set<unsigned int> allowedSubEnvIds;
+      allowedSubEnvIds.insert(0);
+
+      // Write to file
+      m.subWriteContents("my_prefix",
+                         "gsl_matrix_test_write_read",
+                         "m",
+                         allowedSubEnvIds);
+
+      // Now read and make sure we get the same thing
+      QUESO::GslMatrix m2(space.zeroVector());
+      m2.subReadContents("gsl_matrix_test_write_read_sub0", // Need "_sub0"
+                         "m",
+                         allowedSubEnvIds);
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(0,0), m(0,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(0,1), m(0,1), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(1,0), m(1,0), 1e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(m2(1,1), m(1,1), 1e-14);
+
+      // Clean up the file we created
+      int result = std::remove("gsl_matrix_test_write_read_sub0.m");
+
+      CPPUNIT_ASSERT_EQUAL(0, result);  // Make sure nothing went wrong
     }
 
   private:

--- a/test/unit/gsl_matrix.C
+++ b/test/unit/gsl_matrix.C
@@ -44,12 +44,12 @@ namespace QUESOTesting
     CPPUNIT_TEST( test_inverse_power_method );
     CPPUNIT_TEST( test_power_method );
     CPPUNIT_TEST( test_multiple_rhs_matrix_solve );
+    CPPUNIT_TEST( test_cw_extract );
 
     CPPUNIT_TEST_SUITE_END();
 
     // yes, this is necessary
   public:
-
     void setUp()
     {
       _env.reset( new QUESO::FullEnvironment("","",&_options) );
@@ -211,11 +211,31 @@ namespace QUESOTesting
       CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0,result(1,0),1.0e-14);
     }
 
-  private:
+    void test_cw_extract()
+    {
+      QUESO::VectorSpace<> space4(*_env, "", 4, NULL);
+      QUESO::GslMatrix mat4(space4.zeroVector());
 
+      for (unsigned int i = 0; i < 4; i++) {
+        for (unsigned int j = 0; j < 4; j++) {
+          mat4(i,j) = 4*i+j;
+        }
+      }
+
+      QUESO::VectorSpace<> space2(*_env, "", 2, NULL);
+      QUESO::GslMatrix mat2(space2.zeroVector());
+
+      mat4.cwExtract(1, 1, mat2);
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(5.0, mat2(0,0), 1.0e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(6.0, mat2(0,1), 1.0e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(9.0, mat2(1,0), 1.0e-14);
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(10.0, mat2(1,1), 1.0e-14);
+    }
+
+  private:
     QUESO::EnvOptionsValues _options;
     typename QUESO::ScopedPtr<QUESO::BaseEnvironment>::Type _env;
-
   };
 
   CPPUNIT_TEST_SUITE_REGISTRATION( GslMatrixTest );

--- a/test/unit/gsl_vector.C
+++ b/test/unit/gsl_vector.C
@@ -39,9 +39,10 @@ namespace QUESOTesting
   {
   public:
     CPPUNIT_TEST_SUITE( GslVectorTest );
-
     CPPUNIT_TEST( test_min_max );
-
+    CPPUNIT_TEST( test_beta );
+    CPPUNIT_TEST( test_gamma );
+    CPPUNIT_TEST( test_inverse_gamma );
     CPPUNIT_TEST_SUITE_END();
 
     // yes, this is necessary
@@ -75,6 +76,66 @@ namespace QUESOTesting
 
       CPPUNIT_ASSERT_EQUAL(1,index);
       CPPUNIT_ASSERT_EQUAL(vec[1],value);
+    }
+
+    void test_beta()
+    {
+      unsigned int num_samples = 1000000;
+
+      // Instantiate the parameter space
+      QUESO::VectorSpace<> paramSpace(*_env, "", num_samples, NULL);
+
+      // Instantiate the parameter domain
+      QUESO::GslVector vec(paramSpace.zeroVector());
+      QUESO::GslVector a(paramSpace.zeroVector());
+      QUESO::GslVector b(paramSpace.zeroVector());
+      a.cwSet(2.0);
+      b.cwSet(2.0);
+      vec.cwSetBeta(a, b);
+
+      double mean = vec.sumOfComponents() / num_samples;
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.5, mean, 1e-2);
+    }
+
+    void test_gamma()
+    {
+      unsigned int num_samples = 1000000;
+
+      // Instantiate the parameter space
+      QUESO::VectorSpace<> paramSpace(*_env, "", num_samples, NULL);
+
+      // Instantiate the parameter domain
+      QUESO::GslVector vec(paramSpace.zeroVector());
+      QUESO::GslVector a(paramSpace.zeroVector());
+      QUESO::GslVector b(paramSpace.zeroVector());
+      a.cwSet(10.0);
+      b.cwSet(0.5);
+      vec.cwSetGamma(a, b);
+
+      double mean = vec.sumOfComponents() / num_samples;
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(5.0, mean, 1e-2);
+    }
+
+    void test_inverse_gamma()
+    {
+      unsigned int num_samples = 1000000;
+
+      // Instantiate the parameter space
+      QUESO::VectorSpace<> paramSpace(*_env, "", num_samples, NULL);
+
+      // Instantiate the parameter domain
+      QUESO::GslVector vec(paramSpace.zeroVector());
+      QUESO::GslVector a(paramSpace.zeroVector());
+      QUESO::GslVector b(paramSpace.zeroVector());
+      a.cwSet(11.0);
+      b.cwSet(1.0);
+      vec.cwSetInverseGamma(a, b);
+
+      double mean = vec.sumOfComponents() / num_samples;
+
+      CPPUNIT_ASSERT_DOUBLES_EQUAL(0.1, mean, 1e-3);
     }
 
   private:

--- a/test/unit/rng_boost.C
+++ b/test/unit/rng_boost.C
@@ -1,0 +1,120 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2017 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "config_queso.h"
+
+#ifdef QUESO_HAVE_CPPUNIT
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+
+#include <queso/Environment.h>
+#include <queso/RngBoost.h>
+
+namespace QUESOTesting
+{
+
+class RngBoost : public CppUnit::TestCase
+{
+public:
+  CPPUNIT_TEST_SUITE(RngBoost);
+  CPPUNIT_TEST(test_beta);
+  CPPUNIT_TEST(test_gamma);
+  CPPUNIT_TEST(test_uniform);
+  CPPUNIT_TEST(test_gaussian);
+  CPPUNIT_TEST_SUITE_END();
+
+  // yes, this is necessary
+public:
+  void setUp()
+  {
+    _env.reset(new QUESO::FullEnvironment("","",NULL));
+  }
+
+  void test_beta()
+  {
+    QUESO::RngBoost rng_boost(0, 0);
+    rng_boost.resetSeed(0);
+
+    double mean = 0.0;
+    unsigned int num_samples = 1000000;
+
+    for (unsigned int i = 0; i < num_samples; i++) {
+      mean += rng_boost.betaSample(2.0, 2.0) / num_samples;
+    }
+
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.5, mean, 1e-2);
+  }
+
+  void test_gamma()
+  {
+    QUESO::RngBoost rng_boost(0, 0);
+
+    double mean = 0.0;
+    unsigned int num_samples = 1000000;
+
+    for (unsigned int i = 0; i < num_samples; i++) {
+      mean += rng_boost.gammaSample(10.0, 0.5) / num_samples;
+    }
+
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(5.0, mean, 1e-2);
+  }
+
+  void test_uniform()
+  {
+    QUESO::RngBoost rng_boost(0, 0);
+
+    double mean = 0.0;
+    unsigned int num_samples = 1000000;
+
+    for (unsigned int i = 0; i < num_samples; i++) {
+      mean += rng_boost.uniformSample() / num_samples;
+    }
+
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.5, mean, 1e-2);
+  }
+
+  void test_gaussian()
+  {
+    QUESO::RngBoost rng_boost(0, 0);
+
+    double mean = 0.0;
+    unsigned int num_samples = 1000000;
+
+    for (unsigned int i = 0; i < num_samples; i++) {
+      mean += rng_boost.gaussianSample(0.1) / num_samples;
+    }
+
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, mean, 1e-2);
+  }
+
+private:
+  typename QUESO::ScopedPtr<QUESO::BaseEnvironment>::Type _env;
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(RngBoost);
+
+} // end namespace QUESOTesting
+
+#endif // QUESO_HAVE_CPPUNIT

--- a/test/unit/rng_cxx11.C
+++ b/test/unit/rng_cxx11.C
@@ -1,0 +1,123 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2017 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "config_queso.h"
+
+#ifdef QUESO_HAVE_CPPUNIT
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+
+#include <queso/Environment.h>
+
+#ifdef QUESO_HAVE_CXX11
+#include <queso/RngCXX11.h>
+
+namespace QUESOTesting
+{
+
+class RngCXX11Test : public CppUnit::TestCase
+{
+public:
+  CPPUNIT_TEST_SUITE(RngCXX11Test);
+  CPPUNIT_TEST(test_beta);
+  CPPUNIT_TEST(test_gamma);
+  CPPUNIT_TEST(test_uniform);
+  CPPUNIT_TEST(test_gaussian);
+  CPPUNIT_TEST_SUITE_END();
+
+  // yes, this is necessary
+public:
+  void setUp()
+  {
+    _env.reset(new QUESO::FullEnvironment("","",NULL));
+  }
+
+  void test_beta()
+  {
+    QUESO::RngCXX11 rng_cxx11(0, 0);
+    rng_cxx11.resetSeed(0);
+
+    double mean = 0.0;
+    unsigned int num_samples = 1000000;
+
+    for (unsigned int i = 0; i < num_samples; i++) {
+      mean += rng_cxx11.betaSample(2.0, 2.0) / num_samples;
+    }
+
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.5, mean, 1e-2);
+  }
+
+  void test_gamma()
+  {
+    QUESO::RngCXX11 rng_cxx11(0, 0);
+
+    double mean = 0.0;
+    unsigned int num_samples = 1000000;
+
+    for (unsigned int i = 0; i < num_samples; i++) {
+      mean += rng_cxx11.gammaSample(10.0, 0.5) / num_samples;
+    }
+
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(5.0, mean, 1e-2);
+  }
+
+  void test_uniform()
+  {
+    QUESO::RngCXX11 rng_cxx11(0, 0);
+
+    double mean = 0.0;
+    unsigned int num_samples = 1000000;
+
+    for (unsigned int i = 0; i < num_samples; i++) {
+      mean += rng_cxx11.uniformSample() / num_samples;
+    }
+
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.5, mean, 1e-2);
+  }
+
+  void test_gaussian()
+  {
+    QUESO::RngCXX11 rng_cxx11(0, 0);
+
+    double mean = 0.0;
+    unsigned int num_samples = 1000000;
+
+    for (unsigned int i = 0; i < num_samples; i++) {
+      mean += rng_cxx11.gaussianSample(0.1) / num_samples;
+    }
+
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, mean, 1e-2);
+  }
+
+private:
+  typename QUESO::ScopedPtr<QUESO::BaseEnvironment>::Type _env;
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(RngCXX11Test);
+
+} // end namespace QUESOTesting
+
+#endif // QUESO_HAVE_CXX11
+#endif // QUESO_HAVE_CPPUNIT

--- a/test/unit/rng_gsl.C
+++ b/test/unit/rng_gsl.C
@@ -1,0 +1,89 @@
+//-----------------------------------------------------------------------bl-
+//--------------------------------------------------------------------------
+//
+// QUESO - a library to support the Quantification of Uncertainty
+// for Estimation, Simulation and Optimization
+//
+// Copyright (C) 2008-2017 The PECOS Development Team
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Version 2.1 GNU Lesser General
+// Public License as published by the Free Software Foundation.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc. 51 Franklin Street, Fifth Floor,
+// Boston, MA  02110-1301  USA
+//
+//-----------------------------------------------------------------------el-
+
+#include "config_queso.h"
+
+#ifdef QUESO_HAVE_CPPUNIT
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <cppunit/TestCase.h>
+
+#include <queso/Environment.h>
+#include <queso/RngGsl.h>
+
+namespace QUESOTesting
+{
+
+class RngGslTest : public CppUnit::TestCase
+{
+public:
+  CPPUNIT_TEST_SUITE(RngGslTest);
+  CPPUNIT_TEST(test_beta);
+  CPPUNIT_TEST(test_gamma);
+  CPPUNIT_TEST_SUITE_END();
+
+  // yes, this is necessary
+public:
+  void setUp()
+  {
+    _env.reset(new QUESO::FullEnvironment("","",NULL));
+  }
+
+  void test_beta()
+  {
+    QUESO::RngGsl rng_gsl(0, 0);
+
+    double mean = 0.0;
+    unsigned int num_samples = 1000000;
+
+    for (unsigned int i = 0; i < num_samples; i++) {
+      mean += rng_gsl.betaSample(2.0, 2.0) / num_samples;
+    }
+
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.5, mean, 1e-2);
+  }
+
+  void test_gamma()
+  {
+    QUESO::RngGsl rng_gsl(0, 0);
+
+    double mean = 0.0;
+    unsigned int num_samples = 1000000;
+
+    for (unsigned int i = 0; i < num_samples; i++) {
+      mean += rng_gsl.gammaSample(10.0, 0.5) / num_samples;
+    }
+
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(5.0, mean, 1e-2);
+  }
+
+private:
+  typename QUESO::ScopedPtr<QUESO::BaseEnvironment>::Type _env;
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(RngGslTest);
+
+} // end namespace QUESOTesting
+
+#endif // QUESO_HAVE_CPPUNIT


### PR DESCRIPTION
These tests cover a lot of code in `src/core`, with the exception of some of the libmesh-dependent functionality.