### PR TITLE
Make QUESO define GETPOT_NAMESPACE only if needed

### DIFF
--- a/src/basic/src/ScalarFunction.C
+++ b/src/basic/src/ScalarFunction.C
@@ -32,7 +32,9 @@
 #ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <queso/BoostInputOptionsParser.h>
 #else
+#define GETPOT_NAMESPACE QUESO // So we don't clash with other getpots
 #include <queso/getpot.h>
+#undef GETPOT_NAMESPACE
 #endif
 
 #include <cstdlib>

--- a/src/core/inc/Defines.h
+++ b/src/core/inc/Defines.h
@@ -54,9 +54,6 @@
 // Use GSL inline functions
 #define HAVE_INLINE
 
-// So we don't clash with other getpots
-#define GETPOT_NAMESPACE QUESO
-
 // And only do GSL range-checking if we're really debugging
 #ifndef DEBUG
 #define GSL_RANGE_CHECK_OFF

--- a/src/core/inc/InfiniteDimensionalMCMCSamplerOptions.h
+++ b/src/core/inc/InfiniteDimensionalMCMCSamplerOptions.h
@@ -29,7 +29,9 @@
 #ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <queso/BoostInputOptionsParser.h>
 #else
+#define GETPOT_NAMESPACE QUESO // So we don't clash with other getpots
 #include <queso/getpot.h>
+#undef GETPOT_NAMESPACE
 #endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 namespace QUESO {

--- a/src/core/src/Environment.C
+++ b/src/core/src/Environment.C
@@ -28,7 +28,9 @@
 #include <boost/program_options.hpp>
 #endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
+#define GETPOT_NAMESPACE QUESO // So we don't clash with other getpots
 #include <queso/getpot.h>
+#undef GETPOT_NAMESPACE
 
 #include <queso/config_queso.h>
 #include <queso/EnvironmentOptions.h>

--- a/src/core/src/EnvironmentOptions.C
+++ b/src/core/src/EnvironmentOptions.C
@@ -27,7 +27,9 @@
 #ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
 #else
+#define GETPOT_NAMESPACE QUESO // So we don't clash with other getpots
 #include <queso/getpot.h>
+#undef GETPOT_NAMESPACE
 #endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 #include <queso/EnvironmentOptions.h>

--- a/src/core/src/OptimizerOptions.C
+++ b/src/core/src/OptimizerOptions.C
@@ -28,7 +28,9 @@
 #ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <queso/BoostInputOptionsParser.h>
 #else
+#define GETPOT_NAMESPACE QUESO // So we don't clash with other getpots
 #include <queso/getpot.h>
+#undef GETPOT_NAMESPACE
 #endif
 
 #include <queso/OptimizerOptions.h>

--- a/src/gp/src/GPMSAOptions.C
+++ b/src/gp/src/GPMSAOptions.C
@@ -27,7 +27,9 @@
 #ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
 #else
+#define GETPOT_NAMESPACE QUESO // So we don't clash with other getpots
 #include <queso/getpot.h>
+#undef GETPOT_NAMESPACE
 #endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 #include <queso/GPMSAOptions.h>

--- a/src/stats/inc/MLSamplingLevelOptions.h
+++ b/src/stats/inc/MLSamplingLevelOptions.h
@@ -33,7 +33,9 @@
 #ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <queso/BoostInputOptionsParser.h>
 #else
+#define GETPOT_NAMESPACE QUESO // So we don't clash with other getpots
 #include <queso/getpot.h>
+#undef GETPOT_NAMESPACE
 #endif
 
 #define UQ_ML_SAMPLING_L_FILENAME_FOR_NO_FILE "."

--- a/src/stats/src/MetropolisHastingsSGOptions.C
+++ b/src/stats/src/MetropolisHastingsSGOptions.C
@@ -27,7 +27,9 @@
 #ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
 #else
+#define GETPOT_NAMESPACE QUESO // So we don't clash with other getpots
 #include <queso/getpot.h>
+#undef GETPOT_NAMESPACE
 #endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 #include <queso/MetropolisHastingsSGOptions.h>

--- a/src/stats/src/MonteCarloSGOptions.C
+++ b/src/stats/src/MonteCarloSGOptions.C
@@ -27,7 +27,9 @@
 #ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
 #else
+#define GETPOT_NAMESPACE QUESO // So we don't clash with other getpots
 #include <queso/getpot.h>
+#undef GETPOT_NAMESPACE
 #endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 #include <queso/MonteCarloSGOptions.h>

--- a/src/stats/src/StatisticalForwardProblemOptions.C
+++ b/src/stats/src/StatisticalForwardProblemOptions.C
@@ -27,7 +27,9 @@
 #ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
 #else
+#define GETPOT_NAMESPACE QUESO // So we don't clash with other getpots
 #include <queso/getpot.h>
+#undef GETPOT_NAMESPACE
 #endif
 
 #include <queso/StatisticalForwardProblemOptions.h>

--- a/src/stats/src/StatisticalInverseProblemOptions.C
+++ b/src/stats/src/StatisticalInverseProblemOptions.C
@@ -27,7 +27,9 @@
 #ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 #include <boost/program_options.hpp>
 #else
+#define GETPOT_NAMESPACE QUESO // So we don't clash with other getpots
 #include <queso/getpot.h>
+#undef GETPOT_NAMESPACE
 #endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
 #include <queso/StatisticalInverseProblemOptions.h>


### PR DESCRIPTION
And `#undef` when we're done with the #include.

@pbauman You should do this in `GRINS` too.  You don't do this in `GRINS` header files, and hence the getpot clash.  From the grins top-level directory:

```
$ git grep -l "#include \"libmesh/getpot\.h\"" | wc -l
139
```

Libmesh doesn't ever include getpot in their headers, so they don't need it.  I just did it everywhere, including in implementation files, just to be explicit.