### PR TITLE
Make boost optional, allows `--without-boost` config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ before_script:
   - sudo apt-get install -q gfortran
   - sudo apt-get install -q libgsl0-dev
   - sudo apt-get install -q openmpi-bin openmpi-dev
-  - sudo apt-get install -q libboost-dev libboost-math-dev libboost-program-options-dev
   - sudo apt-get install -q libcppunit-dev
 script:
   - ./bootstrap

--- a/configure.ac
+++ b/configure.ac
@@ -187,7 +187,7 @@ AC_CACHE_SAVE
 # Check for boost (required)
 
 AC_LANG([C++])
-BOOST_REQUIRE([1.35])
+BOOST_REQUIRE([1.35], [HAVE_BOOST=0])
 AS_IF([test "x$enable_program_options" != "xno"],
       [
        BOOST_PROGRAM_OPTIONS
@@ -202,6 +202,8 @@ AS_IF([test "x$enable_program_options" = "xno"],
 BOOST_FIND_HEADER([boost/scoped_ptr.hpp])
 BOOST_FIND_HEADER([boost/shared_ptr.hpp])
 BOOST_FIND_HEADER([boost/math/special_functions.hpp])
+
+AM_CONDITIONAL(HAVE_BOOST, test x$HAVE_BOOST = x1)
 AC_CACHE_SAVE
 
 # Check for GLPK (optional)

--- a/examples/Makefile.am
+++ b/examples/Makefile.am
@@ -3,7 +3,11 @@
 AM_CPPFLAGS  = $(QUESO_CPPFLAGS)
 AM_CPPFLAGS += -I$(top_builddir)/src/core/inc
 AM_CPPFLAGS += -I$(top_builddir)/inc
+
+if HAVE_BOOST
 AM_CPPFLAGS += $(BOOST_CPPFLAGS)
+endif
+
 AM_CPPFLAGS += $(GSL_CFLAGS)
 AM_CPPFLAGS += $(GRVY_CFLAGS)
 

--- a/m4/config_summary.m4
+++ b/m4/config_summary.m4
@@ -60,6 +60,12 @@ else
   echo '   'Link with MPI.............. : no
 fi
 
+if test "$HAVE_BOOST" = "1"; then
+  echo '   'Link with Boost............ : yes
+else
+  echo '   'Link with Boost............ : no
+fi
+
 if test "$HAVE_GRVY" = "0"; then
   echo '   'Link with GRVY............. : no
 else

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,6 +1,10 @@
 AM_CPPFLAGS = $(QUESO_CPPFLAGS)
 AM_CPPFLAGS += -I$(top_builddir)/inc
+
+if HAVE_BOOST
 AM_CPPFLAGS += $(BOOST_CPPFLAGS)
+endif
+
 AM_CPPFLAGS += $(GSL_CFLAGS)
 
 if HAVE_ANN
@@ -32,7 +36,11 @@ lib_LTLIBRARIES      = libqueso.la
 libqueso_includedir  = $(prefix)/include/queso
 libqueso_la_LDFLAGS  = $(all_libraries) -release $(GENERIC_RELEASE)
 libqueso_la_LDFLAGS += $(GSL_LIBS)
+
+if HAVE_BOOST
 libqueso_la_LDFLAGS += $(BOOST_PROGRAM_OPTIONS_LDFLAGS) $(BOOST_PROGRAM_OPTIONS_LIBS)
+endif
+
 libqueso_la_LDFLAGS += $(HDF5_LIBS)
 libqueso_la_LIBADD   =  # Empty.  Append below.
 

--- a/src/core/inc/BasicPdfsBoost.h
+++ b/src/core/inc/BasicPdfsBoost.h
@@ -25,6 +25,9 @@
 #ifndef UQ_BASIC_PDFS_BOOST_H
 #define UQ_BASIC_PDFS_BOOST_H
 
+#include <queso/config_queso.h>
+#ifdef QUESO_HAVE_BOOST
+
 #include <queso/BasicPdfsBase.h>
 
 namespace QUESO {
@@ -67,5 +70,7 @@ private:
 };
 
 }  // End namespace QUESO
+
+#endif  // QUESO_HAVE_BOOST
 
 #endif // UQ_BASIC_PDFS_BOOST_H

--- a/src/core/inc/RngBoost.h
+++ b/src/core/inc/RngBoost.h
@@ -25,6 +25,9 @@
 #ifndef UQ_RNG_BOOST_H
 #define UQ_RNG_BOOST_H
 
+#include <queso/config_queso.h>
+#ifdef QUESO_HAVE_BOOST
+
 #include <queso/RngBase.h>
 #include <boost/random/mersenne_twister.hpp>
 
@@ -110,5 +113,7 @@ private:
 };
 
 }  // End namespace QUESO
+
+#endif  // QUESO_HAVE_BOOST
 
 #endif // UQ_RNG_BOOST_H

--- a/src/core/src/BasicPdfsBoost.C
+++ b/src/core/src/BasicPdfsBoost.C
@@ -23,6 +23,9 @@
 //-----------------------------------------------------------------------el-
 
 #include <queso/BasicPdfsBoost.h>
+
+#ifdef QUESO_HAVE_BOOST
+
 #include <boost/math/distributions/gamma.hpp>
 #include <boost/math/distributions/beta.hpp>
 
@@ -58,3 +61,5 @@ BasicPdfsBoost::gammaPdfActualValue(double x, double a, double b) const
 }
 
 }  // End namespace QUESO
+
+#endif  // QUESO_HAVE_BOOST

--- a/src/core/src/Environment.C
+++ b/src/core/src/Environment.C
@@ -1435,8 +1435,12 @@ FullEnvironment::construct (RawType_MPI_Comm inputComm,
     m_basicPdfs.reset(new BasicPdfsGsl(m_worldRank));
   }
   else if (m_optionsObj->m_rngType == "boost") {
+#ifdef QUESO_HAVE_BOOST
     m_rngObject.reset(new RngBoost(m_optionsObj->m_seed,m_worldRank));
     m_basicPdfs.reset(new BasicPdfsBoost(m_worldRank));
+#else
+    queso_error_msg("Boost RNG requested, but QUESO was not built with boost.");
+#endif  // QUESO_HAVE_BOOST
   }
   else if (m_optionsObj->m_rngType == "cxx11") {
 #ifdef QUESO_HAVE_CXX11
@@ -1688,8 +1692,12 @@ FullEnvironment::construct (const char *prefix)
     m_basicPdfs.reset(new BasicPdfsGsl(m_worldRank));
   }
   else if (m_optionsObj->m_rngType == "boost") {
+#ifdef QUESO_HAVE_BOOST
     m_rngObject.reset(new RngBoost(m_optionsObj->m_seed,m_worldRank));
     m_basicPdfs.reset(new BasicPdfsBoost(m_worldRank));
+#else
+    queso_error_msg("Boost RNG requested, but QUESO wasn't built with boost.");
+#endif  // QUESO_HAVE_BOOST
   }
   else if (m_optionsObj->m_rngType == "cxx11") {
 #ifdef QUESO_HAVE_CXX11

--- a/src/core/src/RngBoost.C
+++ b/src/core/src/RngBoost.C
@@ -24,6 +24,8 @@
 
 #include <queso/RngBoost.h>
 
+#ifdef QUESO_HAVE_BOOST
+
 #include <boost/random.hpp>
 #include <boost/math/distributions.hpp>
 
@@ -95,3 +97,5 @@ RngBoost::gammaSample(double a, double b) const
 }
 
 }  // End namespace QUESO
+
+#endif  // QUESO_HAVE_BOOST

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -82,7 +82,12 @@ LDADD       = $(top_builddir)/src/libqueso.la
 AM_CPPFLAGS = $(QUESO_CPPFLAGS)
 AM_CPPFLAGS += -I.
 AM_CPPFLAGS += -I$(top_builddir)/inc
-AM_CPPFLAGS +=  $(BOOST_CPPFLAGS) $(GSL_CFLAGS) $(ANN_CFLAGS)
+
+if HAVE_BOOST
+AM_CPPFLAGS += $(BOOST_CPPFLAGS)
+endif
+
+AM_CPPFLAGS += $(GSL_CFLAGS) $(ANN_CFLAGS)
 
 #----------------
 # CppUnit support

--- a/test/unit/basic_pdfs_boost.C
+++ b/test/unit/basic_pdfs_boost.C
@@ -26,6 +26,8 @@
 
 #ifdef QUESO_HAVE_CPPUNIT
 
+#ifdef QUESO_HAVE_BOOST
+
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>
 
@@ -76,5 +78,7 @@ private:
 CPPUNIT_TEST_SUITE_REGISTRATION(BasicPdfsBoostTest);
 
 } // end namespace QUESOTesting
+
+#endif  // QUESO_HAVE_BOOST
 
 #endif // QUESO_HAVE_CPPUNIT

--- a/test/unit/rng_boost.C
+++ b/test/unit/rng_boost.C
@@ -26,6 +26,8 @@
 
 #ifdef QUESO_HAVE_CPPUNIT
 
+#ifdef QUESO_HAVE_BOOST
+
 #include <cppunit/extensions/HelperMacros.h>
 #include <cppunit/TestCase.h>
 
@@ -116,5 +118,7 @@ private:
 CPPUNIT_TEST_SUITE_REGISTRATION(RngBoost);
 
 } // end namespace QUESOTesting
+
+#endif  // QUESO_HAVE_BOOST
 
 #endif // QUESO_HAVE_CPPUNIT


### PR DESCRIPTION
Not sure on the interaction between this and lack of C++11.

@pbauman I believe this is relevant to you:

![It's happening](https://media.giphy.com/media/rl0FOxdz7CcxO/giphy.gif)