### PR TITLE
GCC 4.4.7 compatibility: remove typename in GPMSAOptions.C

### DIFF
--- a/src/gp/src/GPMSAOptions.C
+++ b/src/gp/src/GPMSAOptions.C
@@ -623,11 +623,11 @@ operator<<(std::ostream& os, const GPMSAOptions & obj)
 template
 void
 GPMSAOptions::set_final_scaling<GslVector>
-  (const std::vector<typename SharedPtr<GslVector>::Type> &,
-   const std::vector<typename SharedPtr<GslVector>::Type> &,
-   const std::vector<typename SharedPtr<GslVector>::Type> &,
-   const std::vector<typename SharedPtr<GslVector>::Type> &,
-   const std::vector<typename SharedPtr<GslVector>::Type> &);
+  (const std::vector<SharedPtr<GslVector>::Type> &,
+   const std::vector<SharedPtr<GslVector>::Type> &,
+   const std::vector<SharedPtr<GslVector>::Type> &,
+   const std::vector<SharedPtr<GslVector>::Type> &,
+   const std::vector<SharedPtr<GslVector>::Type> &);
 
 
 }  // End namespace QUESO


### PR DESCRIPTION
(Dakota won't support this compiler much longer...)
