### PR TITLE
Fix Trilinos compilation

### DIFF
--- a/src/basic/src/TeuchosVectorSpace.C
+++ b/src/basic/src/TeuchosVectorSpace.C
@@ -22,6 +22,7 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/Defines.h>
 #include <queso/VectorSpace.h>
 
 #ifdef QUESO_HAS_TRILINOS

--- a/src/core/src/TeuchosMatrix.C
+++ b/src/core/src/TeuchosMatrix.C
@@ -27,11 +27,10 @@
 #ifdef QUESO_HAS_TRILINOS
 #include <queso/TeuchosMatrix.h>
 #include <queso/TeuchosVector.h>
-#endif
+#include <core/inc/FilePtr.h>
 #include <sys/time.h>
 #include <cmath>
 
-#ifdef QUESO_HAS_TRILINOS
 
 namespace QUESO {
 


### PR DESCRIPTION
Without these updates I can't compile while I have a Trilinos module loaded unless I explicitly disable Trilinos shims at configure time.