### PR TITLE
Trilinos build fixes

### DIFF
--- a/m4/common/ax_trilinos_base.m4
+++ b/m4/common/ax_trilinos_base.m4
@@ -153,9 +153,11 @@ if test "${with_trilinos}" != no ; then
         dnl We need it to back out the discovered TRILINOS_INCLUDE directory.
         gl_TRILINOS_ABSOLUTE_HEADER([Trilinos_version.h])
         TRILINOS_INCLUDE=`AS_DIRNAME([$gl_cv_absolute_Trilinos_version_h])`
+        TRILINOS_LIB="${trilinos_libdir}"
 
         AC_DEFINE(HAVE_TRILINOS,1,[Define if Trilinos is available])
         AC_SUBST(TRILINOS_INCLUDE)
+        AC_SUBST(TRILINOS_LIB)
         ifelse([$2],,,[$2])
     fi
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,6 +23,10 @@ if HDF5_ENABLED
   AM_CPPFLAGS += $(HDF5_CFLAGS)
 endif
 
+if TRILINOS_ENABLED
+  AM_CPPFLAGS += -I$(TRILINOS_INCLUDE)
+endif
+
 if LIBMESH_SLEPC_ENABLED
   AM_CPPFLAGS += $(LIBMESH_CPPFLAGS)# $(LIBMESH_INCLUDE)
 endif
@@ -61,7 +65,13 @@ endif
 # variable later.
 
 if TRILINOS_ENABLED
-  libqueso_la_LDFLAGS += -lteuchoscore -lteuchoscomm -lteuchosnumerics -lteuchosparameterlist -lteuchosremainder -lepetra
+  libqueso_la_LDFLAGS += -L$(TRILINOS_LIB) \
+			 -lteuchoscore \
+			 -lteuchoscomm \
+			 -lteuchosnumerics \
+			 -lteuchosparameterlist \
+			 -lteuchosremainder \
+			 -lepetra
 endif
 
 if LIBMESH_SLEPC_ENABLED


### PR DESCRIPTION
It turns out that #576 was only a sufficient build fix on my laptop, where the Ubuntu system Trilinos was installed in /usr.  If I want to be able to successfully build on module-based systems without manually disabling or unloading Trilinos, QUESO needs to be able to handle building with it in a non-system directory.