### PR TITLE
Deprecating FilePtrSetStruct

### DIFF
--- a/src/core/src/Environment.C
+++ b/src/core/src/Environment.C
@@ -124,10 +124,12 @@ FilePtrSetStruct::FilePtrSetStruct()
   h5Var(-1)
 #endif
 {
+  queso_deprecated();
 }
 
 FilePtrSetStruct::~FilePtrSetStruct()
 {
+  queso_deprecated();
 }
 
   //


### PR DESCRIPTION
This is just to discourage the user from using it.  We'll make the class
internal to just QUESO in the next release.

This is a precursor to #564.