### PR TITLE
Normalization changes

### DIFF
--- a/src/gp/inc/GPMSAOptions.h
+++ b/src/gp/inc/GPMSAOptions.h
@@ -88,51 +88,51 @@ public:
   double m_emulatorBasisVarianceToCapture;
 
   //! Do automatic normalization, using minimum and maximum values in
-  //  the supplied data, for uncertain parameter i.
+  //  the supplied simulator data, for uncertain parameter i.
   //
   //  Normalized values will range from 0 to 1.
   void set_autoscale_minmax_uncertain_parameter(unsigned int i);
 
   //! Do automatic normalization, using minimum and maximum values in
-  //  the supplied data, for scenario parameter i.
+  //  the supplied simulator data, for scenario parameter i.
   //
   //  Normalized values will range from 0 to 1.
   void set_autoscale_minmax_scenario_parameter(unsigned int i);
 
   //! Do automatic normalization, using minimum and maximum values in
-  //  the supplied data, for output data i.
+  //  the supplied simulator data, for output data i.
   //
   //  Normalized values will range from 0 to 1.
   void set_autoscale_minmax_output(unsigned int i);
 
   //! Do automatic normalization, using minimum and maximum values in
-  //  the supplied data, for all input uncertain parameters, all input
-  //  scenario parameters, and all output values.
+  //  the supplied simulator data, for all input uncertain parameters,
+  //  all input scenario parameters, and all output values.
   //
   //  Normalized values will range from 0 to 1.
   void set_autoscale_minmax();
 
   //! Do automatic normalization, using mean and variance of the
-  //  supplied data, for uncertain parameter i.
+  //  supplied simulator data, for uncertain parameter i.
   //
   //  Normalized values will have mean 0 and standard deviation 1.
   void set_autoscale_meanvar_uncertain_parameter(unsigned int i);
 
   //! Do automatic normalization, using mean and variance of the
-  //  supplied data, for scenario parameter i.
+  //  supplied simulator data, for scenario parameter i.
   //
   //  Normalized values will have mean 0 and standard deviation 1.
   void set_autoscale_meanvar_scenario_parameter(unsigned int i);
 
   //! Do automatic normalization, using mean and variance of the
-  //  supplied data, for output i.
+  //  supplied simulator data, for output i.
   //
   //  Normalized values will have mean 0 and standard deviation 1.
   void set_autoscale_meanvar_output(unsigned int i);
 
   //! Do automatic normalization, using mean and variance of the
-  //  supplied data, for all input uncertain parameters, all input
-  //  scenario parameters, and all output values.
+  //  supplied simulator data, for all input uncertain parameters, all
+  //  input scenario parameters, and all output values.
   //
   //  Normalized values will have mean 0 and standard deviation 1.
   void set_autoscale_meanvar();
@@ -163,9 +163,9 @@ public:
                                       double range_min,
                                       double range_max);
 
-  //! Set a value, for output value i in simulation and outputs, of
-  //  the physical output range (range_min, range_max) which should be
-  //  rescaled to (0,1)
+  //! Set a value, for output value i in simulation and experimental
+  //  outputs, of the physical output range (range_min, range_max)
+  //  which should be rescaled to (0,1)
   //
   //  If no value is set and no automatic normalization is specified,
   //  a default of (0,1) will be used; i.e. no normalization.

--- a/src/gp/src/GPMSAOptions.C
+++ b/src/gp/src/GPMSAOptions.C
@@ -61,7 +61,8 @@
 namespace { // Anonymous namespace for helper functions
 
 template <typename V>
-void min_max_update(V & min, V & max, const V & new_data)
+void min_max_update(V & min, V & max, const V & new_data,
+                    const char * warn_on_update = NULL)
 {
   unsigned int dim = min.sizeGlobal();
   queso_assert_equal_to(dim, max.sizeGlobal());
@@ -69,6 +70,19 @@ void min_max_update(V & min, V & max, const V & new_data)
 
   for (unsigned int p=0; p != dim; ++p)
     {
+      if (warn_on_update)
+        {
+          if (min[p] > new_data[p])
+            queso_warning("Experimental " << warn_on_update << " " <<
+                          new_data[p] << " at index " << p <<
+                          " is below minimum simulation " <<
+                          warn_on_update << " " << min[p]);
+          if (max[p] < new_data[p])
+            queso_warning("Experimental " << warn_on_update << " " <<
+                          new_data[p] << " at index " << p <<
+                          " is above maximum simulation " <<
+                          warn_on_update << " " << max[p]);
+        }
       min[p] = std::min(min[p], new_data[p]);
       max[p] = std::max(max[p], new_data[p]);
     }
@@ -550,16 +564,18 @@ GPMSAOptions::set_final_scaling
 
       V minScenario(*m_simulationScenarios[0]);
 
+      // Only use simulation data for scaling.
       for (unsigned int i=1; i < m_simulationScenarios.size(); ++i)
         min_max_update(minScenario, maxScenario,
                        (*m_simulationScenarios[i]));
 
-      // To match Matlab code, only use simulation data for scaling.
-/*
+      // But check the experimental data, and yell at the user if it
+      // falls outside the simulation data range, because they
+      // probably don't want to be extrapolating with their GP.
       for (unsigned int i=0; i < m_experimentScenarios.size(); ++i)
         min_max_update(minScenario, maxScenario,
-                       (*m_experimentScenarios[i]));
-*/
+                       (*m_experimentScenarios[i]),
+                       /*warn_on_update =*/ "scenario parameter");
 
       for (unsigned int p=0; p != dimScenario; ++p)
         if (m_autoscaleMinMaxAll ||
@@ -605,6 +621,10 @@ GPMSAOptions::set_final_scaling
 
       V minOutput(*m_simulationOutputs[0]);
 
+      // Only use simulation data for scaling.  In this case we won't
+      // warn if the experimental data falls outside the simulation
+      // data bounds, because the user can't control their outputs,
+      // just their inputs.
       for (unsigned int i=1; i < m_simulationOutputs.size(); ++i)
         min_max_update(minOutput, maxOutput,
                        (*m_simulationOutputs[i]));
@@ -633,16 +653,11 @@ GPMSAOptions::set_final_scaling
       V varScenario(m_simulationScenarios[0]->env(),
                     m_simulationScenarios[0]->map());
 
+      // For consistency with the min-max behavior, only normalize
+      // using simulation data, not experiment data.
       for (unsigned int i=0; i < m_simulationScenarios.size(); ++i)
         mean_var_update(n, meanScenario, varScenario,
                         *m_simulationScenarios[i]);
-
-      // To match Matlab code, only use simulation data for scaling.
-/*
-      for (unsigned int i=0; i < m_experimentScenarios.size(); ++i)
-        mean_var_update(n, meanScenario, varScenario,
-                        *m_experimentScenarios[i]);
-*/
 
       varScenario /= n - 1;
 

--- a/src/gp/src/GPMSAOptions.C
+++ b/src/gp/src/GPMSAOptions.C
@@ -83,8 +83,11 @@ void min_max_update(V & min, V & max, const V & new_data,
                           " is above maximum simulation " <<
                           warn_on_update << " " << max[p]);
         }
-      min[p] = std::min(min[p], new_data[p]);
-      max[p] = std::max(max[p], new_data[p]);
+      else
+        {
+          min[p] = std::min(min[p], new_data[p]);
+          max[p] = std::max(max[p], new_data[p]);
+        }
     }
 }
 

--- a/src/gp/src/GPMSAOptions.C
+++ b/src/gp/src/GPMSAOptions.C
@@ -554,9 +554,12 @@ GPMSAOptions::set_final_scaling
         min_max_update(minScenario, maxScenario,
                        (*m_simulationScenarios[i]));
 
+      // To match Matlab code, only use simulation data for scaling.
+/*
       for (unsigned int i=0; i < m_experimentScenarios.size(); ++i)
         min_max_update(minScenario, maxScenario,
                        (*m_experimentScenarios[i]));
+*/
 
       for (unsigned int p=0; p != dimScenario; ++p)
         if (m_autoscaleMinMaxAll ||
@@ -634,9 +637,12 @@ GPMSAOptions::set_final_scaling
         mean_var_update(n, meanScenario, varScenario,
                         *m_simulationScenarios[i]);
 
+      // To match Matlab code, only use simulation data for scaling.
+/*
       for (unsigned int i=0; i < m_experimentScenarios.size(); ++i)
         mean_var_update(n, meanScenario, varScenario,
                         *m_experimentScenarios[i]);
+*/
 
       varScenario /= n - 1;
 

--- a/src/gp/src/GPMSAOptions.C
+++ b/src/gp/src/GPMSAOptions.C
@@ -733,7 +733,7 @@ const
 {
   if (i < m_scenarioScaleMin.size())
     return (physical_param - m_scenarioScaleMin[i]) /
-            m_scenarioScaleRange[i];
+            (m_scenarioScaleRange[i] ? m_scenarioScaleRange[i] : 1);
   return physical_param;
 }
 
@@ -745,7 +745,7 @@ const
 {
   if (i < m_uncertainScaleMin.size())
     return (physical_param - m_uncertainScaleMin[i]) /
-            m_uncertainScaleRange[i];
+            (m_uncertainScaleRange[i] ? m_uncertainScaleRange[i] : 1);
   return physical_param;
 }
 
@@ -757,7 +757,7 @@ const
 {
   if (i < m_outputScaleMin.size())
     return (output_data - m_outputScaleMin[i]) /
-            m_outputScaleRange[i];
+            (m_outputScaleRange[i] ? m_outputScaleRange[i] : 1);
   return output_data;
 }
 
@@ -767,7 +767,8 @@ double
 GPMSAOptions::output_scale(unsigned int i)
 const
 {
-  if (i < m_outputScaleRange.size())
+  if (i < m_outputScaleRange.size() &&
+      m_outputScaleRange[i])
     return m_outputScaleRange[i];
   return 1;
 }


### PR DESCRIPTION
Autoscale by simulation data only, to better match the MATLAB code.

Gracefully handle the "we have nothing to scale by if we leave out the experimental data" cases; even with a dummy variable where we don't care about the scaling, NaNs spread like weeds.