### PR TITLE
GPMSAOptions::options_have_been_used sanity checks

### DIFF
--- a/src/gp/inc/GPMSAOptions.h
+++ b/src/gp/inc/GPMSAOptions.h
@@ -292,6 +292,8 @@ private:
   std::string m_option_autoscaleMinMaxAll;
   std::string m_option_autoscaleMeanVarAll;
 
+  bool options_have_been_used;
+
   void checkOptions();
 };
 

--- a/src/gp/src/GPMSAOptions.C
+++ b/src/gp/src/GPMSAOptions.C
@@ -95,7 +95,8 @@ namespace QUESO {
 
 GPMSAOptions::GPMSAOptions(
   const BaseEnvironment & env,
-  const char * prefix)
+  const char * prefix) :
+  options_have_been_used(false)
 {
   this->set_defaults();
   this->parse(env, prefix);
@@ -104,10 +105,11 @@ GPMSAOptions::GPMSAOptions(
 
 GPMSAOptions::GPMSAOptions()
   :
-  m_env(NULL)
+  m_env(NULL),
 #ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-  ,m_parser(new BoostInputOptionsParser())
+  m_parser(new BoostInputOptionsParser()),
 #endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+  options_have_been_used(false)
 {
   this->set_defaults();
   this->set_prefix("");
@@ -117,6 +119,8 @@ GPMSAOptions::GPMSAOptions()
 void
 GPMSAOptions::set_prefix(const char * prefix)
 {
+  queso_require(!options_have_been_used);
+
   m_prefix = std::string(prefix) + "gpmsa_";
 
   m_option_help = m_prefix + "help";
@@ -144,6 +148,8 @@ GPMSAOptions::set_prefix(const char * prefix)
 void
 GPMSAOptions::set_defaults()
 {
+  queso_require(!options_have_been_used);
+
   m_help = UQ_GPMSA_HELP;
   m_maxEmulatorBasisVectors = UQ_GPMSA_MAX_SIMULATOR_BASIS_VECTORS_ODV;
   m_emulatorBasisVarianceToCapture = UQ_GPMSA_SIMULATOR_BASIS_VARIANCE_TO_CAPTURE;
@@ -172,6 +178,8 @@ void
 GPMSAOptions::parse(const BaseEnvironment & env,
                     const char * prefix)
 {
+  queso_require(!options_have_been_used);
+
   m_env = &env;
 
   if (m_env->optionsInputFileName() == "") {
@@ -340,6 +348,8 @@ GPMSAOptions::~GPMSAOptions()
 void
 GPMSAOptions::set_autoscale_minmax()
 {
+  queso_require(!options_have_been_used);
+
   this->m_autoscaleMinMaxAll = true;
 }
 
@@ -347,6 +357,8 @@ GPMSAOptions::set_autoscale_minmax()
 void
 GPMSAOptions::set_autoscale_minmax_uncertain_parameter(unsigned int i)
 {
+  queso_require(!options_have_been_used);
+
   m_autoscaleMinMaxUncertain.insert(i);
 }
 
@@ -354,6 +366,8 @@ GPMSAOptions::set_autoscale_minmax_uncertain_parameter(unsigned int i)
 void
 GPMSAOptions::set_autoscale_minmax_scenario_parameter(unsigned int i)
 {
+  queso_require(!options_have_been_used);
+
   m_autoscaleMinMaxScenario.insert(i);
 }
 
@@ -361,6 +375,8 @@ GPMSAOptions::set_autoscale_minmax_scenario_parameter(unsigned int i)
 void
 GPMSAOptions::set_autoscale_meanvar()
 {
+  queso_require(!options_have_been_used);
+
   this->m_autoscaleMeanVarAll = true;
 }
 
@@ -368,6 +384,8 @@ GPMSAOptions::set_autoscale_meanvar()
 void
 GPMSAOptions::set_autoscale_meanvar_uncertain_parameter(unsigned int i)
 {
+  queso_require(!options_have_been_used);
+
   m_autoscaleMeanVarUncertain.insert(i);
 }
 
@@ -375,6 +393,8 @@ GPMSAOptions::set_autoscale_meanvar_uncertain_parameter(unsigned int i)
 void
 GPMSAOptions::set_autoscale_meanvar_scenario_parameter(unsigned int i)
 {
+  queso_require(!options_have_been_used);
+
   m_autoscaleMeanVarScenario.insert(i);
 }
 
@@ -384,6 +404,8 @@ GPMSAOptions::set_uncertain_parameter_scaling(unsigned int i,
                                               double range_min,
                                               double range_max)
 {
+  queso_require(!options_have_been_used);
+
   if (i >= m_uncertainScaleMin.size())
   {
     m_uncertainScaleMin.resize(i+1, 0);
@@ -399,6 +421,8 @@ GPMSAOptions::set_scenario_parameter_scaling(unsigned int i,
                                              double range_min,
                                              double range_max)
 {
+  queso_require(!options_have_been_used);
+
   if (i >= m_scenarioScaleMin.size())
   {
     m_scenarioScaleMin.resize(i+1, 0);
@@ -549,6 +573,8 @@ GPMSAOptions::set_final_scaling
                                                   std::sqrt(varUncertain[p]));
           }
     }
+
+  options_have_been_used = true;
 }
 
 


### PR DESCRIPTION
We don't want users inadvertently trying to change options after it's
too late, because GPMSAFactory reads and uses GPMSAOptions just as
soon as all the experimental and simulation data has been added.