### PR TITLE
Use GammaRV prior for truncation_error_precision

### DIFF
--- a/src/gp/inc/GPMSA.h
+++ b/src/gp/inc/GPMSA.h
@@ -382,6 +382,7 @@ public:
   typename ScopedPtr<VectorSpace<V, M> >::Type oneDSpace;
 
   // Truncation error precision
+  typename ScopedPtr<VectorSpace<V, M> >::Type truncationErrorPrecisionSpace;
   typename ScopedPtr<V>::Type truncationErrorPrecisionMin;
   typename ScopedPtr<V>::Type truncationErrorPrecisionMax;
   typename ScopedPtr<BoxSubset<V, M> >::Type truncationErrorPrecisionDomain;
@@ -434,7 +435,7 @@ public:
   std::vector<const BaseVectorRV<V, M> *> priors;
 
   // The hyperpriors
-  typename ScopedPtr<UniformVectorRV<V, M> >::Type m_truncationErrorPrecision;  // scalar
+  typename ScopedPtr<GammaVectorRV<V, M> >::Type m_truncationErrorPrecision;  // scalar
   typename ScopedPtr<GammaVectorRV<V, M> >::Type m_emulatorPrecision;  // (dim num_svd_terms) gamma(a, b) shape-rate
   typename ScopedPtr<GammaVectorRV<V, M> >::Type m_observationalPrecision;  // scalar gamma(a, b) shape-rate
   typename ScopedPtr<BetaVectorRV<V, M> >::Type m_emulatorCorrelationStrength;  // (dim scenariosspace + dim parameterspace)
@@ -443,6 +444,8 @@ public:
   typename ScopedPtr<GammaVectorRV<V, M> >::Type m_emulatorDataPrecision;  // (scalar) shape-rate
   typename ScopedPtr<ConcatenatedVectorRV<V, M> >::Type m_totalPrior;  // prior for joint parameters and hyperparameters
 
+  typename ScopedPtr<V>::Type m_truncationErrorPrecisionShapeVec;
+  typename ScopedPtr<V>::Type m_truncationErrorPrecisionScaleVec;
   typename ScopedPtr<V>::Type m_emulatorPrecisionShapeVec;
   typename ScopedPtr<V>::Type m_emulatorPrecisionScaleVec;
   typename ScopedPtr<V>::Type m_observationalPrecisionShapeVec;

--- a/src/gp/inc/GPMSAOptions.h
+++ b/src/gp/inc/GPMSAOptions.h
@@ -185,6 +185,12 @@ public:
   double normalized_uncertain_parameter(unsigned int i,
                                         double physical_param) const;
 
+  //! The shape parameter for the Gamma hyperprior for the truncation error precision
+  double m_truncationErrorPrecisionShape;
+
+  //! The scale parameter for the Gamma hyperprior for the truncation error precision
+  double m_truncationErrorPrecisionScale;
+
   //! The shape parameter for the Gamma hyperprior for the emulator precision
   double m_emulatorPrecisionShape;
 
@@ -274,6 +280,8 @@ private:
 
   std::string m_option_help;
   std::string m_option_maxEmulatorBasisVectors;
+  std::string m_option_truncationErrorPrecisionShape;
+  std::string m_option_truncationErrorPrecisionScale;
   std::string m_option_emulatorBasisVarianceToCapture;
   std::string m_option_emulatorPrecisionShape;
   std::string m_option_emulatorPrecisionScale;

--- a/src/gp/src/GPMSA.C
+++ b/src/gp/src/GPMSA.C
@@ -1184,9 +1184,20 @@ GPMSAFactory<V, M>::setUpHyperpriors()
   // Truncation error precision
   if (this->num_svd_terms < numOutputs)
     {
+      this->truncationErrorPrecisionSpace.reset
+        (new VectorSpace<V, M>
+         (this->m_env,
+          "",
+          1,
+          NULL));
+
       this->truncationErrorPrecisionMin.reset(new V(this->oneDSpace->zeroVector()));
       this->truncationErrorPrecisionMax.reset(new V(this->oneDSpace->zeroVector()));
-      this->truncationErrorPrecisionMin->cwSet(-INFINITY);
+      this->m_truncationErrorPrecisionShapeVec.reset
+        (new V(this->truncationErrorPrecisionSpace->zeroVector()));
+      this->m_truncationErrorPrecisionScaleVec.reset
+        (new V(this->truncationErrorPrecisionSpace->zeroVector()));
+      this->truncationErrorPrecisionMin->cwSet(0);
       this->truncationErrorPrecisionMax->cwSet(INFINITY);
 
       this->truncationErrorPrecisionDomain.reset
@@ -1197,9 +1208,11 @@ GPMSAFactory<V, M>::setUpHyperpriors()
            *(this->truncationErrorPrecisionMax)));
 
       this->m_truncationErrorPrecision.reset
-        (new UniformVectorRV<V, M>
+        (new GammaVectorRV<V, M>
          ("",
-          *(this->truncationErrorPrecisionDomain)));
+          *(this->truncationErrorPrecisionDomain),
+          *(this->m_truncationErrorPrecisionShapeVec),
+          *(this->m_truncationErrorPrecisionScaleVec)));
     }
 
   // Emulator precision

--- a/src/gp/src/GPMSAOptions.C
+++ b/src/gp/src/GPMSAOptions.C
@@ -39,6 +39,8 @@
 #define UQ_GPMSA_HELP ""
 #define UQ_GPMSA_MAX_SIMULATOR_BASIS_VECTORS_ODV 0
 #define UQ_GPMSA_SIMULATOR_BASIS_VARIANCE_TO_CAPTURE 1.0
+#define UQ_GPMSA_TRUNCATION_ERROR_PRECISION_SHAPE_ODV 5.0
+#define UQ_GPMSA_TRUNCATION_ERROR_PRECISION_SCALE_ODV 200.0
 #define UQ_GPMSA_EMULATOR_PRECISION_SHAPE_ODV 5.0
 #define UQ_GPMSA_EMULATOR_PRECISION_SCALE_ODV 0.2
 #define UQ_GPMSA_OBSERVATIONAL_PRECISION_SHAPE_ODV 5.0
@@ -122,6 +124,8 @@ GPMSAOptions::set_prefix(const char * prefix)
   m_option_help = m_prefix + "help";
   m_option_maxEmulatorBasisVectors = m_prefix + "max_emulator_basis_vectors";
   m_option_emulatorBasisVarianceToCapture = m_prefix + "emulator_basis_variance_to_capture";
+  m_option_truncationErrorPrecisionShape = m_prefix + "truncation_error_precision_shape";
+  m_option_truncationErrorPrecisionScale = m_prefix + "truncation_error_precision_scale";
   m_option_emulatorPrecisionShape = m_prefix + "emulator_precision_shape";
   m_option_emulatorPrecisionScale = m_prefix + "emulator_precision_scale";
   m_option_calibrateObservationalPrecision = m_prefix + "calibrate_observational_precision";
@@ -147,6 +151,8 @@ GPMSAOptions::set_defaults()
   m_help = UQ_GPMSA_HELP;
   m_maxEmulatorBasisVectors = UQ_GPMSA_MAX_SIMULATOR_BASIS_VECTORS_ODV;
   m_emulatorBasisVarianceToCapture = UQ_GPMSA_SIMULATOR_BASIS_VARIANCE_TO_CAPTURE;
+  m_truncationErrorPrecisionShape = UQ_GPMSA_TRUNCATION_ERROR_PRECISION_SHAPE_ODV;
+  m_truncationErrorPrecisionScale = UQ_GPMSA_TRUNCATION_ERROR_PRECISION_SCALE_ODV;
   m_emulatorPrecisionShape = UQ_GPMSA_EMULATOR_PRECISION_SHAPE_ODV;
   m_emulatorPrecisionScale = UQ_GPMSA_EMULATOR_PRECISION_SCALE_ODV;
   m_calibrateObservationalPrecision = false;
@@ -187,6 +193,15 @@ GPMSAOptions::parse(const BaseEnvironment & env,
     (m_option_help,
      m_help,
      "produce help message Gaussian process emulator");
+
+  m_parser->registerOption
+    (m_option_truncationErrorPrecisionShape,
+     m_truncationErrorPrecisionShape,
+     "shape hyperprior (Gamma) parameter for truncation error precision");
+  m_parser->registerOption
+    (m_option_truncationErrorPrecisionScale,
+    m_truncationErrorPrecisionScale,
+    "scale hyperprior (Gamma) parameter for truncation error precision");
 
   m_parser->registerOption
     (m_option_emulatorPrecisionShape,
@@ -259,6 +274,8 @@ GPMSAOptions::parse(const BaseEnvironment & env,
   m_parser->scanInputFile();
 
   m_parser->getOption<std::string>(m_option_help,                           m_help);
+  m_parser->getOption<double>(m_option_truncationErrorPrecisionShape,       m_truncationErrorPrecisionShape);
+  m_parser->getOption<double>(m_option_truncationErrorPrecisionScale,       m_truncationErrorPrecisionScale);
   m_parser->getOption<double>(m_option_emulatorPrecisionShape,              m_emulatorPrecisionShape);
   m_parser->getOption<double>(m_option_emulatorPrecisionScale,              m_emulatorPrecisionScale);
   m_parser->getOption<bool>  (m_option_calibrateObservationalPrecision,     m_calibrateObservationalPrecision);
@@ -276,6 +293,14 @@ GPMSAOptions::parse(const BaseEnvironment & env,
   m_parser->getOption<bool>  (m_option_autoscaleMeanVarAll,                 m_autoscaleMeanVarAll);
 #else
   m_help = env.input()(m_option_help, UQ_GPMSA_HELP);
+
+  m_truncationErrorPrecisionShape =
+    env.input()(m_option_truncationErrorPrecisionShape,
+                m_truncationErrorPrecisionShape);
+  m_truncationErrorPrecisionScale =
+    env.input()(m_option_truncationErrorPrecisionScale,
+                m_truncationErrorPrecisionScale);
+
   m_emulatorPrecisionShape =
     env.input()(m_option_emulatorPrecisionShape,
                 m_emulatorPrecisionShape);
@@ -589,7 +614,9 @@ GPMSAOptions::checkOptions()
 void
 GPMSAOptions::print(std::ostream& os) const
 {
-  os << "\n" << m_option_emulatorPrecisionShape << " = " << this->m_emulatorPrecisionShape
+  os << "\n" << m_option_truncationErrorPrecisionShape << " = " << this->m_truncationErrorPrecisionShape
+     << "\n" << m_option_truncationErrorPrecisionScale << " = " << this->m_truncationErrorPrecisionScale
+     << "\n" << m_option_emulatorPrecisionShape << " = " << this->m_emulatorPrecisionShape
      << "\n" << m_option_emulatorPrecisionScale << " = " << this->m_emulatorPrecisionScale
      << "\n" << m_option_calibrateObservationalPrecision << " = " << this->m_calibrateObservationalPrecision
      << "\n" << m_option_observationalPrecisionShape << " = " << this->m_observationalPrecisionShape


### PR DESCRIPTION
This gives us the default shape/scale values we want, and the options
infrastructure to change them, and sets up a proper gamma prior with
those values instead of an improper uniform prior.

This fixes more of the issues noted in #511