### PR TITLE
Refactor logit transform logic into TK

### DIFF
--- a/src/stats/inc/HessianCovMatricesTKGroup.h
+++ b/src/stats/inc/HessianCovMatricesTKGroup.h
@@ -82,6 +82,8 @@ public:
 
   virtual bool covMatrixIsDirty() { return false; }
   virtual void cleanCovMatrix() { }
+
+  virtual void updateLawCovMatrix(const M & covMatrix);
   //@}
 
   //! @name I/O methods

--- a/src/stats/inc/MetropolisAdjustedLangevinTK.h
+++ b/src/stats/inc/MetropolisAdjustedLangevinTK.h
@@ -75,7 +75,7 @@ public:
 
   //! Scales the covariance matrix.
   /*! The covariance matrix is scaled by a factor of \f$ 1/scales^2 \f$.*/
-  void updateLawCovMatrix(const M & covMatrix);
+  virtual void updateLawCovMatrix(const M & covMatrix);
   //@}
 
   //! @name Misc methods

--- a/src/stats/inc/MetropolisHastingsSG.h
+++ b/src/stats/inc/MetropolisHastingsSG.h
@@ -341,9 +341,6 @@ private:
 	double m_initialLogPriorValue;
 	double m_initialLogLikelihoodValue;
 
-  void transformInitialCovMatrixToGaussianSpace(const BoxSubset<P_V, P_M> &
-      boxSubset);
-
   bool m_userDidNotProvideOptions;
 
   unsigned int m_latestDirtyCovMatrixIteration;

--- a/src/stats/inc/ScaledCovMatrixTKGroup.h
+++ b/src/stats/inc/ScaledCovMatrixTKGroup.h
@@ -70,7 +70,7 @@ public:
 
   //! Scales the covariance matrix.
   /*! The covariance matrix is scaled by a factor of \f$ 1/scales^2 \f$.*/
-  void                          updateLawCovMatrix        (const M& covMatrix);
+  virtual void updateLawCovMatrix(const M & covMatrix);
   //@}
 
   //! @name Misc methods

--- a/src/stats/inc/TKGroup.h
+++ b/src/stats/inc/TKGroup.h
@@ -115,6 +115,14 @@ public:
    * After this method is called, covMatrixIsDirty should return \c true.
    */
   virtual void cleanCovMatrix() = 0;
+
+  //! Sets and proposal covariance matrix (and for all DR stage RVs as well)
+  /*!
+   * If the TK has a proposal covariance matrix, set the covariance matrix.
+   * If the TK support delayed rejection, derived classes should scale by a
+   * factor of \f$ 1/scales^2 \f$.
+   */
+  virtual void updateLawCovMatrix(const M & covMatrix) = 0;
   //@}
 
   //! @name I/O methods

--- a/src/stats/inc/TransformedScaledCovMatrixTKGroup.h
+++ b/src/stats/inc/TransformedScaledCovMatrixTKGroup.h
@@ -113,6 +113,8 @@ private:
   //! Sets the mean of the underlying Gaussian RVs to zero.
   void setRVsWithZeroMean();
 
+  void transformCovMatrixToGaussianSpace();
+
   using BaseTKGroup<V, M>::m_env;
   using BaseTKGroup<V, M>::m_prefix;
   using BaseTKGroup<V, M>::m_vectorSpace;

--- a/src/stats/inc/TransformedScaledCovMatrixTKGroup.h
+++ b/src/stats/inc/TransformedScaledCovMatrixTKGroup.h
@@ -74,7 +74,7 @@ public:
 
   //! Scales the covariance matrix of the underlying Gaussian distribution.
   /*! The covariance matrix is scaled by a factor of \f$ 1/scales^2 \f$.*/
-  void updateLawCovMatrix(const M & covMatrix);
+  virtual void updateLawCovMatrix(const M & covMatrix);
   //@}
 
   //! @name Misc methods
@@ -113,7 +113,7 @@ private:
   //! Sets the mean of the underlying Gaussian RVs to zero.
   void setRVsWithZeroMean();
 
-  void transformCovMatrixToGaussianSpace();
+  void transformCovMatrixToGaussianSpace(M & covMatrix);
 
   using BaseTKGroup<V, M>::m_env;
   using BaseTKGroup<V, M>::m_prefix;

--- a/src/stats/src/HessianCovMatricesTKGroup.C
+++ b/src/stats/src/HessianCovMatricesTKGroup.C
@@ -373,6 +373,13 @@ HessianCovMatricesTKGroup<V,M>::clearPreComputingPositions()
 }
 
 template <class V, class M>
+void
+HessianCovMatricesTKGroup<V, M>::updateLawCovMatrix(const M & covMatrix)
+{
+  queso_error_msg(std::string("Stochastic Newton does not support adaptivity"));
+}
+
+template <class V, class M>
 unsigned int
 HessianCovMatricesTKGroup<V, M>::set_dr_stage(unsigned int stageId)
 {

--- a/src/stats/src/MetropolisHastingsSG.C
+++ b/src/stats/src/MetropolisHastingsSG.C
@@ -2232,20 +2232,7 @@ MetropolisHastingsSG<P_V, P_M>::adapt(unsigned int positionId,
       }
     }
 
-    // Transform the proposal covariance matrix if we have Logit transforms
-    // turned on.
-    //
-    // This logic should really be done inside the kernel itself
-    if (this->m_optionsObj->m_tk == "logit_random_walk") {
-      (dynamic_cast<TransformedScaledCovMatrixTKGroup<P_V,P_M>* >(m_tk.get()))
-        ->updateLawCovMatrix(tmpMatrix);
-    }
-    else {
-      // Assume that if we're not doing a logit transform, we're doing a random
-      // something sensible
-      (dynamic_cast<ScaledCovMatrixTKGroup<P_V,P_M>* >(m_tk.get()))
-        ->updateLawCovMatrix(tmpMatrix);
-    }
+    m_tk->updateLawCovMatrix(tmpMatrix);
 
 #ifdef UQ_DRAM_MCG_REQUIRES_INVERTED_COV_MATRICES
     queso_require_msg(!(UQ_INCOMPLETE_IMPLEMENTATION_RC), "need to code the update of m_upperCholProposalPrecMatrices");


### PR DESCRIPTION
The fact we were doing logit transforms outside of the TK designed for logit transforms bothered me.

I can't do it everywhere, though, one of the pieces of logic relies fundamentally on the adaptivity formulation.  See #555 for details.