### PR TITLE
InfiniteDimensionalMCMCSamplerOptions GetPot codepath fix

### DIFF
--- a/src/core/src/InfiniteDimensionalMCMCSamplerOptions.C
+++ b/src/core/src/InfiniteDimensionalMCMCSamplerOptions.C
@@ -67,15 +67,15 @@ InfiniteDimensionalMCMCSamplerOptions::InfiniteDimensionalMCMCSamplerOptions(
 
   m_parser->getOption<std::string>(m_option_dataOutputDirName,  m_dataOutputDirName);
   m_parser->getOption<std::string>(m_option_dataOutputFileName, m_dataOutputFileName);
-  m_parser->getOption<unsigned int>(m_option_num_iters,          m_num_iters);
-  m_parser->getOption<unsigned int>(m_option_save_freq,          m_save_freq);
+  m_parser->getOption<unsigned int>(m_option_num_iters,         m_num_iters);
+  m_parser->getOption<unsigned int>(m_option_save_freq,         m_save_freq);
   m_parser->getOption<double     >(m_option_rwmh_step,          m_rwmh_step);
 #else
-  m_option_dataOutputDirName = m_env.input()(m_option_dataOutputDirName, UQ_INF_DATA_OUTPUT_DIR_NAME_ODV);
-  m_option_dataOutputFileName = m_env.input()(m_option_dataOutputFileName, UQ_INF_DATA_OUTPUT_FILE_NAME_ODV);
-  m_option_num_iters = m_env.input()(m_option_num_iters, UQ_INF_NUM_ITERS_ODV);
-  m_option_save_freq = m_env.input()(m_option_save_freq, UQ_INF_SAVE_FREQ_ODV);
-  m_option_rwmh_step = m_env.input()(m_option_rwmh_step, UQ_INF_RWMH_STEP_ODV);;
+  m_dataOutputDirName = m_env.input()(m_option_dataOutputDirName, UQ_INF_DATA_OUTPUT_DIR_NAME_ODV);
+  m_dataOutputFileName = m_env.input()(m_option_dataOutputFileName, UQ_INF_DATA_OUTPUT_FILE_NAME_ODV);
+  m_num_iters = m_env.input()(m_option_num_iters, UQ_INF_NUM_ITERS_ODV);
+  m_save_freq = m_env.input()(m_option_save_freq, UQ_INF_SAVE_FREQ_ODV);
+  m_rwmh_step = m_env.input()(m_option_rwmh_step, UQ_INF_RWMH_STEP_ODV);;
 #endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   checkOptions();

--- a/test/test_infinite/test_inf_options.C
+++ b/test/test_infinite/test_inf_options.C
@@ -89,11 +89,9 @@ int main(int argc, char **argv)
   QUESO::InfiniteDimensionalMCMCSamplerOptions opts(env, "");
   QUESO::InfiniteDimensionalMCMCSampler sampler(env, mu, llhd, &opts);
 
-  if (opts.m_num_iters != 10 ||  // Input file value is 10
-      opts.m_save_freq != 5 ||  // Ditto 5
-      opts.m_rwmh_step != 0.1) {
-    return 1;
-  }
+  queso_require_equal_to(opts.m_num_iters, 10);
+  queso_require_equal_to(opts.m_save_freq, 5);
+  queso_require_equal_to(opts.m_rwmh_step, 0.1);
 
   return 0;
 }
@@ -107,6 +105,7 @@ int main(int argc, char **argv)
 #else
 int main()
 {
+  std::cout << "QUESO was configured without libMesh support." << std::endl;
   return 77;
 }
 #endif


### PR DESCRIPTION
This fixes a regression test failure for me.  The infinite-D options code was severely broken for anyone not configuring with Boost program_options.