### PR TITLE
Observational precision calibration option

### DIFF
--- a/examples/gp/pseudovector/gpmsa_pseudovector.C
+++ b/examples/gp/pseudovector/gpmsa_pseudovector.C
@@ -32,7 +32,9 @@ readData(const std::vector<QUESO::SharedPtr<QUESO::GslVector>::Type> & simulatio
   double m2sim = 0;
 
   // First line is a header, so we ignore it
-  fgets(line, size, fp_in);
+  char * gotline = fgets(line, size, fp_in);
+  if (!gotline)
+    queso_error_msg("dakota_pstudy.dat was unreadable");
 
   i = 0;
   while (fscanf(fp_in, "%d %lf %lf %lf %lf %lf %lf\n", &id, &k_tmasl, &k_tmoml,

--- a/examples/gp/pseudovector/gpmsa_pseudovector.C
+++ b/examples/gp/pseudovector/gpmsa_pseudovector.C
@@ -187,6 +187,9 @@ int main(int argc, char ** argv) {
                  numSimulations,
                  numExperiments);
 
+  // We want to calibrate for the observation precision
+  gpmsaFactory.options().m_calibrateObservationalPrecision = true;
+
   // std::vector containing all the points in scenario space where we have
   // simulations
   std::vector<QUESO::SharedPtr<QUESO::GslVector>::Type>

--- a/examples/gp/scalar/gpmsa_scalar.C
+++ b/examples/gp/scalar/gpmsa_scalar.C
@@ -31,7 +31,9 @@ double readData(const std::vector<QUESO::SharedPtr<QUESO::GslVector>::Type> & si
   double m2sim = 0;
 
   // First line is a header, so we ignore it
-  fgets(line, size, fp_in);
+  char * gotline = fgets(line, size, fp_in);
+  if (!gotline)
+    queso_error_msg("dakota_pstudy.dat was unreadable");
 
   i = 0;
   while (fscanf(fp_in, "%d %lf %lf %lf %lf %lf %lf\n", &id, &k_tmasl, &k_tmoml,

--- a/examples/gp/vector/gpmsa_vector.C
+++ b/examples/gp/vector/gpmsa_vector.C
@@ -205,6 +205,9 @@ int main(int argc, char ** argv) {
                  numSimulations,
                  numExperiments);
 
+  // We want to calibrate for the observation precision
+  gpmsaFactory.options().m_calibrateObservationalPrecision = true;
+
   // std::vector containing all the points in scenario space where we have
   // simulations
   std::vector<QUESO::SharedPtr<QUESO::GslVector>::Type>

--- a/examples/gp/vector/gpmsa_vector.C
+++ b/examples/gp/vector/gpmsa_vector.C
@@ -36,7 +36,9 @@ readData(const std::vector<QUESO::SharedPtr<QUESO::GslVector>::Type> & simulatio
   double m2expsim = 0;
 
   // First line is a header, so we ignore it
-  fgets(line, size, fp_in);
+  char * gotline = fgets(line, size, fp_in);
+  if (!gotline)
+    queso_error_msg("dakota_pstudy.dat was unreadable");
 
   i = 0;
   while (fscanf(fp_in, "%d %lf %lf %lf %lf %lf %lf\n", &id, &k_tmasl, &k_tmoml,

--- a/src/gp/inc/GPMSA.h
+++ b/src/gp/inc/GPMSA.h
@@ -141,6 +141,11 @@ public:
   //! @name Getters
   //@{
 
+  //! Return GPMSAOptions structure
+  const GPMSAOptions & options() const;
+
+  GPMSAOptions & options();
+
   //! Return number of simulations
   unsigned int numSimulations() const;
 

--- a/src/gp/inc/GPMSA.h
+++ b/src/gp/inc/GPMSA.h
@@ -66,7 +66,8 @@ public:
                 const ConcatenatedVectorRV<V, M> & m_totalPrior,
                 const V & residual_in,
                 const M & BT_Wy_B_inv_in,
-                const M & KT_K_inv_in);
+                const M & KT_K_inv_in,
+                bool calibrate_observational_precision);
 
   virtual ~GPMSAEmulator();
 
@@ -118,6 +119,8 @@ public:
   const M & BT_Wy_B_inv;
 
   const M & KT_K_inv;
+
+  bool m_calibrateObservationalPrecision;
 };
 
 template <class V = GslVector, class M = GslMatrix>
@@ -477,7 +480,6 @@ public:
 private:
   bool allocated_m_opts;
   GPMSAOptions * m_opts;
-
 };
 
 }  // End namespace QUESO

--- a/src/gp/inc/GPMSAOptions.h
+++ b/src/gp/inc/GPMSAOptions.h
@@ -77,6 +77,10 @@ public:
   //! The scale parameter for the Gamma hyperprior for the emulator precision
   double m_emulatorPrecisionScale;
 
+  //! Whether to use an observational error precision hyperparameter
+  //  lambda_y rather than a fixed multiplier of 1.
+  bool m_calibrateObservationalPrecision;
+
   //! The shape parameter for the Gamma hyperprior for the observational precision
   double m_observationalPrecisionShape;
 
@@ -123,6 +127,7 @@ private:
   std::string m_option_help;
   std::string m_option_emulatorPrecisionShape;
   std::string m_option_emulatorPrecisionScale;
+  std::string m_option_calibrateObservationalPrecision;
   std::string m_option_observationalPrecisionShape;
   std::string m_option_observationalPrecisionScale;
   std::string m_option_emulatorCorrelationStrengthAlpha;

--- a/src/gp/inc/GPMSAOptions.h
+++ b/src/gp/inc/GPMSAOptions.h
@@ -79,6 +79,8 @@ public:
 
   //! Whether to use an observational error precision hyperparameter
   //  lambda_y rather than a fixed multiplier of 1.
+  //
+  // False by default.
   bool m_calibrateObservationalPrecision;
 
   //! The shape parameter for the Gamma hyperprior for the observational precision

--- a/src/gp/src/GPMSA.C
+++ b/src/gp/src/GPMSA.C
@@ -102,7 +102,6 @@ GPMSAEmulator<V, M>::lnValue(const V & domainVector,
   // theta(2)
   // ...
   // theta(dimParameter)
-  // emulator_mean                // = "mu"
   // truncation_error_precision   // = "lambda_eta", only exists in
   //                                   vector case
   // emulator_precision(1)        // = "lambda_{w i}" in vector case

--- a/src/gp/src/GPMSA.C
+++ b/src/gp/src/GPMSA.C
@@ -515,6 +515,22 @@ GPMSAFactory<V, M>::~GPMSAFactory()
 }
 
 template <class V, class M>
+const GPMSAOptions &
+GPMSAFactory<V, M>::options() const
+{
+  return *this->m_opts;
+}
+
+
+template <class V, class M>
+GPMSAOptions &
+GPMSAFactory<V, M>::options()
+{
+  return *this->m_opts;
+}
+
+
+template <class V, class M>
 unsigned int
 GPMSAFactory<V, M>::numSimulations() const
 {

--- a/src/gp/src/GPMSAOptions.C
+++ b/src/gp/src/GPMSAOptions.C
@@ -78,6 +78,7 @@ GPMSAOptions::set_prefix(const char * prefix)
   m_option_help = m_prefix + "help";
   m_option_emulatorPrecisionShape = m_prefix + "emulator_precision_shape";
   m_option_emulatorPrecisionScale = m_prefix + "emulator_precision_scale";
+  m_option_calibrateObservationalPrecision = m_prefix + "calibrate_observational_precision";
   m_option_observationalPrecisionShape = m_prefix + "observational_precision_shape";
   m_option_observationalPrecisionScale = m_prefix + "observational_precision_scale";
   m_option_emulatorCorrelationStrengthAlpha = m_prefix + "emulator_correlation_strength_alpha";
@@ -98,6 +99,7 @@ GPMSAOptions::set_defaults()
   m_help = UQ_GPMSA_HELP;
   m_emulatorPrecisionShape = UQ_GPMSA_EMULATOR_PRECISION_SHAPE_ODV;
   m_emulatorPrecisionScale = UQ_GPMSA_EMULATOR_PRECISION_SCALE_ODV;
+  m_calibrateObservationalPrecision = false;
   m_observationalPrecisionShape = UQ_GPMSA_OBSERVATIONAL_PRECISION_SHAPE_ODV;
   m_observationalPrecisionScale = UQ_GPMSA_OBSERVATIONAL_PRECISION_SCALE_ODV;
   m_emulatorCorrelationStrengthAlpha = UQ_GPMSA_EMULATOR_CORRELATION_STRENGTH_ALPHA_ODV;
@@ -141,6 +143,11 @@ GPMSAOptions::parse(const BaseEnvironment & env,
     (m_option_emulatorPrecisionScale,
     m_emulatorPrecisionScale,
     "scale hyperprior (Gamma) parameter for emulator precision");
+
+  m_parser->registerOption
+    (m_option_calibrateObservationalPrecision,
+    m_calibrateObservationalPrecision,
+    "whether to use a calibrated hyperparameter for observational precision");
 
   m_parser->registerOption
     (m_option_observationalPrecisionShape,
@@ -192,6 +199,7 @@ GPMSAOptions::parse(const BaseEnvironment & env,
   m_parser->getOption<std::string>(m_option_help,                           m_help);
   m_parser->getOption<double>(m_option_emulatorPrecisionShape,              m_emulatorPrecisionShape);
   m_parser->getOption<double>(m_option_emulatorPrecisionScale,              m_emulatorPrecisionScale);
+  m_parser->getOption<bool>  (m_option_calibrateObservationalPrecision,     m_calibrateObservationalPrecision);
   m_parser->getOption<double>(m_option_observationalPrecisionShape,         m_observationalPrecisionShape);
   m_parser->getOption<double>(m_option_observationalPrecisionScale,         m_observationalPrecisionScale);
   m_parser->getOption<double>(m_option_emulatorCorrelationStrengthAlpha,    m_emulatorCorrelationStrengthAlpha);
@@ -211,6 +219,9 @@ GPMSAOptions::parse(const BaseEnvironment & env,
     env.input()(m_option_emulatorPrecisionScale,
                 m_emulatorPrecisionScale);
 
+  m_calibrateObservationalPrecision =
+    env.input()(m_option_calibrateObservationalPrecision,
+                m_calibrateObservationalPrecision);
   m_observationalPrecisionShape =
     env.input()(m_option_observationalPrecisionShape,
                 m_observationalPrecisionShape);
@@ -269,6 +280,7 @@ GPMSAOptions::print(std::ostream& os) const
 {
   os << "\n" << m_option_emulatorPrecisionShape << " = " << this->m_emulatorPrecisionShape
      << "\n" << m_option_emulatorPrecisionScale << " = " << this->m_emulatorPrecisionScale
+     << "\n" << m_option_calibrateObservationalPrecision << " = " << this->m_calibrateObservationalPrecision
      << "\n" << m_option_observationalPrecisionShape << " = " << this->m_observationalPrecisionShape
      << "\n" << m_option_observationalPrecisionScale << " = " << this->m_observationalPrecisionScale
      << "\n" << m_option_emulatorCorrelationStrengthAlpha << " = " << this->m_emulatorCorrelationStrengthAlpha

--- a/test/test_Regression/test_gpmsa_cobra.C
+++ b/test/test_Regression/test_gpmsa_cobra.C
@@ -36,7 +36,9 @@ double readData(const std::vector<QUESO::SharedPtr<QUESO::GslVector>::Type> & si
   double m2sim = 0;
 
   // First line is a header, so we ignore it
-  fgets(line, size, fp_in);
+  char * gotline = fgets(line, size, fp_in);
+  if (!gotline)
+    queso_error_msg("dakota_pstudy.dat was unreadable");
 
   i = 0;
   while (fscanf(fp_in, "%d %lf %lf %lf %lf %lf %lf\n", &id, &k_tmasl, &k_tmoml,

--- a/test/test_gpmsa/test_gpmsa_vector.C
+++ b/test/test_gpmsa/test_gpmsa_vector.C
@@ -221,6 +221,9 @@ int main(int argc, char ** argv) {
                  numSimulations,
                  numExperiments);
 
+  // We want to calibrate for the observation precision
+  gpmsaFactory.options().m_calibrateObservationalPrecision = true;
+
   // std::vector containing all the points in scenario space where we have
   // simulations
   std::vector<QUESO::SharedPtr<QUESO::GslVector>::Type>

--- a/test/test_gpmsa/test_gpmsa_vector.C
+++ b/test/test_gpmsa/test_gpmsa_vector.C
@@ -40,7 +40,9 @@ readData(const std::vector<QUESO::SharedPtr<QUESO::GslVector>::Type> & simulatio
   double m2expsim = 0;
 
   // First line is a header, so we ignore it
-  fgets(line, size, fp_in);
+  char * gotline = fgets(line, size, fp_in);
+  if (!gotline)
+    queso_error_msg("dakota_pstudy.dat was unreadable");
 
   i = 0;
   while (fscanf(fp_in, "%d %lf %lf %lf %lf %lf %lf\n", &id, &k_tmasl, &k_tmoml,


### PR DESCRIPTION
This lets us decide whether to use "lambda_y" on a case by case basis, rather than simply always using a fixed observation covariance matrix in scalar cases and always multiplying it by that hyperparameter in multivariate/functional cases.

I set the default to "false", which gives us consistency between cases but forces code using the multivariate case to explicitly set that option back to "true".