### PR TITLE
Make build system handle boost prog opts macro

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -97,8 +97,12 @@ AC_ARG_ENABLE([boost-program-options],
               AS_HELP_STRING([--disable-boost-program-options], [Disables use
                               of boost program options for parsing the QUESO
                               input file.  GetPot will be used instead.]),
-              [enable_program_options="no"],
-              [enable_program_options="yes"])
+              [case "${enableval}" in
+               yes) enable_program_options=yes ;;
+               no)  enable_program_options=no ;;
+               *)   AC_MSG_ERROR(bad value ${enableval} for --disable-boost-program-options) ;;
+              esac],
+              [enable_program_options=yes])
 
 #-------------------
 # Compilers and MPI
@@ -195,8 +199,7 @@ AS_IF([test "x$enable_program_options" != "xno"],
 
 AS_IF([test "x$enable_program_options" = "xno"],
       [
-       QUESO_CPPFLAGS="$QUESO_CPPFLAGS -DDISABLE_BOOST_PROGRAM_OPTIONS"
-       AC_SUBST(QUESO_CPPFLAGS)
+       AC_DEFINE(DISABLE_BOOST_PROGRAM_OPTIONS, 1, [Flag determining whether boost program options is disabled])
       ])
 
 BOOST_FIND_HEADER([boost/scoped_ptr.hpp])

--- a/src/basic/inc/ScalarFunction.h
+++ b/src/basic/inc/ScalarFunction.h
@@ -158,7 +158,7 @@ protected:
   const VectorSet<V, M> & m_domainSet;
 
 private:
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   //! Input parser
   ScopedPtr<BoostInputOptionsParser>::Type m_parser;
 #endif

--- a/src/basic/src/ScalarFunction.C
+++ b/src/basic/src/ScalarFunction.C
@@ -22,13 +22,14 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/config_queso.h>
 #include <queso/ScalarFunction.h>
 #include <queso/VectorSet.h>
 #include <queso/VectorSpace.h>
 #include <queso/GslVector.h>
 #include <queso/GslMatrix.h>
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <queso/BoostInputOptionsParser.h>
 #else
 #include <queso/getpot.h>
@@ -47,7 +48,7 @@ BaseScalarFunction<V, M>::BaseScalarFunction(const char * prefix,
   : m_env(domainSet.env()),
     m_prefix((std::string)(prefix) + "func_"),
     m_domainSet(domainSet),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_parser(new BoostInputOptionsParser(m_env.optionsInputFileName())),
 #endif
     m_fdStepSize(1, std::atof(QUESO_BASESCALARFN_FD_STEPSIZE_ODV))
@@ -55,7 +56,7 @@ BaseScalarFunction<V, M>::BaseScalarFunction(const char * prefix,
   unsigned int dim = m_domainSet.vectorSpace().dimLocal();
 
   // Snarf fd step size from input file.
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_parser->registerOption<std::string>(m_prefix + "fdStepSize",
                                         QUESO_BASESCALARFN_FD_STEPSIZE_ODV,
                                         "step size for finite difference");

--- a/src/basic/src/SequenceStatisticalOptions.C
+++ b/src/basic/src/SequenceStatisticalOptions.C
@@ -25,9 +25,9 @@
 #include <queso/Defines.h>
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 #include <queso/SequenceStatisticalOptions.h>
 #include <queso/Miscellaneous.h>

--- a/src/core/inc/BoostInputOptionsParser.h
+++ b/src/core/inc/BoostInputOptionsParser.h
@@ -21,7 +21,8 @@
 // Boston, MA  02110-1301  USA
 //
 //-----------------------------------------------------------------------el-
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#include <queso/config_queso.h>
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 #ifndef UQ_BOOST_INPUT_OPTIONS_H
 #define UQ_BOOST_INPUT_OPTIONS_H
@@ -106,4 +107,4 @@ private:
 
 #endif  // UQ_BOOST_INPUT_OPTIONS_H
 
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS

--- a/src/core/inc/Environment.h
+++ b/src/core/inc/Environment.h
@@ -38,7 +38,7 @@
 #include <fstream>
 
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 // Forward declarations
 namespace boost {
   namespace program_options {
@@ -46,7 +46,7 @@ namespace boost {
     class variables_map;
     }
 }
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 namespace QUESO {
 
@@ -340,25 +340,25 @@ public:
   void    setOptionsInputFileAccessState(bool newState) const; // Yes, 'const'
 
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #ifdef UQ_USES_COMMAND_LINE_OPTIONS
   const boost::program_options::options_description& allOptionsDesc () const;
 #endif
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   //! Access function to private attribute m_allOptionsMap. It is an instance of boost::program_options::variables_map(), which
   //! allows concrete variables to map which store variables in real map.
   boost::program_options::variables_map&      allOptionsMap () const;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   //! This method scans the input file provided by the user to QUESO.
   /*! It checks if no input file is passed and updates the private attribute m_allOptionsDesc, which
    * keeps all the options.*/
   void    scanInputFileForMyOptions(const boost::program_options::options_description& optionsDesc) const;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   //! Access function to private attribute m_displayVerbosity. It manages how much information will be
   //! release during the use of the QUESO library.
@@ -446,10 +446,10 @@ protected:
 
   std::string m_optionsInputFileName;
   mutable bool m_optionsInputFileAccessState; // Yes, 'mutable'
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   ScopedPtr<boost::program_options::options_description>::Type m_allOptionsDesc;
   ScopedPtr<boost::program_options::variables_map>::Type m_allOptionsMap;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   ScopedPtr<GetPot>::Type m_input;
 
   unsigned int m_subId;

--- a/src/core/inc/EnvironmentOptions.h
+++ b/src/core/inc/EnvironmentOptions.h
@@ -29,9 +29,10 @@
 #include <set>
 #include <vector>
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#include <queso/config_queso.h>
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <queso/BoostInputOptionsParser.h>
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 #include <queso/ScopedPtr.h>
 
@@ -55,14 +56,14 @@
 #define UQ_ENV_NUM_DEBUG_PARAMS_ODV         0
 #define UQ_ENV_DEBUG_PARAM_ODV              0.
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 // Forward declarations
 namespace boost {
   namespace program_options {
     class options_description;
     }
 }
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 namespace QUESO {
 
@@ -172,9 +173,9 @@ public:
 private:
   const BaseEnvironment * m_env;
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   ScopedPtr<BoostInputOptionsParser>::Type m_parser;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   //! Input file option name for flagging helpful printing output
   std::string m_option_help;
@@ -262,13 +263,13 @@ public:
   EnvOptionsValues  m_ov;
 
 private:
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   //! Define my environment options as the default options
   void   defineMyOptions  (boost::program_options::options_description& optionsDesc) const;
 
   //! Gets the option values of the environment.
   void   getMyOptionValues(boost::program_options::options_description& optionsDesc);
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   //! Environment.
   const BaseEnvironment& m_env;
@@ -280,9 +281,9 @@ private:
   /*! Uses boost::program_options::options_description. A set of option descriptions.
    * This provides convenient interface for adding new option method, and facilities
    * to search for options by name.*/
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   ScopedPtr<boost::program_options::options_description>::Type m_optionsDesc;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   std::string              m_option_help;
 

--- a/src/core/inc/InfiniteDimensionalMCMCSamplerOptions.h
+++ b/src/core/inc/InfiniteDimensionalMCMCSamplerOptions.h
@@ -26,11 +26,11 @@
 
 #include <queso/Environment.h>
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <queso/BoostInputOptionsParser.h>
 #else
 #include <queso/getpot.h>
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 namespace QUESO {
 
@@ -83,9 +83,9 @@ public:
   const BaseEnvironment& env() const;
 
 private:
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   BoostInputOptionsParser * m_parser;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   const BaseEnvironment& m_env;
 

--- a/src/core/src/BoostInputOptionsParser.C
+++ b/src/core/src/BoostInputOptionsParser.C
@@ -22,7 +22,8 @@
 //
 //-----------------------------------------------------------------------el-
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#include <queso/config_queso.h>
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
 
 #include <queso/BoostInputOptionsParser.h>
@@ -176,4 +177,4 @@ template void BoostInputOptionsParser::getOption<std::vector<unsigned int, std::
 template void BoostInputOptionsParser::getOption<std::vector<double, std::allocator<double> > >(const std::string&, std::vector<double, std::allocator<double> >&) const;
 
 }  // End namespace QUESO
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS

--- a/src/core/src/Environment.C
+++ b/src/core/src/Environment.C
@@ -24,9 +24,9 @@
 
 #include <queso/Environment.h>
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 #include <queso/getpot.h>
 
@@ -153,10 +153,10 @@ BaseEnvironment::BaseEnvironment(
   m_fullCommSize               (1),
   m_optionsInputFileName       (""),
   m_optionsInputFileAccessState(true),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_allOptionsDesc             (),
   m_allOptionsMap              (),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_input                      (new GetPot),
   m_subComm                    (),
   m_subRank                    (-1),
@@ -192,10 +192,10 @@ BaseEnvironment::BaseEnvironment(
   m_fullCommSize               (1),
   m_optionsInputFileName       (passedOptionsInputFileName),
   m_optionsInputFileAccessState(true),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_allOptionsDesc             (),
   m_allOptionsMap              (),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_input                      (new GetPot),
   m_subComm                    (),
   m_subRank                    (-1),
@@ -369,7 +369,7 @@ BaseEnvironment::setOptionsInputFileAccessState(bool newState) const
   return;
 }
 //-------------------------------------------------------
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #ifdef UQ_USES_COMMAND_LINE_OPTIONS
 const boost::program_options::options_description&
 BaseEnvironment::allOptionsDesc() const
@@ -379,9 +379,9 @@ BaseEnvironment::allOptionsDesc() const
   return *m_allOptionsDesc;
 }
 #endif
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 //-------------------------------------------------------
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 boost::program_options::variables_map&
 BaseEnvironment::allOptionsMap() const
 {
@@ -390,9 +390,9 @@ BaseEnvironment::allOptionsMap() const
   queso_require_msg(m_allOptionsMap, "m_allOptionsMap variable is NULL");
   return *m_allOptionsMap;
 }
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 //-------------------------------------------------------
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 void
 BaseEnvironment::scanInputFileForMyOptions(const boost::program_options::options_description& optionsDesc) const
 {
@@ -444,7 +444,7 @@ BaseEnvironment::scanInputFileForMyOptions(const boost::program_options::options
 
   return;
 }
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 //-----------------------------------------------------
 unsigned int
 BaseEnvironment::displayVerbosity() const
@@ -1235,10 +1235,10 @@ FullEnvironment::construct (RawType_MPI_Comm inputComm,
     // If there's an input file, we grab the options from there.  Otherwise the
     // defaults are used
     if (m_optionsInputFileName != "") {
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
       m_allOptionsMap.reset(new boost::program_options::variables_map());
       m_allOptionsDesc.reset(new boost::program_options::options_description("Allowed options"));
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
       readOptionsInputFile();
 
@@ -1516,10 +1516,10 @@ FullEnvironment::construct (const char *prefix)
     // If there's an input file, we grab the options from there.  Otherwise the
     // defaults are used
     if (m_optionsInputFileName != "") {
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
       m_allOptionsMap.reset(new boost::program_options::variables_map());
       m_allOptionsDesc.reset(new boost::program_options::options_description("Allowed options"));
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
       readOptionsInputFile();
 

--- a/src/core/src/EnvironmentOptions.C
+++ b/src/core/src/EnvironmentOptions.C
@@ -24,11 +24,11 @@
 
 #include <queso/Defines.h>
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
 #else
 #include <queso/getpot.h>
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 #include <queso/EnvironmentOptions.h>
 #include <queso/Miscellaneous.h>
@@ -61,9 +61,9 @@ EnvOptionsValues::EnvOptionsValues()
     m_numDebugParams(UQ_ENV_NUM_DEBUG_PARAMS_ODV),
     m_debugParams(m_numDebugParams,0.),
     m_env(NULL),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_parser(),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_option_help(m_prefix + "help"),
     m_option_numSubEnvironments(m_prefix + "numSubEnvironments"),
     m_option_subDisplayFileName(m_prefix + "subDisplayFileName"),
@@ -100,9 +100,9 @@ EnvOptionsValues::EnvOptionsValues(const BaseEnvironment * env, const char *
     m_numDebugParams(UQ_ENV_NUM_DEBUG_PARAMS_ODV),
     m_debugParams(m_numDebugParams,0.),
     m_env(env),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_parser(new BoostInputOptionsParser(env->optionsInputFileName())),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_option_help(m_prefix + "help"),
     m_option_numSubEnvironments(m_prefix + "numSubEnvironments"),
     m_option_subDisplayFileName(m_prefix + "subDisplayFileName"),
@@ -117,7 +117,7 @@ EnvOptionsValues::EnvOptionsValues(const BaseEnvironment * env, const char *
     m_option_platformName(m_prefix + "platformName"),
     m_option_identifyingString(m_prefix + "identifyingString")
 {
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   // Register all options with parser
   m_parser->registerOption<std::string >(m_option_help, UQ_ENV_HELP, "produce help message for environment");
   m_parser->registerOption<unsigned int>(m_option_numSubEnvironments, UQ_ENV_NUM_SUB_ENVIRONMENTS_ODV, "number of subEnvironments");
@@ -172,7 +172,7 @@ EnvOptionsValues::EnvOptionsValues(const BaseEnvironment * env, const char *
   m_seed = m_env->input()(m_option_seed, UQ_ENV_SEED_ODV);
   m_platformName = m_env->input()(m_option_platformName, UQ_ENV_PLATFORM_NAME_ODV);
   m_identifyingString = m_env->input()(m_option_identifyingString, UQ_ENV_IDENTIFYING_STRING_ODV);
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   checkOptions();
 }
@@ -235,11 +235,11 @@ EnvOptionsValues::copy(const EnvOptionsValues& src)
 std::ostream& operator<<(std::ostream& os, const EnvOptionsValues & obj)
 {
   // Print the parser
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   os << (*(obj.m_parser)) << std::endl;
 #else
   obj.m_env->input().print(os);
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   // Print the option names and current values
   os <<         obj.m_option_numSubEnvironments    << " = " << obj.m_numSubEnvironments
@@ -274,9 +274,9 @@ EnvironmentOptions::EnvironmentOptions(
   m_ov                          (),
   m_env                         (env),
   m_prefix                      ((std::string)(prefix) + "env_"),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_optionsDesc                 (new boost::program_options::options_description("Environment options")),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_option_help                 (m_prefix + "help"                 ),
   m_option_numSubEnvironments   (m_prefix + "numSubEnvironments"   ),
   m_option_subDisplayFileName   (m_prefix + "subDisplayFileName"   ),
@@ -303,9 +303,9 @@ EnvironmentOptions::EnvironmentOptions(
   m_ov                          (alternativeOptionsValues),
   m_env                         (env),
   m_prefix                      ((std::string)(prefix) + "env_"),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_optionsDesc                 (),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_option_help                 (m_prefix + "help"                 ),
   m_option_numSubEnvironments   (m_prefix + "numSubEnvironments"   ),
   m_option_subDisplayFileName   (m_prefix + "subDisplayFileName"   ),
@@ -342,15 +342,15 @@ void
 EnvironmentOptions::scanOptionsValues()
 {
   queso_deprecated();
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   queso_require_msg(m_optionsDesc, "m_optionsDesc variable is NULL");
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   defineMyOptions                (*m_optionsDesc);
   m_env.scanInputFileForMyOptions(*m_optionsDesc);
   getMyOptionValues              (*m_optionsDesc);
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   // 'm_subDisplayOutputFile' is still not available at this moment. Use 'std::cout'
   //if (m_env.subScreenFile() != NULL) {
@@ -391,7 +391,7 @@ EnvironmentOptions::print(std::ostream& os) const
   return;
 }
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 // Private methods ----------------------------------
 void
 EnvironmentOptions::defineMyOptions(boost::program_options::options_description& optionsDesc) const
@@ -527,7 +527,7 @@ EnvironmentOptions::getMyOptionValues(boost::program_options::options_descriptio
 
   return;
 }
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 // Operator outside class definition ----------------
 std::ostream& operator<<(std::ostream& os, const EnvironmentOptions& obj)

--- a/src/core/src/InfiniteDimensionalMCMCSamplerOptions.C
+++ b/src/core/src/InfiniteDimensionalMCMCSamplerOptions.C
@@ -21,6 +21,7 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/config_queso.h>
 #include <queso/InfiniteDimensionalMCMCSamplerOptions.h>
 
 // ODV = option default value
@@ -41,9 +42,9 @@ InfiniteDimensionalMCMCSamplerOptions::InfiniteDimensionalMCMCSamplerOptions(
     m_num_iters(UQ_INF_NUM_ITERS_ODV),
     m_save_freq(UQ_INF_SAVE_FREQ_ODV),
     m_rwmh_step(UQ_INF_RWMH_STEP_ODV),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_parser(new BoostInputOptionsParser(env.optionsInputFileName())),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_env(env),
     m_option_help(m_prefix + "help"),
     m_option_dataOutputDirName(m_prefix + "dataOutputDirName"),
@@ -54,7 +55,7 @@ InfiniteDimensionalMCMCSamplerOptions::InfiniteDimensionalMCMCSamplerOptions(
 {
   queso_require_not_equal_to_msg(m_env.optionsInputFileName(), std::string(""), std::string("this constructor is incompatible with the abscense of an options input file"));
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_parser->registerOption(m_option_help, "produce help message for infinite dimensional sampler");
   m_parser->registerOption<std::string>(m_option_dataOutputDirName, UQ_INF_DATA_OUTPUT_DIR_NAME_ODV, "name of data output dir");
   m_parser->registerOption<std::string>(m_option_dataOutputFileName, UQ_INF_DATA_OUTPUT_FILE_NAME_ODV, "name of data output file (HDF5)");
@@ -75,7 +76,7 @@ InfiniteDimensionalMCMCSamplerOptions::InfiniteDimensionalMCMCSamplerOptions(
   m_option_num_iters = m_env.input()(m_option_num_iters, UQ_INF_NUM_ITERS_ODV);
   m_option_save_freq = m_env.input()(m_option_save_freq, UQ_INF_SAVE_FREQ_ODV);
   m_option_rwmh_step = m_env.input()(m_option_rwmh_step, UQ_INF_RWMH_STEP_ODV);;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   checkOptions();
 }
@@ -105,9 +106,9 @@ void InfiniteDimensionalMCMCSamplerOptions::print(std::ostream & os) const
 std::ostream & operator<<(std::ostream & os,
     const InfiniteDimensionalMCMCSamplerOptions & obj)
 {
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   os << (*(obj.m_parser)) << std::endl;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   obj.print(os);
   return os;
 }

--- a/src/core/src/OptimizerOptions.C
+++ b/src/core/src/OptimizerOptions.C
@@ -25,7 +25,7 @@
 #include <queso/Defines.h>
 #include <queso/Environment.h>
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <queso/BoostInputOptionsParser.h>
 #else
 #include <queso/getpot.h>
@@ -46,9 +46,9 @@ OptimizerOptions::OptimizerOptions()
     m_fdfstepSize(UQ_OPT_FDFSTEP_SIZE),
     m_lineTolerance(UQ_OPT_LINE_TOLERANCE),
     m_env(NULL),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_parser(NULL),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_option_help(m_prefix + "help"),
     m_option_maxIterations(m_prefix + "maxIterations"),
     m_option_tolerance(m_prefix + "tolerance"),
@@ -72,9 +72,9 @@ OptimizerOptions::OptimizerOptions(const BaseEnvironment * env, const char *
     m_fdfstepSize(UQ_OPT_FDFSTEP_SIZE),
     m_lineTolerance(UQ_OPT_LINE_TOLERANCE),
     m_env(env),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_parser(new BoostInputOptionsParser(env->optionsInputFileName())),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_option_help(m_prefix + "help"),
     m_option_maxIterations(m_prefix + "maxIterations"),
     m_option_tolerance(m_prefix + "tolerance"),
@@ -84,7 +84,7 @@ OptimizerOptions::OptimizerOptions(const BaseEnvironment * env, const char *
     m_option_fdfstepSize(m_prefix + "fdfStepSize"),
     m_option_lineTolerance(m_prefix + "lineTolerance")
 {
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_parser->registerOption<std::string>(m_option_help, UQ_OPT_HELP,
       "produce help message for statistical inverse problem");
 
@@ -125,7 +125,7 @@ OptimizerOptions::OptimizerOptions(const BaseEnvironment * env, const char *
   m_fstepSize = m_env->input()(m_option_fstepSize, UQ_OPT_FSTEP_SIZE);
   m_fdfstepSize = m_env->input()(m_option_fdfstepSize, UQ_OPT_FDFSTEP_SIZE);
   m_lineTolerance = m_env->input()(m_option_lineTolerance, UQ_OPT_LINE_TOLERANCE);
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   checkOptions();
 }

--- a/src/gp/inc/GPMSAOptions.h
+++ b/src/gp/inc/GPMSAOptions.h
@@ -24,10 +24,10 @@
 #include <queso/Environment.h>
 #include <queso/SharedPtr.h>
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <queso/BoostInputOptionsParser.h>
 #include <queso/ScopedPtr.h>
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 #ifndef UQ_GPMSA_OPTIONS_H
 #define UQ_GPMSA_OPTIONS_H
@@ -236,9 +236,9 @@ public:
 private:
   const BaseEnvironment * m_env;
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   QUESO::ScopedPtr<BoostInputOptionsParser>::Type m_parser;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   // True if the specified autoscaling should be done for all inputs
   bool m_autoscaleMinMaxAll;

--- a/src/gp/src/GPMSAOptions.C
+++ b/src/gp/src/GPMSAOptions.C
@@ -24,11 +24,11 @@
 
 #include <queso/Defines.h>
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
 #else
 #include <queso/getpot.h>
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 #include <queso/GPMSAOptions.h>
 
@@ -105,9 +105,9 @@ GPMSAOptions::GPMSAOptions(
 GPMSAOptions::GPMSAOptions()
   :
   m_env(NULL)
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   ,m_parser(new BoostInputOptionsParser())
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 {
   this->set_defaults();
   this->set_prefix("");
@@ -180,7 +180,7 @@ GPMSAOptions::parse(const BaseEnvironment & env,
 
   this->set_prefix(prefix);
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_parser.reset(new BoostInputOptionsParser(env.optionsInputFileName()));
 
   m_parser->registerOption<std::string>
@@ -327,7 +327,7 @@ GPMSAOptions::parse(const BaseEnvironment & env,
   m_autoscaleMeanVarAll =
     env.input()(m_option_autoscaleMeanVarAll,
                 m_autoscaleMeanVarAll);
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   checkOptions();
 }
@@ -610,9 +610,9 @@ GPMSAOptions::print(std::ostream& os) const
 std::ostream &
 operator<<(std::ostream& os, const GPMSAOptions & obj)
 {
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   os << (*(obj.m_parser)) << std::endl;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   obj.print(os);
   return os;
 }

--- a/src/stats/inc/MLSamplingLevelOptions.h
+++ b/src/stats/inc/MLSamplingLevelOptions.h
@@ -30,7 +30,7 @@
 #include <queso/Environment.h>
 #include <queso/SequenceStatisticalOptions.h>
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <queso/BoostInputOptionsParser.h>
 #else
 #include <queso/getpot.h>
@@ -377,9 +377,9 @@ private:
 
   const BaseEnvironment&        m_env;
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   BoostInputOptionsParser * m_parser;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   std::string                   m_option_help;
 

--- a/src/stats/inc/MLSamplingOptions.h
+++ b/src/stats/inc/MLSamplingOptions.h
@@ -28,9 +28,9 @@
 #include <queso/Environment.h>
 #include <queso/MLSamplingLevelOptions.h>
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <queso/BoostInputOptionsParser.h>
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 #define UQ_ML_SAMPLING_FILENAME_FOR_NO_FILE "."
 
@@ -129,9 +129,9 @@ public:
 private:
   const BaseEnvironment& m_env;
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   BoostInputOptionsParser * m_parser;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   std::string                   m_option_help;
 #ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY

--- a/src/stats/inc/MetropolisHastingsSGOptions.h
+++ b/src/stats/inc/MetropolisHastingsSGOptions.h
@@ -29,9 +29,9 @@
 #include <queso/MLSamplingLevelOptions.h>
 #include <queso/SequenceStatisticalOptions.h>
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <queso/BoostInputOptionsParser.h>
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 #undef  UQ_MH_SG_REQUIRES_INVERTED_COV_MATRICES
 #define UQ_NOTHING_JUST_FOR_TEST_OF_SVN_ID 1
@@ -100,13 +100,13 @@
 #define UQ_MH_SG_TK                                                   "logit_random_walk"
 #define UQ_MH_SG_UPDATE_INTERVAL                                      1
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 namespace boost {
   namespace program_options {
     class options_description;
   }
 }
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 namespace QUESO {
 
@@ -620,9 +620,9 @@ private:
   // Cache a pointer to the environment.
   const BaseEnvironment * m_env;
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   ScopedPtr<BoostInputOptionsParser>::Type m_parser;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   //! Option name for MhOptionsValues::m_help.  Option name is m_prefix + "mh_help"
   std::string                   m_option_help;
@@ -815,18 +815,18 @@ public:
   std::string                        m_prefix;
 
 private:
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   //! Defines the options for the Metropolis-Hastings generator of samples as the default options.
   void   defineMyOptions  (boost::program_options::options_description& optionsDesc) const;
 
   //! Gets the sequence options defined to the  Metropolis-Hastings algorithm.
   void   getMyOptionValues(boost::program_options::options_description& optionsDesc);
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   const BaseEnvironment& m_env;
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   ScopedPtr<boost::program_options::options_description>::Type m_optionsDesc;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   std::string                   m_option_help;
 

--- a/src/stats/inc/MonteCarloSGOptions.h
+++ b/src/stats/inc/MonteCarloSGOptions.h
@@ -28,9 +28,9 @@
 #include <queso/Environment.h>
 #include <queso/SequenceStatisticalOptions.h>
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <queso/BoostInputOptionsParser.h>
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 #define UQ_MOC_SG_FILENAME_FOR_NO_FILE "."
 
@@ -56,7 +56,7 @@
 #define UQ_MOC_SG_QSEQ_DATA_OUTPUT_ALLOWED_SET_ODV ""
 #define UQ_MOC_SG_QSEQ_COMPUTE_STATS_ODV           0
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 namespace boost {
   namespace program_options {
     class options_description;
@@ -140,9 +140,9 @@ public:
 #endif
 
 private:
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   BoostInputOptionsParser * m_parser;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   std::string                   m_option_help;
   std::string                   m_option_dataOutputFileName;
@@ -231,7 +231,7 @@ public:
   std::string                        m_prefix;
 
 private:
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   //! Defines the options for the Monte Carlo sequence generator as the default options.
   void   defineMyOptions  (boost::program_options::options_description& optionsDesc) const;
 
@@ -240,7 +240,7 @@ private:
 #endif
 
   const BaseEnvironment& m_env;
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   boost::program_options::options_description*      m_optionsDesc;
 #endif
 

--- a/src/stats/inc/StatisticalForwardProblemOptions.h
+++ b/src/stats/inc/StatisticalForwardProblemOptions.h
@@ -22,9 +22,10 @@
 //
 //-----------------------------------------------------------------------el-
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#include <queso/config_queso.h>
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <queso/BoostInputOptionsParser.h>
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 #include <queso/Environment.h>
 
@@ -46,13 +47,13 @@
 #define UQ_SFP_SOLVER_ODV                  "mc" // Monte Carlo
 #endif
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 namespace boost {
   namespace program_options {
     class options_description;
   }
 }
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 namespace QUESO {
 
@@ -107,9 +108,9 @@ public:
   //McOptionsValues m_mcOptionsValues;
 
 private:
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   BoostInputOptionsParser * m_parser;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   // The input options as strings so we can parse the input file later
   std::string                   m_option_help;
@@ -172,19 +173,19 @@ public:
   std::string                   m_prefix;
 
 private:
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   //! Define my SFP options as the default options.
   void   defineMyOptions  (boost::program_options::options_description& optionsDesc) const;
 
   //! Gets the option values of the SFP.
   void   getMyOptionValues(boost::program_options::options_description& optionsDesc);
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   const BaseEnvironment& m_env;
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   boost::program_options::options_description*      m_optionsDesc;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   std::string                   m_option_help;
   std::string                   m_option_computeSolution;
   std::string                   m_option_computeCovariances;

--- a/src/stats/inc/StatisticalInverseProblemOptions.h
+++ b/src/stats/inc/StatisticalInverseProblemOptions.h
@@ -22,9 +22,10 @@
 //
 //-----------------------------------------------------------------------el-
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#include <queso/config_queso.h>
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <queso/BoostInputOptionsParser.h>
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 #include <queso/Environment.h>
 
@@ -47,13 +48,13 @@
 #define UQ_SIP_SEEDWITHMAPESTIMATOR 0
 #define UQ_SIP_USEOPTIMIZERMONITOR 1
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 namespace boost {
   namespace program_options {
     class options_description;
   }
 }
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 namespace QUESO {
 
@@ -111,9 +112,9 @@ public:
   bool m_useOptimizerMonitor;
 
 private:
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   ScopedPtr<BoostInputOptionsParser>::Type m_parser;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   // The input options as strings so we can parse the input file later
   std::string                   m_option_help;
@@ -175,18 +176,18 @@ public:
   std::string                   m_prefix;
 
 private:
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   //! Define my SIP options as the default options.
   void   defineMyOptions  (boost::program_options::options_description& optionsDesc) const;
   //! Gets the option values of the SIP.
   void   getMyOptionValues(boost::program_options::options_description& optionsDesc);
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   const BaseEnvironment& m_env;
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   ScopedPtr<boost::program_options::options_description>::Type m_optionsDesc;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   std::string                   m_option_help;
   std::string                   m_option_computeSolution;

--- a/src/stats/src/MLSamplingLevelOptions.C
+++ b/src/stats/src/MLSamplingLevelOptions.C
@@ -22,6 +22,7 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/config_queso.h>
 #include <queso/MLSamplingLevelOptions.h>
 #include <queso/Miscellaneous.h>
 
@@ -111,9 +112,9 @@ MLSamplingLevelOptions::MLSamplingLevelOptions(
     m_amEta                                    (UQ_ML_SAMPLING_L_AM_ETA_ODV),
     m_amEpsilon                                (UQ_ML_SAMPLING_L_AM_EPSILON_ODV),
     m_env                                      (env),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_parser(new BoostInputOptionsParser(env.optionsInputFileName())),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_option_help                                      (m_prefix + "help"                                      ),
 #ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY
 #else
@@ -186,10 +187,10 @@ MLSamplingLevelOptions::MLSamplingLevelOptions(
     m_option_tk                                        (m_prefix + "tk"                                        ),
     m_option_updateInterval                            (m_prefix + "updateInterval"                            )
 {
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   this->defineAllOptions();
   m_parser->scanInputFile();
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   this->getAllOptions();
 
   checkOptions(&env);
@@ -198,7 +199,7 @@ MLSamplingLevelOptions::MLSamplingLevelOptions(
 void
 MLSamplingLevelOptions::defineAllOptions()
 {
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_parser->registerOption<std::string >(m_option_help,                                       UQ_ML_SAMPLING_L_HELP                      , "produce help message for Bayesian Markov chain distr. calculator");
 #ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY
 #else
@@ -270,13 +271,13 @@ MLSamplingLevelOptions::defineAllOptions()
   m_parser->registerOption<std::string >(m_option_algorithm,                                  UQ_ML_SAMPLING_L_ALGORITHM                 , "which algorithm to use for sampling"                             );
   m_parser->registerOption<std::string >(m_option_tk,                                         UQ_ML_SAMPLING_L_TK                        , "which transition kernel to use for sampling"                     );
   m_parser->registerOption<unsigned int>(m_option_updateInterval,                             UQ_ML_SAMPLING_L_UPDATE_INTERVAL           , "how often to call TK's updateTK method"                          );
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 }
 
 void
 MLSamplingLevelOptions::getAllOptions()
 {
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_parser->getOption<std::string >(m_option_help,                                       m_help);
 #ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY
 #else
@@ -481,7 +482,7 @@ MLSamplingLevelOptions::getAllOptions()
   m_algorithm                                 = m_env.input()(m_option_algorithm,                                  UQ_ML_SAMPLING_L_ALGORITHM                 );
   m_tk                                        = m_env.input()(m_option_tk,                                         UQ_ML_SAMPLING_L_TK                        );
   m_updateInterval                            = m_env.input()(m_option_updateInterval,                             UQ_ML_SAMPLING_L_UPDATE_INTERVAL           );
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 }
 
 void
@@ -594,7 +595,7 @@ MLSamplingLevelOptions::scanOptionsValues(const MLSamplingLevelOptions* defaultO
   // FIXME
   if (defaultOptions) this->copyOptionsValues(*defaultOptions);
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   // Replace the parser since default values changed
   if (m_parser) {
     delete m_parser;
@@ -604,7 +605,7 @@ MLSamplingLevelOptions::scanOptionsValues(const MLSamplingLevelOptions* defaultO
   // FIXME: Does this work with GetPot?
   this->defineAllOptions();
   m_parser->scanInputFile();
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   this->getAllOptions();
 
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
@@ -840,9 +841,9 @@ MLSamplingLevelOptions::env() const
 
 std::ostream& operator<<(std::ostream& os, const MLSamplingLevelOptions& obj)
 {
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   os << (*(obj.m_parser)) << std::endl;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   obj.print(os);
   return os;
 }

--- a/src/stats/src/MLSamplingOptions.C
+++ b/src/stats/src/MLSamplingOptions.C
@@ -22,6 +22,7 @@
 //
 //-----------------------------------------------------------------------el-
 
+#include <queso/config_queso.h>
 #include <queso/MLSamplingOptions.h>
 #include <queso/Miscellaneous.h>
 
@@ -45,9 +46,9 @@ MLSamplingOptions::MLSamplingOptions(const BaseEnvironment& env, const char* pre
     m_dataOutputFileName                   (UQ_ML_SAMPLING_DATA_OUTPUT_FILE_NAME_ODV  ),
   //m_dataOutputAllowedSet                 (),
     m_env                                  (env),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_parser(new BoostInputOptionsParser(env.optionsInputFileName())),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_option_help                          (m_prefix + "help"                          ),
 #ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY
     m_option_restartOutput_levelPeriod     (m_prefix + "restartOutput_levelPeriod"     ),
@@ -63,7 +64,7 @@ MLSamplingOptions::MLSamplingOptions(const BaseEnvironment& env, const char* pre
     m_option_dataOutputFileName            (m_prefix + "dataOutputFileName"  ),
     m_option_dataOutputAllowedSet          (m_prefix + "dataOutputAllowedSet")
 {
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_parser->registerOption<std::string >(m_option_help,                           UQ_ML_SAMPLING_HELP,                                   "produce help msg for ML sampling options"      );
 #ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY
   m_parser->registerOption<unsigned int>(m_option_restartOutput_levelPeriod,      UQ_ML_SAMPLING_RESTART_OUTPUT_LEVEL_PERIOD_ODV,        "restartOutput_levelPeriod"                     );
@@ -120,7 +121,7 @@ MLSamplingOptions::MLSamplingOptions(const BaseEnvironment& env, const char* pre
     m_dataOutputAllowedSet.insert(allowed);
   }
 
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   checkOptions(&env);
 }
@@ -171,9 +172,9 @@ MLSamplingOptions::print(std::ostream& os) const
 
 std::ostream& operator<<(std::ostream& os, const MLSamplingOptions& obj)
 {
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   os << (*(obj.m_parser)) << std::endl;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   obj.print(os);
   return os;

--- a/src/stats/src/MetropolisHastingsSGOptions.C
+++ b/src/stats/src/MetropolisHastingsSGOptions.C
@@ -24,11 +24,11 @@
 
 #include <queso/Environment.h>
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
 #else
 #include <queso/getpot.h>
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 #include <queso/MetropolisHastingsSGOptions.h>
 #include <queso/Miscellaneous.h>
@@ -112,9 +112,9 @@ MhOptionsValues::MhOptionsValues(
     m_alternativeFilteredSsOptionsValues       (),
 #endif
     m_env(NULL),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_parser(),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_option_help                                      (m_prefix + "help"                                      ),
     m_option_dataOutputFileName                        (m_prefix + "dataOutputFileName"                        ),
     m_option_dataOutputAllowAll                        (m_prefix + "dataOutputAllowAll"                        ),
@@ -255,9 +255,9 @@ MhOptionsValues::MhOptionsValues(
     m_alternativeFilteredSsOptionsValues       (),
 #endif
     m_env(env),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_parser(new BoostInputOptionsParser(env->optionsInputFileName())),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_option_help                                      (m_prefix + "help"                                      ),
     m_option_dataOutputFileName                        (m_prefix + "dataOutputFileName"                        ),
     m_option_dataOutputAllowAll                        (m_prefix + "dataOutputAllowAll"                        ),
@@ -323,7 +323,7 @@ MhOptionsValues::MhOptionsValues(
   if (alternativeFilteredSsOptionsValues) m_alternativeFilteredSsOptionsValues = *alternativeFilteredSsOptionsValues;
 #endif
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_parser->registerOption<std::string >(m_option_help,                                       UQ_MH_SG_HELP,                                                 "produce help msg for Bayesian Metropolis-Hastings"          );
   m_parser->registerOption<std::string >(m_option_dataOutputFileName,                         UQ_MH_SG_DATA_OUTPUT_FILE_NAME_ODV                           , "name of generic output file"                                );
   m_parser->registerOption<bool        >(m_option_dataOutputAllowAll,                         UQ_MH_SG_DATA_OUTPUT_ALLOW_ALL_ODV                           , "allow all subEnvs write to a generic output file"           );
@@ -560,7 +560,7 @@ MhOptionsValues::MhOptionsValues(
   m_algorithm = m_env->input()(m_option_algorithm, UQ_MH_SG_ALGORITHM);
   m_tk = m_env->input()(m_option_tk, UQ_MH_SG_TK);
   m_updateInterval = m_env->input()(m_option_updateInterval, UQ_MH_SG_UPDATE_INTERVAL);
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   checkOptions(env);
 }
@@ -742,9 +742,9 @@ MhOptionsValues::copy(const MhOptionsValues& src)
 
 std::ostream & operator<<(std::ostream & os, const MhOptionsValues & obj)
 {
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   os << (*(obj.m_parser)) << std::endl;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   os <<         obj.m_option_dataOutputFileName                         << " = " << obj.m_dataOutputFileName
      << "\n" << obj.m_option_dataOutputAllowAll                         << " = " << obj.m_dataOutputAllowAll
@@ -849,9 +849,9 @@ MetropolisHastingsSGOptions::MetropolisHastingsSGOptions(
 #endif
   m_prefix                                           ((std::string)(prefix) + "mh_"),
   m_env                                              (env),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_optionsDesc                                      (new boost::program_options::options_description("Bayesian Metropolis-Hastings options")),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_option_help                                      (m_prefix + "help"                                      ),
   m_option_dataOutputFileName                        (m_prefix + "dataOutputFileName"                        ),
   m_option_dataOutputAllowAll                        (m_prefix + "dataOutputAllowAll"                        ),
@@ -931,9 +931,9 @@ MetropolisHastingsSGOptions::MetropolisHastingsSGOptions(
 #endif
   m_prefix                                           ((std::string)(prefix) + "mh_"),
   m_env                                              (env),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_optionsDesc                                      (),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_option_help                                      (m_prefix + "help"                                      ),
   m_option_dataOutputFileName                        (m_prefix + "dataOutputFileName"                        ),
   m_option_dataOutputAllowAll                        (m_prefix + "dataOutputAllowAll"                        ),
@@ -1033,9 +1033,9 @@ MetropolisHastingsSGOptions::MetropolisHastingsSGOptions(
 #endif
   m_prefix                                           (mlOptions.m_prefix),
   m_env                                              (mlOptions.env()),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_optionsDesc                                      (),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_option_help                                      (m_prefix + "help"                                      ),
   m_option_dataOutputFileName                        (m_prefix + "dataOutputFileName"                        ),
   m_option_dataOutputAllowAll                        (m_prefix + "dataOutputAllowAll"                        ),
@@ -1194,13 +1194,13 @@ MetropolisHastingsSGOptions::scanOptionsValues()
 {
   queso_deprecated();
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   queso_require_msg(m_optionsDesc, "m_optionsDesc variable is NULL");
 
   defineMyOptions                (*m_optionsDesc);
   m_env.scanInputFileForMyOptions(*m_optionsDesc);
   getMyOptionValues              (*m_optionsDesc);
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   if ((m_env.subDisplayFile() != NULL) &&
       (m_ov.m_totallyMute == false   )) {
@@ -1313,7 +1313,7 @@ MetropolisHastingsSGOptions::print(std::ostream& os) const
   return;
 }
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 // Private methods----------------------------------
 void
 MetropolisHastingsSGOptions::defineMyOptions(boost::program_options::options_description& optionsDesc) const
@@ -1384,9 +1384,9 @@ MetropolisHastingsSGOptions::defineMyOptions(boost::program_options::options_des
 
   return;
 }
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 // -------------------------------------------------
 void
 MetropolisHastingsSGOptions::getMyOptionValues(boost::program_options::options_description& optionsDesc)
@@ -1711,7 +1711,7 @@ MetropolisHastingsSGOptions::getMyOptionValues(boost::program_options::options_d
     m_ov.m_updateInterval = ((const boost::program_options::variable_value&) m_env.allOptionsMap()[m_option_updateInterval]).as<unsigned int>();
   }
 }
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 // --------------------------------------------------
 // Operator declared outside class definition ------

--- a/src/stats/src/MonteCarloSGOptions.C
+++ b/src/stats/src/MonteCarloSGOptions.C
@@ -24,11 +24,11 @@
 
 #include <queso/Defines.h>
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
 #else
 #include <queso/getpot.h>
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 #include <queso/MonteCarloSGOptions.h>
 #include <queso/Miscellaneous.h>
@@ -72,9 +72,9 @@ McOptionsValues::McOptionsValues(
     m_alternativePSsOptionsValues(),
     m_alternativeQSsOptionsValues(),
 #endif
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_parser(NULL),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_option_help                     (m_prefix + "help"                       ),
     m_option_dataOutputFileName       (m_prefix + "dataOutputFileName"         ),
     m_option_dataOutputAllowedSet     (m_prefix + "dataOutputAllowedSet"       ),
@@ -138,9 +138,9 @@ McOptionsValues::McOptionsValues(
     m_alternativePSsOptionsValues(),
     m_alternativeQSsOptionsValues(),
 #endif
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_parser(new BoostInputOptionsParser(env->optionsInputFileName())),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_option_help                     (m_prefix + "help"                       ),
     m_option_dataOutputFileName       (m_prefix + "dataOutputFileName"         ),
     m_option_dataOutputAllowedSet     (m_prefix + "dataOutputAllowedSet"       ),
@@ -170,7 +170,7 @@ McOptionsValues::McOptionsValues(
   if (alternativeQSsOptionsValues) m_alternativeQSsOptionsValues = *alternativeQSsOptionsValues;
 #endif
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_parser->registerOption<std::string >(m_option_help,                      UQ_MOC_SG_HELP                            , "produce help message for Monte Carlo distribution calculator");
   m_parser->registerOption<std::string >(m_option_dataOutputFileName,        UQ_MOC_SG_DATA_OUTPUT_FILE_NAME_ODV       , "name of generic data output file"                            );
   m_parser->registerOption<std::string >(m_option_dataOutputAllowedSet,      UQ_MOC_SG_DATA_OUTPUT_ALLOWED_SET_ODV     , "subEnvs that will write to generic data output file"         );
@@ -268,7 +268,7 @@ McOptionsValues::McOptionsValues(
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
   m_qseq_computeStats = env->input()(m_option_qseq_computeStats, UQ_MOC_SG_QSEQ_COMPUTE_STATS_ODV);
 #endif
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 }
 
 // Copy constructor --------------------------------
@@ -329,9 +329,9 @@ McOptionsValues::copy(const McOptionsValues& src)
 
 std::ostream & operator<<(std::ostream & os, const McOptionsValues & obj)
 {
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   os << (*(obj.m_parser)) << std::endl;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   os <<         obj.m_option_dataOutputFileName   << " = " << obj.m_dataOutputFileName
      << "\n" << obj.m_option_dataOutputAllowedSet << " = ";
@@ -386,9 +386,9 @@ MonteCarloSGOptions::MonteCarloSGOptions(
 #endif
   m_prefix                          ((std::string)(prefix) + "mc_"),
   m_env                             (env),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_optionsDesc                     (new boost::program_options::options_description("Monte Carlo options")),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_option_help                     (m_prefix + "help"                       ),
   m_option_dataOutputFileName       (m_prefix + "dataOutputFileName"         ),
   m_option_dataOutputAllowedSet     (m_prefix + "dataOutputAllowedSet"       ),
@@ -429,9 +429,9 @@ MonteCarloSGOptions::MonteCarloSGOptions(
 #endif
   m_prefix                          ((std::string)(prefix) + "mc_"),
   m_env                             (env),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_optionsDesc                     (NULL),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_option_help                     (m_prefix + "help"                     ),
   m_option_dataOutputFileName       (m_prefix + "dataOutputFileName"       ),
   m_option_dataOutputAllowedSet     (m_prefix + "dataOutputAllowedSet"     ),
@@ -484,9 +484,9 @@ MonteCarloSGOptions::~MonteCarloSGOptions()
   if (m_pseqStatisticalOptionsObj) delete m_pseqStatisticalOptionsObj; // dakota
   if (m_qseqStatisticalOptionsObj) delete m_qseqStatisticalOptionsObj; // dakota
 #endif
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   if (m_optionsDesc              ) delete m_optionsDesc;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 }
 // I/O methods -------------------------------------
 void
@@ -494,13 +494,13 @@ MonteCarloSGOptions::scanOptionsValues()
 {
   queso_deprecated();
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   queso_require_msg(m_optionsDesc, "m_optionsDesc variable is NULL");
 
   defineMyOptions                (*m_optionsDesc);
   m_env.scanInputFileForMyOptions(*m_optionsDesc);
   getMyOptionValues              (*m_optionsDesc);
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   if (m_env.subDisplayFile() != NULL) {
     *m_env.subDisplayFile() << "In MonteCarloSGOptions::scanOptionsValues()"
@@ -520,7 +520,7 @@ MonteCarloSGOptions::scanOptionsValues()
   return;
 }
 // Private methods ---------------------------------
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 void
 MonteCarloSGOptions::defineMyOptions(boost::program_options::options_description& optionsDesc) const
 {
@@ -665,7 +665,7 @@ MonteCarloSGOptions::getMyOptionValues(boost::program_options::options_descripti
 #endif
   return;
 }
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 void
 MonteCarloSGOptions::print(std::ostream& os) const

--- a/src/stats/src/StatisticalForwardProblemOptions.C
+++ b/src/stats/src/StatisticalForwardProblemOptions.C
@@ -24,7 +24,7 @@
 
 #include <queso/Defines.h>
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
 #else
 #include <queso/getpot.h>
@@ -49,9 +49,9 @@ SfpOptionsValues::SfpOptionsValues()
     m_computeCorrelations (UQ_SFP_COMPUTE_CORRELATIONS_ODV ),
     m_dataOutputFileName  (UQ_SFP_DATA_OUTPUT_FILE_NAME_ODV),
     //m_dataOutputAllowedSet(),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_parser(NULL),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_option_help                (m_prefix + "help"                ),
     m_option_computeSolution     (m_prefix + "computeSolution"     ),
     m_option_computeCovariances  (m_prefix + "computeCovariances"  ),
@@ -75,9 +75,9 @@ SfpOptionsValues::SfpOptionsValues(const BaseEnvironment * env, const char *
     m_computeCorrelations (UQ_SFP_COMPUTE_CORRELATIONS_ODV ),
     m_dataOutputFileName  (UQ_SFP_DATA_OUTPUT_FILE_NAME_ODV),
     //m_dataOutputAllowedSet(),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_parser(new BoostInputOptionsParser(env->optionsInputFileName())),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
     m_option_help                (m_prefix + "help"                ),
     m_option_computeSolution     (m_prefix + "computeSolution"     ),
     m_option_computeCovariances  (m_prefix + "computeCovariances"  ),
@@ -89,7 +89,7 @@ SfpOptionsValues::SfpOptionsValues(const BaseEnvironment * env, const char *
     m_solverString        (UQ_SFP_SOLVER_ODV               )
 #endif
 {
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_parser->registerOption<std::string>(m_option_help,                 UQ_SFP_HELP,                        "produce help message for statistical forward problem");
   m_parser->registerOption<bool       >(m_option_computeSolution,      UQ_SFP_COMPUTE_SOLUTION_ODV       , "compute solution process"                            );
   m_parser->registerOption<bool       >(m_option_computeCovariances,   UQ_SFP_COMPUTE_COVARIANCES_ODV    , "compute pq covariances"                              );
@@ -130,7 +130,7 @@ SfpOptionsValues::SfpOptionsValues(const BaseEnvironment * env, const char *
 #ifdef UQ_SFP_READS_SOLVER_OPTION
   m_solver = env->input()(m_option_solver, UQ_SFP_SOLVER_ODV);
 #endif
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   checkOptions();
 }
@@ -179,9 +179,9 @@ SfpOptionsValues::copy(const SfpOptionsValues& src)
 std::ostream &
 operator<<(std::ostream & os, const SfpOptionsValues & obj)
 {
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   os << (*(obj.m_parser)) << std::endl;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   os <<         obj.m_option_computeSolution      << " = " << obj.m_computeSolution
      << "\n" << obj.m_option_computeCovariances   << " = " << obj.m_computeCovariances
@@ -210,9 +210,9 @@ StatisticalForwardProblemOptions::StatisticalForwardProblemOptions(
   m_ov                         (),
   m_prefix                     ((std::string)(prefix) + "fp_"   ),
   m_env                        (env),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_optionsDesc                (new boost::program_options::options_description("Statistical Forward Problem options")),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_option_help                (m_prefix + "help"                ),
   m_option_computeSolution     (m_prefix + "computeSolution"     ),
   m_option_computeCovariances  (m_prefix + "computeCovariances"  ),
@@ -236,9 +236,9 @@ StatisticalForwardProblemOptions::StatisticalForwardProblemOptions(
   m_ov                         (alternativeOptionsValues         ),
   m_prefix                     ((std::string)(prefix) + "fp_"    ),
   m_env                        (env),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_optionsDesc                (NULL),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_option_help                (m_prefix + "help"                ),
   m_option_computeSolution     (m_prefix + "computeSolution"     ),
   m_option_computeCovariances  (m_prefix + "computeCovariances"  ),
@@ -266,9 +266,9 @@ StatisticalForwardProblemOptions::~StatisticalForwardProblemOptions()
 {
   queso_deprecated();
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   if (m_optionsDesc) delete m_optionsDesc;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 }
 
 // I/O methods -------------------------------------
@@ -277,13 +277,13 @@ StatisticalForwardProblemOptions::scanOptionsValues()
 {
   queso_deprecated();
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   queso_require_msg(m_optionsDesc, "m_optionsDesc variable is NULL");
 
   defineMyOptions                (*m_optionsDesc);
   m_env.scanInputFileForMyOptions(*m_optionsDesc);
   getMyOptionValues              (*m_optionsDesc);
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   if (m_env.subDisplayFile() != NULL) {
     *m_env.subDisplayFile() << "In StatisticalForwardProblemOptions::scanOptionsValues()"
@@ -317,7 +317,7 @@ StatisticalForwardProblemOptions::print(std::ostream& os) const
   return;
 }
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 // Private methods ---------------------------------
 void
 StatisticalForwardProblemOptions::defineMyOptions(boost::program_options::options_description& optionsDesc) const
@@ -338,9 +338,9 @@ StatisticalForwardProblemOptions::defineMyOptions(boost::program_options::option
 
   return;
 }
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 //--------------------------------------------------
 void
 StatisticalForwardProblemOptions::getMyOptionValues(boost::program_options::options_description& optionsDesc)
@@ -391,7 +391,7 @@ StatisticalForwardProblemOptions::getMyOptionValues(boost::program_options::opti
 
   return;
 }
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 // --------------------------------------------------
 // Operator declared outside class definition ------

--- a/src/stats/src/StatisticalInverseProblemOptions.C
+++ b/src/stats/src/StatisticalInverseProblemOptions.C
@@ -24,11 +24,11 @@
 
 #include <queso/Defines.h>
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
 #else
 #include <queso/getpot.h>
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 #include <queso/StatisticalInverseProblemOptions.h>
 #include <queso/Miscellaneous.h>
@@ -49,9 +49,9 @@ SipOptionsValues::SipOptionsValues()
   m_seedWithMAPEstimator(UQ_SIP_SEEDWITHMAPESTIMATOR),
   m_useOptimizerMonitor(UQ_SIP_USEOPTIMIZERMONITOR),
 //m_dataOutputAllowedSet(),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_parser(),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_option_help                (m_prefix + "help"                ),
   m_option_computeSolution     (m_prefix + "computeSolution"     ),
   m_option_dataOutputFileName  (m_prefix + "dataOutputFileName"  ),
@@ -75,9 +75,9 @@ SipOptionsValues::SipOptionsValues(const BaseEnvironment * env, const char *
   m_seedWithMAPEstimator(UQ_SIP_SEEDWITHMAPESTIMATOR),
   m_useOptimizerMonitor(UQ_SIP_USEOPTIMIZERMONITOR),
 //m_dataOutputAllowedSet(),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_parser(new BoostInputOptionsParser(env->optionsInputFileName())),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_option_help                (m_prefix + "help"                ),
   m_option_computeSolution     (m_prefix + "computeSolution"     ),
   m_option_dataOutputFileName  (m_prefix + "dataOutputFileName"  ),
@@ -89,7 +89,7 @@ SipOptionsValues::SipOptionsValues(const BaseEnvironment * env, const char *
   m_option_seedWithMAPEstimator(m_prefix + "seedWithMAPEstimator"),
   m_option_useOptimizerMonitor(m_prefix + "useOptimizerMonitor")
 {
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_parser->registerOption<std::string>(m_option_help, UQ_SIP_HELP, "produce help message for statistical inverse problem");
   m_parser->registerOption<bool       >(m_option_computeSolution,      UQ_SIP_COMPUTE_SOLUTION_ODV       , "compute solution process"                            );
   m_parser->registerOption<std::string>(m_option_dataOutputFileName,   UQ_SIP_DATA_OUTPUT_FILE_NAME_ODV  , "name of data output file"                            );
@@ -130,7 +130,7 @@ SipOptionsValues::SipOptionsValues(const BaseEnvironment * env, const char *
 #endif
   m_seedWithMAPEstimator = env->input()(m_option_seedWithMAPEstimator, UQ_SIP_SEEDWITHMAPESTIMATOR);
   m_useOptimizerMonitor = env->input()(m_option_useOptimizerMonitor,  UQ_SIP_USEOPTIMIZERMONITOR);
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   checkOptions();
 }
@@ -199,9 +199,9 @@ StatisticalInverseProblemOptions::StatisticalInverseProblemOptions(
   m_ov                         (),
   m_prefix                     ((std::string)(prefix) + "ip_"),
   m_env                        (env),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_optionsDesc                (new boost::program_options::options_description("Statistical Inverse Problem options")),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_option_help                (m_prefix + "help"                ),
   m_option_computeSolution     (m_prefix + "computeSolution"     ),
   m_option_dataOutputFileName  (m_prefix + "dataOutputFileName"  ),
@@ -225,9 +225,9 @@ StatisticalInverseProblemOptions::StatisticalInverseProblemOptions(
   m_ov                         (alternativeOptionsValues),
   m_prefix                     ((std::string)(prefix) + "ip_"),
   m_env                        (env),
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_optionsDesc                (),
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   m_option_help                (m_prefix + "help"                ),
   m_option_computeSolution     (m_prefix + "computeSolution"     ),
   m_option_dataOutputFileName  (m_prefix + "dataOutputFileName"  ),
@@ -260,13 +260,13 @@ StatisticalInverseProblemOptions::~StatisticalInverseProblemOptions()
 void
 StatisticalInverseProblemOptions::scanOptionsValues()
 {
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   queso_require_msg(m_optionsDesc, "m_optionsDesc variable is NULL");
 
   defineMyOptions                (*m_optionsDesc);
   m_env.scanInputFileForMyOptions(*m_optionsDesc);
   getMyOptionValues              (*m_optionsDesc);
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   if (m_env.subDisplayFile() != NULL) {
     *m_env.subDisplayFile() << "In StatisticalInverseProblemOptions::scanOptionsValues()"
@@ -301,7 +301,7 @@ StatisticalInverseProblemOptions::print(std::ostream& os) const
   return;
 }
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 void
 StatisticalInverseProblemOptions::defineMyOptions(boost::program_options::options_description& optionsDesc) const
 {
@@ -319,9 +319,9 @@ StatisticalInverseProblemOptions::defineMyOptions(boost::program_options::option
     (m_option_useOptimizerMonitor.c_str(), boost::program_options::value<bool>()->default_value(UQ_SIP_USEOPTIMIZERMONITOR), "toggle printing of optimisation progress when seed with MAP estimator")
   ;
 }
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 //--------------------------------------------------
 void
 StatisticalInverseProblemOptions::getMyOptionValues(boost::program_options::options_description& optionsDesc)
@@ -370,7 +370,7 @@ StatisticalInverseProblemOptions::getMyOptionValues(boost::program_options::opti
     m_ov.m_useOptimizerMonitor = ((const boost::program_options::variable_value&) m_env.allOptionsMap()[m_option_useOptimizerMonitor]).as<bool>();
   }
 }
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 // --------------------------------------------------
 // Operator declared outside class definition ------

--- a/test/test_InputOptionsParser/test_BoostInputOptionsParser.C
+++ b/test/test_InputOptionsParser/test_BoostInputOptionsParser.C
@@ -1,4 +1,5 @@
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#include <queso/config_queso.h>
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <queso/asserts.h>
 #include <queso/BoostInputOptionsParser.h>
 
@@ -147,11 +148,11 @@ void test_empty()
   queso_require_equal_to(optionsValues.m_set_unsigned_int.empty(), true);
   queso_require_equal_to(optionsValues.m_vector_double.empty(), true);
 }
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 int main(int argc, char ** argv)
 {
-#ifndef DISABLE_BOOST_PROGRAM_OPTIONS
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   test_default();
   test_good();
   test_empty();
@@ -159,5 +160,5 @@ int main(int argc, char ** argv)
   return 0;
 #else
   return 77;
-#endif  // DISABLE_BOOST_PROGRAM_OPTIONS
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 }


### PR DESCRIPTION
So that when the user installs it, it's in config_queso.h for them and
they won't need to explicitly pass it when compiling their statistical
application.

Also add #include <queso/config_queso.h> wherever I have a file that
needs that macro.

Fixes #582.