### PR TITLE
GCC-4.4.7 Compatibility: explicit SharedPtr() ctor

### DIFF
--- a/src/misc/src/MonteCarloQuadrature.C
+++ b/src/misc/src/MonteCarloQuadrature.C
@@ -41,7 +41,7 @@ namespace QUESO
 
     const BaseVectorRealizer< V, M > & realizer = uniform_rv.realizer();
 
-    this->m_positions.resize(n_samples,NULL);
+    this->m_positions.resize(n_samples,SharedPtr<GslVector>::Type());
 
     for( unsigned int i = 0; i < n_samples; i++ )
       {

--- a/src/misc/src/TensorProductQuadrature.C
+++ b/src/misc/src/TensorProductQuadrature.C
@@ -50,7 +50,7 @@ namespace QUESO
         total_n_q_points *= q_rules[i]->positions().size();
       }
 
-    this->m_positions.resize(total_n_q_points,NULL);
+    this->m_positions.resize(total_n_q_points,SharedPtr<GslVector>::Type());
     this->m_weights.resize(total_n_q_points);
 
     // The positions are just a tensor product of the positions for each of the 1-D rules.


### PR DESCRIPTION
Change a couple instances of NULL to SharedPtr<>::Type() to satisfy
older compiler.  There are probably many ways to fix this; feel free to choose another.