### PR TITLE
Fix an indexing in error in BT_Wy_B ridge addition

### DIFF
--- a/src/gp/src/GPMSA.C
+++ b/src/gp/src/GPMSA.C
@@ -962,14 +962,18 @@ GPMSAFactory<V, M>::setUpEmulator()
   // overridden by user options.
   //
   // This is "DKridge" in the MATLAB prototype
-  for (unsigned int i=0; i != Brows; ++i)
+  //
+  // The number of rows BT_Wy_B has is Bcols
+  for (unsigned int i=0; i != Bcols; ++i)
     BT_Wy_B(i,i) +=
       this->m_opts->m_observationalPrecisionRidge;
 
   BT_Wy_B_inv.reset(new M(BT_Wy_B.inverse()));
 
   // Add a ridge to the inverse even, if the user requested one.
-  for (unsigned int i=0; i != Brows; ++i)
+  //
+  // The number of rows BT_Wy_B_inv has is Bcols
+  for (unsigned int i=0; i != Bcols; ++i)
     (*BT_Wy_B_inv)(i,i) +=
       this->m_opts->m_observationalCovarianceRidge;
 

--- a/src/gp/src/GPMSA.C
+++ b/src/gp/src/GPMSA.C
@@ -977,6 +977,9 @@ GPMSAFactory<V, M>::setUpEmulator()
     (*BT_Wy_B_inv)(i,i) +=
       this->m_opts->m_observationalCovarianceRidge;
 
+  queso_assert_equal_to(BT_Wy_B_inv->numCols(), BT_Wy_B_inv->numRowsGlobal());
+  queso_assert_equal_to(BT_Wy_B_inv->numCols(), Bcols);
+
   this->setUpHyperpriors();
 
   this->m_constructedGP = true;


### PR DESCRIPTION
We were indexing over the number of rows of B, but this is wrong.  The
number of rows it has is the number of columns of B.