### PR TITLE
More granular options parsing for Environment

### DIFF
--- a/src/core/inc/Environment.h
+++ b/src/core/inc/Environment.h
@@ -171,15 +171,23 @@ public:
   //@{
   //! Default constructor.
   /*!
-   * initialOptionsValues can be overridden by those in
-   * passedOptionsInputFileName
+   * initialOptionsValues apply first, followed by any overrides
+   * present in passedOptionsInputFileName.  Historically the behavior was:
+   *   IF      alternative options passed in, use them exclusively
+   *   ELSE IF input file, parse and set options from it
+   *   ELSE    use default options
+   * so the input file was ignored when options object was passed in.
    */
   BaseEnvironment(const char* passedOptionsInputFileName, EnvOptionsValues* initialOptionsValues);
 
   //! Alternate constructor.
   /*!
-   * initialOptionsValues can be overridden by those in
-   * passedOptionsInputFileName
+   * initialOptionsValues apply first, followed by any overrides
+   * present in passedOptionsInputFileName.  Historically the behavior was:
+   *   IF      alternative options passed in, use them exclusively
+   *   ELSE IF input file, parse and set options from it
+   *   ELSE    use default options
+   * so the input file was ignored when options object was passed in.
    */
   BaseEnvironment(const std::string & passedOptionsInputFileName,
                   EnvOptionsValues* initialOptionsValues);
@@ -493,10 +501,26 @@ public:
    * Initializes the full communicator, reads the options, deals with multiple
    * sub-environments, e.g. dealing with sub/self/inter0-communicators, handles
    * path for output files.
+   *
+   * initialOptionsValues apply first, followed by any overrides
+   * present in passedOptionsInputFileName.  Historically the behavior was:
+   *   IF      alternative options passed in, use them exclusively
+   *   ELSE IF input file, parse and set options from it
+   *   ELSE    use default options
+   * so the input file was ignored when options object was passed in.
    */
 #ifdef QUESO_HAS_MPI
   FullEnvironment(RawType_MPI_Comm inputComm, const char* passedOptionsInputFileName, const char* prefix, EnvOptionsValues* initialOptionsValues);
 
+  //! Parallel constructor.
+  /*!
+   * initialOptionsValues apply first, followed by any overrides
+   * present in passedOptionsInputFileName.  Historically the behavior was:
+   *   IF      alternative options passed in, use them exclusively
+   *   ELSE IF input file, parse and set options from it
+   *   ELSE    use default options
+   * so the input file was ignored when options object was passed in.
+   */
   FullEnvironment(RawType_MPI_Comm inputComm,
                   const std::string& passedOptionsInputFileName,
                   const std::string& prefix,
@@ -507,9 +531,25 @@ public:
   /*!
    * No communicator is passed. Output path handling is exactly as in the
    * parallel ctor.
+   *
+   * initialOptionsValues apply first, followed by any overrides
+   * present in passedOptionsInputFileName.  Historically the behavior was:
+   *   IF      alternative options passed in, use them exclusively
+   *   ELSE IF input file, parse and set options from it
+   *   ELSE    use default options
+   * so the input file was ignored when options object was passed in.
    */
   FullEnvironment(const char* passedOptionsInputFileName, const char* prefix, EnvOptionsValues* initialOptionsValues);
 
+  //! Serial constructor.
+  /*!
+   * initialOptionsValues apply first, followed by any overrides
+   * present in passedOptionsInputFileName.  Historically the behavior was:
+   *   IF      alternative options passed in, use them exclusively
+   *   ELSE IF input file, parse and set options from it
+   *   ELSE    use default options
+   * so the input file was ignored when options object was passed in.
+   */
   FullEnvironment(const std::string& passedOptionsInputFileName,
                   const std::string& prefix,
                   EnvOptionsValues* initialOptionsValues);
@@ -535,7 +575,7 @@ private:
   void        construct(const char *prefix);
 
   //! Checks the options input file and reads the options.
-  void        readOptionsInputFile(const char* prefix);
+  void        readOptionsInputFile(const std::string& prefix);
   //void        queso_terminate_handler();
 
 };

--- a/src/core/inc/Environment.h
+++ b/src/core/inc/Environment.h
@@ -170,10 +170,19 @@ public:
   //! @name Constructor/Destructor methods
   //@{
   //! Default constructor.
-  BaseEnvironment(const char* passedOptionsInputFileName, EnvOptionsValues* alternativeOptionsValues);
+  /*!
+   * initialOptionsValues can be overridden by those in
+   * passedOptionsInputFileName
+   */
+  BaseEnvironment(const char* passedOptionsInputFileName, EnvOptionsValues* initialOptionsValues);
 
+  //! Alternate constructor.
+  /*!
+   * initialOptionsValues can be overridden by those in
+   * passedOptionsInputFileName
+   */
   BaseEnvironment(const std::string & passedOptionsInputFileName,
-                  EnvOptionsValues* alternativeOptionsValues);
+                  EnvOptionsValues* initialOptionsValues);
 
   //! Destructor
   /*! It deallocates memory and does other cleanup for the class object and its class members when
@@ -456,7 +465,7 @@ public:
   //! @name Constructor/Destructor methods
   //@{
   //! Default constructor. Does nothing.
-  /*! It initialized BaseEnvironment with no input file and a NULL pointer for the alternativeOptionsValues.*/
+  /*! It initializes BaseEnvironment with no input file and default options */
   EmptyEnvironment();
 
   //! Destructor
@@ -486,12 +495,12 @@ public:
    * path for output files.
    */
 #ifdef QUESO_HAS_MPI
-  FullEnvironment(RawType_MPI_Comm inputComm, const char* passedOptionsInputFileName, const char* prefix, EnvOptionsValues* alternativeOptionsValues);
+  FullEnvironment(RawType_MPI_Comm inputComm, const char* passedOptionsInputFileName, const char* prefix, EnvOptionsValues* initialOptionsValues);
 
   FullEnvironment(RawType_MPI_Comm inputComm,
                   const std::string& passedOptionsInputFileName,
                   const std::string& prefix,
-                  EnvOptionsValues* alternativeOptionsValues);
+                  EnvOptionsValues* initialOptionsValues);
 #endif
 
   //! Serial constructor.
@@ -499,11 +508,11 @@ public:
    * No communicator is passed. Output path handling is exactly as in the
    * parallel ctor.
    */
-  FullEnvironment(const char* passedOptionsInputFileName, const char* prefix, EnvOptionsValues* alternativeOptionsValues);
+  FullEnvironment(const char* passedOptionsInputFileName, const char* prefix, EnvOptionsValues* initialOptionsValues);
 
   FullEnvironment(const std::string& passedOptionsInputFileName,
                   const std::string& prefix,
-                  EnvOptionsValues* alternativeOptionsValues);
+                  EnvOptionsValues* initialOptionsValues);
 
   //! Destructor
  ~FullEnvironment();
@@ -526,7 +535,7 @@ private:
   void        construct(const char *prefix);
 
   //! Checks the options input file and reads the options.
-  void        readOptionsInputFile();
+  void        readOptionsInputFile(const char* prefix);
   //void        queso_terminate_handler();
 
 };

--- a/src/core/inc/EnvironmentOptions.h
+++ b/src/core/inc/EnvironmentOptions.h
@@ -94,6 +94,15 @@ public:
   //! Copy constructor
   EnvOptionsValues(const EnvOptionsValues& src);
 
+  //! Set parameter option names to begin with prefix
+  void set_prefix(const char* prefix);
+
+  //! Set default values for parameter options
+  void set_defaults();
+
+  //! Given prefix, read the input file for parameters named "prefix"+*
+  void parse(const BaseEnvironment* env, const char* prefix);
+
   //! Destructor
   virtual ~EnvOptionsValues();
   //@}

--- a/src/core/inc/EnvironmentOptions.h
+++ b/src/core/inc/EnvironmentOptions.h
@@ -95,13 +95,13 @@ public:
   EnvOptionsValues(const EnvOptionsValues& src);
 
   //! Set parameter option names to begin with prefix
-  void set_prefix(const char* prefix);
+  void set_prefix(const std::string& prefix);
 
   //! Set default values for parameter options
   void set_defaults();
 
   //! Given prefix, read the input file for parameters named "prefix"+*
-  void parse(const BaseEnvironment* env, const char* prefix);
+  void parse(const BaseEnvironment& env, const std::string& prefix);
 
   //! Destructor
   virtual ~EnvOptionsValues();

--- a/src/core/inc/InfiniteDimensionalMCMCSamplerOptions.h
+++ b/src/core/inc/InfiniteDimensionalMCMCSamplerOptions.h
@@ -47,6 +47,9 @@ namespace QUESO {
 class InfiniteDimensionalMCMCSamplerOptions
 {
 public:
+  //! Constructor
+  InfiniteDimensionalMCMCSamplerOptions();
+
   //! Given prefix, read the input file for parameters named prefix_*
   InfiniteDimensionalMCMCSamplerOptions(const BaseEnvironment& env, const char* prefix);
 

--- a/src/core/inc/InfiniteDimensionalMCMCSamplerOptions.h
+++ b/src/core/inc/InfiniteDimensionalMCMCSamplerOptions.h
@@ -50,6 +50,15 @@ public:
   //! Given prefix, read the input file for parameters named prefix_*
   InfiniteDimensionalMCMCSamplerOptions(const BaseEnvironment& env, const char* prefix);
 
+  //! Set default values for parameter options
+  void set_defaults();
+
+  //! Set parameter option names to begin with prefix
+  void set_prefix(const std::string& prefix);
+
+  //! Given prefix, read the input file for parameters named "prefix"+*
+  void parse(const BaseEnvironment& env, const std::string& prefix);
+
   //! Destructor
   virtual ~InfiniteDimensionalMCMCSamplerOptions();
 
@@ -86,10 +95,10 @@ public:
 
 private:
 #ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-  BoostInputOptionsParser * m_parser;
+  ScopedPtr<BoostInputOptionsParser>::Type m_parser;
 #endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
-  const BaseEnvironment& m_env;
+  const BaseEnvironment* m_env;
 
   std::string m_option_help;
   std::string m_option_dataOutputDirName;

--- a/src/core/inc/OptimizerOptions.h
+++ b/src/core/inc/OptimizerOptions.h
@@ -71,6 +71,15 @@ public:
   //! Copy constructor
   OptimizerOptions(const OptimizerOptions & rhs);
 
+  //! Set default values for parameter options
+  void set_defaults();
+
+  //! Set parameter option names to begin with prefix
+  void set_prefix(const std::string& prefix);
+
+  //! Given prefix, read the input file for parameters named "prefix"+*
+  void parse(const BaseEnvironment& env, const std::string& prefix);
+
   //! Destructor
   virtual ~OptimizerOptions();
   //@}
@@ -135,7 +144,9 @@ public:
 private:
   const BaseEnvironment * m_env;
 
-  BoostInputOptionsParser * m_parser;
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+  ScopedPtr<BoostInputOptionsParser>::Type m_parser;
+#endif
 
   // The input options as strings so we can parse the input file later
   std::string m_option_help;

--- a/src/core/src/Environment.C
+++ b/src/core/src/Environment.C
@@ -342,8 +342,7 @@ BaseEnvironment::subDisplayFile() const
 std::string
 BaseEnvironment::subDisplayFileName() const
 {
-  if (m_optionsObj == NULL) return ".";
-
+  queso_require_msg(m_optionsObj, "m_optionsObj variable is NULL");
   return m_optionsObj->m_subDisplayFileName;
 }
 //-------------------------------------------------------
@@ -511,18 +510,21 @@ BaseEnvironment::basicPdfs() const
 std::string
 BaseEnvironment::platformName() const
 {
+  queso_require_msg(m_optionsObj, "m_optionsObj variable is NULL");
   return m_optionsObj->m_platformName;
 }
 //-------------------------------------------------------
 std::string
 BaseEnvironment::identifyingString() const
 {
+  queso_require_msg(m_optionsObj, "m_optionsObj variable is NULL");
   return m_optionsObj->m_identifyingString;
 }
 //-------------------------------------------------------
 void
 BaseEnvironment::resetIdentifyingString(const std::string& newString)
 {
+  queso_require_msg(m_optionsObj, "m_optionsObj variable is NULL");
   m_optionsObj->m_identifyingString = newString;
   return;
 }
@@ -1758,16 +1760,8 @@ void queso_terminate_handler()
 }
 
 
-//-------------------------------------------------------
-// Previous behavior:
-//   * IF      alternative options passed in, use them exclusively
-//   * ELSE IF input file, parse and set options from it
-//   * ELSE    use default options
-// New behavior:
-//   * START   with default options or passed alternative options
-//   * IF      input file, any parsed options override stored values
 void
-FullEnvironment::readOptionsInputFile(const char* prefix)
+FullEnvironment::readOptionsInputFile(const std::string& prefix)
 {
   // Check file for readability for both Boost and GetPot cases
   std::ifstream* ifs = new std::ifstream(m_optionsInputFileName.c_str());
@@ -1799,7 +1793,7 @@ FullEnvironment::readOptionsInputFile(const char* prefix)
   m_input->parse_input_file(m_optionsInputFileName);
 
   // allow input file options to override current options class values
-  m_optionsObj->parse(this, prefix);
+  m_optionsObj->parse(*this, prefix);
 
   return;
 }

--- a/src/core/src/EnvironmentOptions.C
+++ b/src/core/src/EnvironmentOptions.C
@@ -47,6 +47,9 @@ namespace QUESO {
 EnvOptionsValues::EnvOptionsValues()
   :
   m_env(NULL)
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+  , m_parser(new BoostInputOptionsParser())
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 {
   this->set_defaults();
   this->set_prefix("");

--- a/src/core/src/EnvironmentOptions.C
+++ b/src/core/src/EnvironmentOptions.C
@@ -47,9 +47,6 @@ namespace QUESO {
 EnvOptionsValues::EnvOptionsValues()
   :
   m_env(NULL)
-#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-  , m_parser()
-#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 {
   this->set_defaults();
   this->set_prefix("");
@@ -264,7 +261,7 @@ EnvOptionsValues::parse(const BaseEnvironment& env, const std::string& prefix)
   m_parser->scanInputFile();
 
   // Retrieve parsed options
-  m_parser->getOption<std::string >(m_option_help, m_help);
+  m_parser->getOption<std::string>(m_option_help, m_help);
   m_parser->getOption<unsigned int>(m_option_numSubEnvironments, m_numSubEnvironments);
   m_parser->getOption<std::string>(m_option_subDisplayFileName, m_subDisplayFileName);
   m_parser->getOption<bool>(m_option_subDisplayAllowAll, m_subDisplayAllowAll);

--- a/src/core/src/EnvironmentOptions.C
+++ b/src/core/src/EnvironmentOptions.C
@@ -46,138 +46,23 @@ namespace QUESO {
 // Default constructor ------------------------------
 EnvOptionsValues::EnvOptionsValues()
   :
-    m_prefix("env_"),
-    m_help(UQ_ENV_HELP),
-    m_numSubEnvironments(UQ_ENV_NUM_SUB_ENVIRONMENTS_ODV),
-    m_subDisplayFileName(UQ_ENV_SUB_DISPLAY_FILE_NAME_ODV),
-    m_subDisplayAllowAll(UQ_ENV_SUB_DISPLAY_ALLOW_ALL_ODV),
-    m_subDisplayAllowInter0(UQ_ENV_SUB_DISPLAY_ALLOW_INTER0_ODV),
-    //m_subDisplayAllowedSet (),
-    m_displayVerbosity(UQ_ENV_DISPLAY_VERBOSITY_ODV),
-    m_syncVerbosity(UQ_ENV_SYNC_VERBOSITY_ODV),
-    m_checkingLevel(UQ_ENV_CHECKING_LEVEL_ODV),
-    m_rngType(UQ_ENV_RNG_TYPE_ODV),
-    m_seed(UQ_ENV_SEED_ODV),
-    m_platformName(UQ_ENV_PLATFORM_NAME_ODV),
-    m_identifyingString(UQ_ENV_IDENTIFYING_STRING_ODV),
-    m_numDebugParams(UQ_ENV_NUM_DEBUG_PARAMS_ODV),
-    m_debugParams(m_numDebugParams,0.),
-    m_env(NULL),
+  m_env(NULL)
 #ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-    m_parser(),
+  , m_parser(new BoostInputOptionsParser())
 #endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-    m_option_help(m_prefix + "help"),
-    m_option_numSubEnvironments(m_prefix + "numSubEnvironments"),
-    m_option_subDisplayFileName(m_prefix + "subDisplayFileName"),
-    m_option_subDisplayAllowAll(m_prefix + "subDisplayAllowAll"),
-    m_option_subDisplayAllowInter0(m_prefix + "subDisplayAllowInter0"),
-    m_option_subDisplayAllowedSet(m_prefix + "subDisplayAllowedSet"),
-    m_option_displayVerbosity(m_prefix + "displayVerbosity"),
-    m_option_syncVerbosity(m_prefix + "syncVerbosity"),
-    m_option_checkingLevel(m_prefix + "checkingLevel"),
-    m_option_rngType(m_prefix + "rngType"),
-    m_option_seed(m_prefix + "seed"),
-    m_option_platformName(m_prefix + "platformName"),
-    m_option_identifyingString(m_prefix + "identifyingString")
 {
+  this->set_defaults();
+  this->set_prefix("");
 }
 
-EnvOptionsValues::EnvOptionsValues(const BaseEnvironment * env, const char *
-    prefix)
-  :
-    m_prefix((std::string)(prefix) + "env_"),
-    m_help(UQ_ENV_HELP),
-    m_numSubEnvironments(UQ_ENV_NUM_SUB_ENVIRONMENTS_ODV),
-    m_subDisplayFileName(UQ_ENV_SUB_DISPLAY_FILE_NAME_ODV),
-    m_subDisplayAllowAll(UQ_ENV_SUB_DISPLAY_ALLOW_ALL_ODV),
-    m_subDisplayAllowInter0(UQ_ENV_SUB_DISPLAY_ALLOW_INTER0_ODV),
-    //m_subDisplayAllowedSet (),
-    m_displayVerbosity(UQ_ENV_DISPLAY_VERBOSITY_ODV),
-    m_syncVerbosity(UQ_ENV_SYNC_VERBOSITY_ODV),
-    m_checkingLevel(UQ_ENV_CHECKING_LEVEL_ODV),
-    m_rngType(UQ_ENV_RNG_TYPE_ODV),
-    m_seed(UQ_ENV_SEED_ODV),
-    m_platformName(UQ_ENV_PLATFORM_NAME_ODV),
-    m_identifyingString(UQ_ENV_IDENTIFYING_STRING_ODV),
-    m_numDebugParams(UQ_ENV_NUM_DEBUG_PARAMS_ODV),
-    m_debugParams(m_numDebugParams,0.),
-    m_env(env),
-#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-    m_parser(new BoostInputOptionsParser(env->optionsInputFileName())),
-#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-    m_option_help(m_prefix + "help"),
-    m_option_numSubEnvironments(m_prefix + "numSubEnvironments"),
-    m_option_subDisplayFileName(m_prefix + "subDisplayFileName"),
-    m_option_subDisplayAllowAll(m_prefix + "subDisplayAllowAll"),
-    m_option_subDisplayAllowInter0(m_prefix + "subDisplayAllowInter0"),
-    m_option_subDisplayAllowedSet(m_prefix + "subDisplayAllowedSet"),
-    m_option_displayVerbosity(m_prefix + "displayVerbosity"),
-    m_option_syncVerbosity(m_prefix + "syncVerbosity"),
-    m_option_checkingLevel(m_prefix + "checkingLevel"),
-    m_option_rngType(m_prefix + "rngType"),
-    m_option_seed(m_prefix + "seed"),
-    m_option_platformName(m_prefix + "platformName"),
-    m_option_identifyingString(m_prefix + "identifyingString")
+
+EnvOptionsValues::EnvOptionsValues(const BaseEnvironment* env,
+				   const char* prefix)
 {
-#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-  // Register all options with parser
-  m_parser->registerOption<std::string >(m_option_help, UQ_ENV_HELP, "produce help message for environment");
-  m_parser->registerOption<unsigned int>(m_option_numSubEnvironments, UQ_ENV_NUM_SUB_ENVIRONMENTS_ODV, "number of subEnvironments");
-  m_parser->registerOption<std::string >(m_option_subDisplayFileName, UQ_ENV_SUB_DISPLAY_FILE_NAME_ODV, "output filename for subscreen writing");
-  m_parser->registerOption<bool        >(m_option_subDisplayAllowAll, UQ_ENV_SUB_DISPLAY_ALLOW_ALL_ODV, "Allow all processors to write to output file");
-  m_parser->registerOption<bool        >(m_option_subDisplayAllowInter0, UQ_ENV_SUB_DISPLAY_ALLOW_INTER0_ODV, "Allow all inter0 nodes to write to output file");
-  m_parser->registerOption<std::string >(m_option_subDisplayAllowedSet, UQ_ENV_SUB_DISPLAY_ALLOWED_SET_ODV, "subEnvs that will write to output file");
-  m_parser->registerOption<unsigned int>(m_option_displayVerbosity, UQ_ENV_DISPLAY_VERBOSITY_ODV, "set verbosity");
-  m_parser->registerOption<unsigned int>(m_option_syncVerbosity, UQ_ENV_SYNC_VERBOSITY_ODV, "set sync verbosity");
-  m_parser->registerOption<unsigned int>(m_option_checkingLevel, UQ_ENV_CHECKING_LEVEL_ODV, "set checking level");
-  m_parser->registerOption<std::string >(m_option_rngType, UQ_ENV_RNG_TYPE_ODV, "set rngType");
-  m_parser->registerOption<int         >(m_option_seed, UQ_ENV_SEED_ODV, "set seed");
-  m_parser->registerOption<std::string >(m_option_platformName, UQ_ENV_PLATFORM_NAME_ODV, "platform name");
-  m_parser->registerOption<std::string >(m_option_identifyingString, UQ_ENV_IDENTIFYING_STRING_ODV, "identifying string");
-
-  // Read the input file
-  m_parser->scanInputFile();
-
-  m_parser->getOption<std::string >(m_option_help, m_help);
-  m_parser->getOption<unsigned int>(m_option_numSubEnvironments, m_numSubEnvironments);
-  m_parser->getOption<std::string>(m_option_subDisplayFileName, m_subDisplayFileName);
-  m_parser->getOption<bool>(m_option_subDisplayAllowAll, m_subDisplayAllowAll);
-  m_parser->getOption<bool>(m_option_subDisplayAllowInter0, m_subDisplayAllowInter0);
-  m_parser->getOption<std::set<unsigned int> >(m_option_subDisplayAllowedSet, m_subDisplayAllowedSet);
-  m_parser->getOption<unsigned int>(m_option_displayVerbosity, m_displayVerbosity);
-  m_parser->getOption<unsigned int>(m_option_syncVerbosity, m_syncVerbosity);
-  m_parser->getOption<unsigned int>(m_option_checkingLevel, m_checkingLevel);
-  m_parser->getOption<std::string>(m_option_rngType, m_rngType);
-  m_parser->getOption<int>(m_option_seed, m_seed);
-  m_parser->getOption<std::string>(m_option_platformName, m_platformName);
-  m_parser->getOption<std::string>(m_option_identifyingString, m_identifyingString);
-#else
-  m_help = m_env->input()(m_option_help, UQ_ENV_HELP);
-  m_numSubEnvironments = m_env->input()(m_option_numSubEnvironments, UQ_ENV_NUM_SUB_ENVIRONMENTS_ODV);
-  m_subDisplayFileName = m_env->input()(m_option_subDisplayFileName, UQ_ENV_SUB_DISPLAY_FILE_NAME_ODV);
-  m_subDisplayAllowAll = m_env->input()(m_option_subDisplayAllowAll, UQ_ENV_SUB_DISPLAY_ALLOW_ALL_ODV);
-  m_subDisplayAllowInter0 = m_env->input()(m_option_subDisplayAllowInter0, UQ_ENV_SUB_DISPLAY_ALLOW_INTER0_ODV);
-
-  // UQ_ENV_SUB_DISPLAY_ALLOWED_SET_ODV is the empty set (string) by default
-  unsigned int size = m_env->input().vector_variable_size(m_option_subDisplayAllowedSet);
-  for (unsigned int i = 0; i < size; i++) {
-    // We default to empty set, so the default values are actually never
-    // used here
-    unsigned int allowed = m_env->input()(m_option_subDisplayAllowedSet, i, i);
-    m_subDisplayAllowedSet.insert(allowed);
-  }
-
-  m_displayVerbosity = m_env->input()(m_option_displayVerbosity, UQ_ENV_DISPLAY_VERBOSITY_ODV);
-  m_syncVerbosity = m_env->input()(m_option_syncVerbosity, UQ_ENV_SYNC_VERBOSITY_ODV);
-  m_checkingLevel = m_env->input()(m_option_checkingLevel, UQ_ENV_CHECKING_LEVEL_ODV);
-  m_rngType = m_env->input()(m_option_rngType, UQ_ENV_RNG_TYPE_ODV);
-  m_seed = m_env->input()(m_option_seed, UQ_ENV_SEED_ODV);
-  m_platformName = m_env->input()(m_option_platformName, UQ_ENV_PLATFORM_NAME_ODV);
-  m_identifyingString = m_env->input()(m_option_identifyingString, UQ_ENV_IDENTIFYING_STRING_ODV);
-#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-
-  checkOptions();
+  this->set_defaults();
+  this->parse(env, prefix);
 }
+
 
 void
 EnvOptionsValues::checkOptions()
@@ -262,6 +147,176 @@ std::ostream& operator<<(std::ostream& os, const EnvOptionsValues & obj)
    //<< "\n" << obj.m_option_numDebugParams    << " = " << obj.m_numDebugParams
      << std::endl;
   return os;
+}
+
+
+void
+EnvOptionsValues::set_defaults()
+{
+  m_help = UQ_ENV_HELP;
+  m_numSubEnvironments = UQ_ENV_NUM_SUB_ENVIRONMENTS_ODV;
+  m_subDisplayFileName = UQ_ENV_SUB_DISPLAY_FILE_NAME_ODV;
+  m_subDisplayAllowAll = UQ_ENV_SUB_DISPLAY_ALLOW_ALL_ODV;
+  m_subDisplayAllowInter0 = UQ_ENV_SUB_DISPLAY_ALLOW_INTER0_ODV;
+  //m_subDisplayAllowedSet  = ;
+  m_displayVerbosity = UQ_ENV_DISPLAY_VERBOSITY_ODV;
+  m_syncVerbosity = UQ_ENV_SYNC_VERBOSITY_ODV;
+  m_checkingLevel = UQ_ENV_CHECKING_LEVEL_ODV;
+  m_rngType = UQ_ENV_RNG_TYPE_ODV;
+  m_seed = UQ_ENV_SEED_ODV;
+  m_platformName = UQ_ENV_PLATFORM_NAME_ODV;
+  m_identifyingString = UQ_ENV_IDENTIFYING_STRING_ODV;
+  m_numDebugParams = UQ_ENV_NUM_DEBUG_PARAMS_ODV;
+  m_debugParams.assign(m_numDebugParams, 0.);
+}
+
+
+void
+EnvOptionsValues::set_prefix(const char* prefix)
+{
+  m_prefix = (std::string)(prefix) + "env_";
+
+  m_option_help = m_prefix + "help";
+  m_option_numSubEnvironments = m_prefix + "numSubEnvironments";
+  m_option_subDisplayFileName = m_prefix + "subDisplayFileName";
+  m_option_subDisplayAllowAll = m_prefix + "subDisplayAllowAll";
+  m_option_subDisplayAllowInter0 = m_prefix + "subDisplayAllowInter0";
+  m_option_subDisplayAllowedSet = m_prefix + "subDisplayAllowedSet";
+  m_option_displayVerbosity = m_prefix + "displayVerbosity";
+  m_option_syncVerbosity = m_prefix + "syncVerbosity";
+  m_option_checkingLevel = m_prefix + "checkingLevel";
+  m_option_rngType = m_prefix + "rngType";
+  m_option_seed = m_prefix + "seed";
+  m_option_platformName = m_prefix + "platformName";
+  m_option_identifyingString = m_prefix + "identifyingString";
+
+}
+
+
+void
+EnvOptionsValues::parse(const BaseEnvironment* env, const char* prefix)
+{
+  m_env = env;
+
+  if (m_env->optionsInputFileName().empty()) {
+    queso_error_msg("Missing input file is required");
+  }
+
+  this->set_prefix(prefix);
+
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+
+  m_parser.reset(new BoostInputOptionsParser(env->optionsInputFileName()));
+
+  // Register all options with parser
+  m_parser->registerOption<std::string>
+    (m_option_help, m_help, 
+    "produce help message for environment");
+  m_parser->registerOption<unsigned int>
+    (m_option_numSubEnvironments, m_numSubEnvironments,
+    "number of subEnvironments");
+  m_parser->registerOption<std::string >
+    (m_option_subDisplayFileName, m_subDisplayFileName,
+    "output filename for subscreen writing");
+  m_parser->registerOption<bool>
+    (m_option_subDisplayAllowAll, m_subDisplayAllowAll,
+    "Allow all processors to write to output file");
+  m_parser->registerOption<bool>
+    (m_option_subDisplayAllowInter0, m_subDisplayAllowInter0,
+    "Allow all inter0 nodes to write to output file");
+
+  // convert the current member set of integers to a string for default handling
+  std::ostringstream sdas_as_string;
+  std::ostream_iterator<unsigned int> out_it(sdas_as_string, " ");
+  std::copy(m_subDisplayAllowedSet.begin(), m_subDisplayAllowedSet.end(),
+            out_it);
+  m_parser->registerOption<std::string>
+    (m_option_subDisplayAllowedSet, sdas_as_string.str(),
+    "subEnvs that will write to output file");
+
+  m_parser->registerOption<unsigned int>
+    (m_option_displayVerbosity, m_displayVerbosity,
+    "set verbosity");
+  m_parser->registerOption<unsigned int>
+    (m_option_syncVerbosity, m_syncVerbosity,
+    "set sync verbosity");
+  m_parser->registerOption<unsigned int>
+    (m_option_checkingLevel, m_checkingLevel,
+    "set checking level");
+  m_parser->registerOption<std::string>
+    (m_option_rngType, m_rngType,
+    "set rngType");
+  m_parser->registerOption<int>
+    (m_option_seed, m_seed,
+    "set seed");
+  m_parser->registerOption<std::string>
+    (m_option_platformName, m_platformName,
+    "platform name");
+  m_parser->registerOption<std::string>
+    (m_option_identifyingString, m_identifyingString,
+    "identifying string");
+
+  // Read the input file
+  m_parser->scanInputFile();
+
+  // Retrieve parsed options
+  m_parser->getOption<std::string >(m_option_help, m_help);
+  m_parser->getOption<unsigned int>(m_option_numSubEnvironments, m_numSubEnvironments);
+  m_parser->getOption<std::string>(m_option_subDisplayFileName, m_subDisplayFileName);
+  m_parser->getOption<bool>(m_option_subDisplayAllowAll, m_subDisplayAllowAll);
+  m_parser->getOption<bool>(m_option_subDisplayAllowInter0, m_subDisplayAllowInter0);
+  m_parser->getOption<std::set<unsigned int> >(m_option_subDisplayAllowedSet, m_subDisplayAllowedSet);
+  m_parser->getOption<unsigned int>(m_option_displayVerbosity, m_displayVerbosity);
+  m_parser->getOption<unsigned int>(m_option_syncVerbosity, m_syncVerbosity);
+  m_parser->getOption<unsigned int>(m_option_checkingLevel, m_checkingLevel);
+  m_parser->getOption<std::string>(m_option_rngType, m_rngType);
+  m_parser->getOption<int>(m_option_seed, m_seed);
+  m_parser->getOption<std::string>(m_option_platformName, m_platformName);
+  m_parser->getOption<std::string>(m_option_identifyingString, m_identifyingString);
+#else
+
+  m_help = m_env->input()(m_option_help, m_help);
+
+  m_numSubEnvironments =
+    m_env->input()(m_option_numSubEnvironments, m_numSubEnvironments);
+
+  m_subDisplayFileName =
+    m_env->input()(m_option_subDisplayFileName, m_subDisplayFileName);
+
+  m_subDisplayAllowAll =
+    m_env->input()(m_option_subDisplayAllowAll, m_subDisplayAllowAll);
+
+  m_subDisplayAllowInter0 =
+    m_env->input()(m_option_subDisplayAllowInter0, m_subDisplayAllowInter0);
+
+  // UQ_ENV_SUB_DISPLAY_ALLOWED_SET_ODV is the empty set (string) by default
+  unsigned int size = m_env->input().vector_variable_size(m_option_subDisplayAllowedSet);
+  for (unsigned int i = 0; i < size; i++) {
+    // We default to empty set, so the default values are actually never
+    // used here
+    unsigned int allowed = m_env->input()(m_option_subDisplayAllowedSet, i, i);
+    m_subDisplayAllowedSet.insert(allowed);
+  }
+
+  m_displayVerbosity =
+    m_env->input()(m_option_displayVerbosity, m_displayVerbosity);
+
+  m_syncVerbosity = m_env->input()(m_option_syncVerbosity, m_syncVerbosity);
+
+  m_checkingLevel = m_env->input()(m_option_checkingLevel, m_checkingLevel);
+
+  m_rngType = m_env->input()(m_option_rngType, m_rngType);
+
+  m_seed = m_env->input()(m_option_seed, m_seed);
+
+  m_platformName = m_env->input()(m_option_platformName, m_platformName);
+
+  m_identifyingString =
+    m_env->input()(m_option_identifyingString, m_identifyingString);
+
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+
+  checkOptions();
 }
 
 }  // End namespace QUESO

--- a/src/core/src/InfiniteDimensionalMCMCSamplerOptions.C
+++ b/src/core/src/InfiniteDimensionalMCMCSamplerOptions.C
@@ -33,6 +33,17 @@
 
 namespace QUESO {
 
+InfiniteDimensionalMCMCSamplerOptions::InfiniteDimensionalMCMCSamplerOptions()
+  :
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+  m_parser(new BoostInputOptionsParser()),
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+  m_env(NULL)
+{
+  this->set_defaults();
+  this->set_prefix("");
+}
+
 InfiniteDimensionalMCMCSamplerOptions::InfiniteDimensionalMCMCSamplerOptions(
     const BaseEnvironment& env,
     const char * prefix)

--- a/src/core/src/OptimizerOptions.C
+++ b/src/core/src/OptimizerOptions.C
@@ -40,6 +40,9 @@ namespace QUESO {
 OptimizerOptions::OptimizerOptions()
   : 
   m_env(NULL)
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+  , m_parser(new BoostInputOptionsParser())
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 {
   this->set_defaults();
   this->set_prefix("");

--- a/src/core/src/OptimizerOptions.C
+++ b/src/core/src/OptimizerOptions.C
@@ -38,98 +38,18 @@
 namespace QUESO {
 
 OptimizerOptions::OptimizerOptions()
-  : m_prefix("ip_"),
-    m_help(UQ_OPT_HELP),
-    m_maxIterations(UQ_OPT_MAX_ITERATIONS),
-    m_tolerance(UQ_OPT_TOLERANCE),
-    m_finiteDifferenceStepSize(UQ_OPT_FINITE_DIFFERENCE_STEP_SIZE),
-    m_solverType(UQ_OPT_SOLVER_TYPE),
-    m_fstepSize(UQ_OPT_FSTEP_SIZE),
-    m_fdfstepSize(UQ_OPT_FDFSTEP_SIZE),
-    m_lineTolerance(UQ_OPT_LINE_TOLERANCE),
-    m_env(NULL),
-#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-    m_parser(NULL),
-#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-    m_option_help(m_prefix + "help"),
-    m_option_maxIterations(m_prefix + "maxIterations"),
-    m_option_tolerance(m_prefix + "tolerance"),
-    m_option_finiteDifferenceStepSize(m_prefix + "finiteDifferenceStepSize"),
-    m_option_solverType(m_prefix + "solverType"),
-    m_option_fstepSize(m_prefix + "fstepSize"),
-    m_option_fdfstepSize(m_prefix + "fdfStepSize"),
-    m_option_lineTolerance(m_prefix + "lineTolerance")
+  : 
+  m_env(NULL)
 {
+  this->set_defaults();
+  this->set_prefix("");
 }
 
-OptimizerOptions::OptimizerOptions(const BaseEnvironment * env, const char *
-    prefix)
-  : m_prefix((std::string)(prefix) + "optimizer_"),
-    m_help(UQ_OPT_HELP),
-    m_maxIterations(UQ_OPT_MAX_ITERATIONS),
-    m_tolerance(UQ_OPT_TOLERANCE),
-    m_finiteDifferenceStepSize(UQ_OPT_FINITE_DIFFERENCE_STEP_SIZE),
-    m_solverType(UQ_OPT_SOLVER_TYPE),
-    m_fstepSize(UQ_OPT_FSTEP_SIZE),
-    m_fdfstepSize(UQ_OPT_FDFSTEP_SIZE),
-    m_lineTolerance(UQ_OPT_LINE_TOLERANCE),
-    m_env(env),
-#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-    m_parser(new BoostInputOptionsParser(env->optionsInputFileName())),
-#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-    m_option_help(m_prefix + "help"),
-    m_option_maxIterations(m_prefix + "maxIterations"),
-    m_option_tolerance(m_prefix + "tolerance"),
-    m_option_finiteDifferenceStepSize(m_prefix + "finiteDifferenceStepSize"),
-    m_option_solverType(m_prefix + "solverType"),
-    m_option_fstepSize(m_prefix + "fstepSize"),
-    m_option_fdfstepSize(m_prefix + "fdfStepSize"),
-    m_option_lineTolerance(m_prefix + "lineTolerance")
+OptimizerOptions::
+OptimizerOptions(const BaseEnvironment* env, const char* prefix)
 {
-#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-  m_parser->registerOption<std::string>(m_option_help, UQ_OPT_HELP,
-      "produce help message for statistical inverse problem");
-
-  m_parser->registerOption<unsigned int>(m_option_maxIterations,
-      UQ_OPT_MAX_ITERATIONS,
-      "max number of optimizer iterations to do");
-  m_parser->registerOption<double>(m_option_tolerance, UQ_OPT_TOLERANCE,
-      "optimize until gradient is less than tolerance");
-  m_parser->registerOption<double>(m_option_finiteDifferenceStepSize,
-      UQ_OPT_FINITE_DIFFERENCE_STEP_SIZE,
-      "if no deriv is given, do finite difference with this step size");
-  m_parser->registerOption<std::string>(m_option_solverType, UQ_OPT_SOLVER_TYPE,
-      "which optimisation algorithm to use");
-  m_parser->registerOption<double>(m_option_fstepSize, UQ_OPT_FSTEP_SIZE,
-      "sets the step size used in gradient-free solvers");
-  m_parser->registerOption<double>(m_option_fdfstepSize, UQ_OPT_FDFSTEP_SIZE,
-      "sets the step size used in gradient-based solvers");
-  m_parser->registerOption<double>(m_option_lineTolerance, UQ_OPT_LINE_TOLERANCE,
-      "sets the line minimisation tolerance");
-
-  m_parser->scanInputFile();
-
-  m_parser->getOption<std::string>(m_option_help, m_help);
-  m_parser->getOption<unsigned int>(m_option_maxIterations, m_maxIterations);
-  m_parser->getOption<double>(m_option_tolerance, m_tolerance);
-  m_parser->getOption<double>(m_option_finiteDifferenceStepSize,
-      m_finiteDifferenceStepSize);
-  m_parser->getOption<std::string>(m_option_solverType, m_solverType);
-  m_parser->getOption<double>(m_option_fstepSize, m_fstepSize);
-  m_parser->getOption<double>(m_option_fdfstepSize, m_fdfstepSize);
-  m_parser->getOption<double>(m_option_lineTolerance, m_lineTolerance);
-#else
-  m_help = m_env->input()(m_option_help, UQ_OPT_HELP);
-  m_maxIterations = m_env->input()(m_option_maxIterations, UQ_OPT_MAX_ITERATIONS);
-  m_tolerance = m_env->input()(m_option_tolerance, UQ_OPT_TOLERANCE);
-  m_finiteDifferenceStepSize = m_env->input()(m_option_finiteDifferenceStepSize, UQ_OPT_FINITE_DIFFERENCE_STEP_SIZE);
-  m_solverType = m_env->input()(m_option_solverType, UQ_OPT_SOLVER_TYPE);
-  m_fstepSize = m_env->input()(m_option_fstepSize, UQ_OPT_FSTEP_SIZE);
-  m_fdfstepSize = m_env->input()(m_option_fdfstepSize, UQ_OPT_FDFSTEP_SIZE);
-  m_lineTolerance = m_env->input()(m_option_lineTolerance, UQ_OPT_LINE_TOLERANCE);
-#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-
-  checkOptions();
+  this->set_defaults();
+  this->parse(*env, prefix);
 }
 
 OptimizerOptions::OptimizerOptions(const OptimizerOptions & rhs)
@@ -143,7 +63,9 @@ OptimizerOptions::OptimizerOptions(const OptimizerOptions & rhs)
     m_fstepSize(rhs.m_fstepSize),
     m_fdfstepSize(rhs.m_fdfstepSize),
     m_lineTolerance(rhs.m_lineTolerance),
-    m_parser(rhs.m_parser),  // We'll never touch the input file in a copied object
+// #ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+//     m_parser(rhs.m_parser),  // We'll never touch the input file in a copied object
+// #endif
     m_option_help(rhs.m_option_help),
     m_option_maxIterations(rhs.m_option_maxIterations),
     m_option_tolerance(rhs.m_option_tolerance),
@@ -183,6 +105,91 @@ operator<<(std::ostream& os, const OptimizerOptions & obj)
   os << "\n" << obj.m_option_lineTolerance << " = " << obj.m_lineTolerance;
   os << std::endl;
   return os;
+}
+
+
+void OptimizerOptions::set_defaults()
+{
+  m_help = UQ_OPT_HELP;
+  m_maxIterations = UQ_OPT_MAX_ITERATIONS;
+  m_tolerance = UQ_OPT_TOLERANCE;
+  m_finiteDifferenceStepSize = UQ_OPT_FINITE_DIFFERENCE_STEP_SIZE;
+  m_solverType = UQ_OPT_SOLVER_TYPE;
+  m_fstepSize = UQ_OPT_FSTEP_SIZE;
+  m_fdfstepSize = UQ_OPT_FDFSTEP_SIZE;
+  m_lineTolerance = UQ_OPT_LINE_TOLERANCE;
+}
+
+
+void OptimizerOptions::set_prefix(const std::string& prefix)
+{
+  // NOTE: previously default ctor was setting to "ip_"
+  m_prefix = prefix + "optimizer_";
+
+  m_option_help = m_prefix + "help";
+  m_option_maxIterations = m_prefix + "maxIterations";
+  m_option_tolerance = m_prefix + "tolerance";
+  m_option_finiteDifferenceStepSize = m_prefix + "finiteDifferenceStepSize";
+  m_option_solverType = m_prefix + "solverType";
+  m_option_fstepSize = m_prefix + "fstepSize";
+  m_option_fdfstepSize = m_prefix + "fdfStepSize";
+  m_option_lineTolerance = m_prefix + "lineTolerance";
+}
+
+
+void OptimizerOptions::
+parse(const BaseEnvironment& env, const std::string& prefix)
+{
+  m_env = &env;
+
+  this->set_prefix(prefix);
+
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+
+  m_parser.reset(new BoostInputOptionsParser(env.optionsInputFileName()));
+
+  m_parser->registerOption<std::string>(m_option_help, m_help,
+      "produce help message for statistical inverse problem");
+  m_parser->registerOption<unsigned int>(m_option_maxIterations,
+      m_maxIterations,
+      "max number of optimizer iterations to do");
+  m_parser->registerOption<double>(m_option_tolerance, m_tolerance,
+      "optimize until gradient is less than tolerance");
+  m_parser->registerOption<double>(m_option_finiteDifferenceStepSize,
+      m_finiteDifferenceStepSize,
+      "if no deriv is given, do finite difference with this step size");
+  m_parser->registerOption<std::string>(m_option_solverType, m_solverType,
+      "which optimisation algorithm to use");
+  m_parser->registerOption<double>(m_option_fstepSize, m_fstepSize,
+      "sets the step size used in gradient-free solvers");
+  m_parser->registerOption<double>(m_option_fdfstepSize, m_fdfstepSize,
+      "sets the step size used in gradient-based solvers");
+  m_parser->registerOption<double>(m_option_lineTolerance, m_lineTolerance,
+      "sets the line minimisation tolerance");
+
+  m_parser->scanInputFile();
+
+  m_parser->getOption<std::string>(m_option_help, m_help);
+  m_parser->getOption<unsigned int>(m_option_maxIterations, m_maxIterations);
+  m_parser->getOption<double>(m_option_tolerance, m_tolerance);
+  m_parser->getOption<double>(m_option_finiteDifferenceStepSize,
+      m_finiteDifferenceStepSize);
+  m_parser->getOption<std::string>(m_option_solverType, m_solverType);
+  m_parser->getOption<double>(m_option_fstepSize, m_fstepSize);
+  m_parser->getOption<double>(m_option_fdfstepSize, m_fdfstepSize);
+  m_parser->getOption<double>(m_option_lineTolerance, m_lineTolerance);
+#else
+  m_help = m_env->input()(m_option_help, m_help);
+  m_maxIterations = m_env->input()(m_option_maxIterations, m_maxIterations);
+  m_tolerance = m_env->input()(m_option_tolerance, m_tolerance);
+  m_finiteDifferenceStepSize = m_env->input()(m_option_finiteDifferenceStepSize, m_finiteDifferenceStepSize);
+  m_solverType = m_env->input()(m_option_solverType, m_solverType);
+  m_fstepSize = m_env->input()(m_option_fstepSize, m_fstepSize);
+  m_fdfstepSize = m_env->input()(m_option_fdfstepSize, m_fdfstepSize);
+  m_lineTolerance = m_env->input()(m_option_lineTolerance, m_lineTolerance);
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+
+  checkOptions();
 }
 
 }  // End namespace QUESO

--- a/src/misc/inc/Miscellaneous.h
+++ b/src/misc/inc/Miscellaneous.h
@@ -80,6 +80,10 @@ void MiscComputePositionsBetweenMinMax(V minValues, V maxValues,
 template <class V1,class V2>
 void MiscCheckTheParallelEnvironment(const V1& vec1, const V2& vec2);
 
+//! Convert container contents to space-separated string, omitting trailing whitespace
+template<typename T>
+std::string container_to_string(const T& container);
+
 }  // End namespace QUESO
 
 #endif // UQ_MISCELLANEOUS_H

--- a/src/misc/src/Miscellaneous.C
+++ b/src/misc/src/Miscellaneous.C
@@ -30,6 +30,7 @@
 #include <sys/time.h>
 #include <iostream>
 #include <fstream>
+#include <sstream>
 #include <libgen.h>
 #include <sys/stat.h>
 #include <cmath>
@@ -595,8 +596,23 @@ MiscCheckTheParallelEnvironment(const V1& vec1, const V2& vec2)
   return;
 }
 
+
+template<typename T>
+std::string container_to_string(const T& container)
+{
+  std::ostringstream oss;
+  typename T::const_iterator it = container.begin();
+  for ( ; it != container.end(); ++it) {
+    if (it != container.begin())
+      oss << ' ';
+    oss << *it;
+  }
+  return oss.str();
+}
+
 }  // End namespace QUESO
 
 template void QUESO::MiscCheckTheParallelEnvironment<QUESO::GslVector, QUESO::GslVector>(QUESO::GslVector const&, QUESO::GslVector const&);
 template bool QUESO::MiscCheckForSameValueInAllNodes<bool>(bool&, double, QUESO::MpiComm const&, char const*);
 template bool QUESO::MiscCheckForSameValueInAllNodes<double>(double&, double, QUESO::MpiComm const&, char const*);
+template std::string QUESO::container_to_string(const std::set<unsigned int>& container);

--- a/src/misc/src/Miscellaneous.C
+++ b/src/misc/src/Miscellaneous.C
@@ -616,3 +616,4 @@ template void QUESO::MiscCheckTheParallelEnvironment<QUESO::GslVector, QUESO::Gs
 template bool QUESO::MiscCheckForSameValueInAllNodes<bool>(bool&, double, QUESO::MpiComm const&, char const*);
 template bool QUESO::MiscCheckForSameValueInAllNodes<double>(double&, double, QUESO::MpiComm const&, char const*);
 template std::string QUESO::container_to_string(const std::set<unsigned int>& container);
+template std::string QUESO::container_to_string(const std::vector<double>& container);

--- a/src/stats/inc/MLSamplingLevelOptions.h
+++ b/src/stats/inc/MLSamplingLevelOptions.h
@@ -134,6 +134,15 @@ public:
 
   //MLSamplingLevelOptions(const MLSamplingLevelOptions& inputOptions);
 
+  //! Set default values for parameter options
+  void set_defaults();
+
+  //! Set parameter option names to begin with prefix
+  void set_prefix(const std::string& prefix);
+
+  //! Given prefix, read the input file for parameters named "prefix"+*
+  void parse(const BaseEnvironment& env, const std::string& prefix);
+
   //! Destructor
   virtual ~MLSamplingLevelOptions();
   //@}
@@ -175,9 +184,6 @@ public:
 
   //! subEnvs that will write to generic output file.
   std::set<unsigned int>             m_dataOutputAllowedSet;
-
-  //! subEnvs that will write to generic output file.
-  std::string                        m_str1;
 
   //! Perform load balancing with chosen algorithm (0 = no balancing).
   unsigned int                       m_loadBalanceAlgorithmId;
@@ -227,9 +233,7 @@ public:
 
 
   std::set<unsigned int>             m_parameterDisabledSet; // gpmsa2
-  std::string                        m_str2; // gpmsa2
   std::vector<double>                m_initialValuesOfDisabledParameters; // gpmsa2
-  std::string                        m_str3; // gpmsa2
 
   //! Name of input file for raw chain.
   std::string                        m_rawChainDataInputFileName;
@@ -268,7 +272,6 @@ public:
   //! subEnvs that will write to output file for raw chain.
   std::set<unsigned int>             m_rawChainDataOutputAllowedSet;
 
-  std::string                        m_str4;
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
   //! Compute statistics on raw chain.
   bool                               m_rawChainComputeStats;
@@ -294,7 +297,6 @@ public:
 
   //! subEnvs that will write to output file for filtered chain.
   std::set<unsigned int>             m_filteredChainDataOutputAllowedSet;
-  std::string                        m_str5;
 
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
   //! Compute statistics on filtered chain.
@@ -318,7 +320,6 @@ public:
 
   //! 'dr' list of scales for proposal covariance matrices from 2nd stage on.
   std::vector<double>                m_drScalesForExtraStages;
-  std::string                        m_str6;
 
   //! Whether or not 'dr' is used during 'am' non adaptive interval.
   bool                               m_drDuringAmNonAdaptiveInt;
@@ -347,9 +348,6 @@ public:
   //! subEnvs that will write to output file for 'am' adapted matrices.
   std::set<unsigned int>             m_amAdaptedMatricesDataOutputAllowedSet;
 
-
-  std::string                        m_str7;
-
   //! 'am' eta.
   double                             m_amEta;
 
@@ -374,10 +372,10 @@ private:
   void getAllOptions();
   void defineAllOptions();
 
-  const BaseEnvironment&        m_env;
+  const BaseEnvironment*        m_env;
 
 #ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-  BoostInputOptionsParser * m_parser;
+  ScopedPtr<BoostInputOptionsParser>::Type m_parser;
 #endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   std::string                   m_option_help;
@@ -458,7 +456,7 @@ private:
   std::string                   m_option_tk;
   std::string                   m_option_updateInterval;
 
-  void checkOptions(const BaseEnvironment * env);
+  void checkOptions();
 
   friend std::ostream & operator<<(std::ostream & os,
       const MLSamplingLevelOptions & obj);

--- a/src/stats/inc/MLSamplingLevelOptions.h
+++ b/src/stats/inc/MLSamplingLevelOptions.h
@@ -129,6 +129,9 @@ class MLSamplingLevelOptions
 public:
   //! @name Constructor/Destructor methods
   //@{
+  //! Constructor
+  MLSamplingLevelOptions();
+
   //! Constructor: reads options from the input file.
   MLSamplingLevelOptions(const BaseEnvironment& env, const char* prefix);
 

--- a/src/stats/inc/MLSamplingOptions.h
+++ b/src/stats/inc/MLSamplingOptions.h
@@ -76,6 +76,9 @@ public:
   //@{
   //! Default constructor.
   /*! Assigns the default suite of options to the Multilevel sequence generator.*/
+  MLSamplingOptions();
+
+  //! Parsing constructor.
   MLSamplingOptions(const BaseEnvironment& env, const char* prefix);
 
   //! Set default values for parameter options

--- a/src/stats/inc/MLSamplingOptions.h
+++ b/src/stats/inc/MLSamplingOptions.h
@@ -78,6 +78,15 @@ public:
   /*! Assigns the default suite of options to the Multilevel sequence generator.*/
   MLSamplingOptions(const BaseEnvironment& env, const char* prefix);
 
+  //! Set default values for parameter options
+  void set_defaults();
+
+  //! Set parameter option names to begin with prefix
+  void set_prefix(const std::string& prefix);
+
+  //! Given prefix, read the input file for parameters named "prefix"+*
+  void parse(const BaseEnvironment& env, const std::string& prefix);
+
   //! Destructor
   virtual ~MLSamplingOptions();
   //@}
@@ -127,10 +136,10 @@ public:
   std::set<unsigned int> m_dataOutputAllowedSet;
 
 private:
-  const BaseEnvironment& m_env;
+  const BaseEnvironment* m_env;
 
 #ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-  BoostInputOptionsParser * m_parser;
+  ScopedPtr<BoostInputOptionsParser>::Type m_parser;
 #endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   std::string                   m_option_help;
@@ -149,7 +158,7 @@ private:
   std::string                   m_option_dataOutputAllowAll;
   std::string                   m_option_dataOutputAllowedSet;
 
-  void checkOptions(const BaseEnvironment * env);
+  void checkOptions();
 
   friend std::ostream & operator<<(std::ostream & os,
       const MLSamplingOptions & obj);

--- a/src/stats/inc/MetropolisHastingsSGOptions.h
+++ b/src/stats/inc/MetropolisHastingsSGOptions.h
@@ -156,6 +156,15 @@ public:
   /*! Extract options from MLSamplingLevelOptions to \c this.*/
   MhOptionsValues (const MLSamplingLevelOptions& ml_opts);
 
+  //! Set parameter option names to begin with prefix
+  void set_prefix(const std::string& prefix);
+
+  //! Set default values for parameter options
+  void set_defaults();
+
+  //! Given prefix, read the input file for parameters named "prefix"+*
+  void parse(const BaseEnvironment& env, const std::string& prefix);
+
   //! Destructor
   virtual ~MhOptionsValues            ();
   //@}
@@ -751,9 +760,7 @@ private:
   //! Copies the option values from \c src to \c this.
   void copy(const MhOptionsValues& src);
 
-  // We pass the the passed environment to get access to the MPI ranks etc for
-  // sanity checks
-  void checkOptions(const BaseEnvironment * env);
+  void checkOptions();
 
   friend std::ostream & operator<<(std::ostream & os,
       const MhOptionsValues & obj);

--- a/src/stats/inc/MonteCarloSGOptions.h
+++ b/src/stats/inc/MonteCarloSGOptions.h
@@ -100,6 +100,15 @@ public:
   /*! It assigns the same options values from  \c src to \c this.*/
   McOptionsValues            (const McOptionsValues& src);
 
+  //! Set default values for parameter options
+  void set_defaults();
+
+  //! Set parameter option names to begin with prefix
+  void set_prefix(const std::string& prefix);
+
+  //! Given prefix, read the input file for parameters named "prefix"+*
+  void parse(const BaseEnvironment& env, const std::string& prefix);
+
   //! Destructor
   virtual ~McOptionsValues            ();
   //@}
@@ -141,7 +150,7 @@ public:
 
 private:
 #ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-  BoostInputOptionsParser * m_parser;
+  ScopedPtr<BoostInputOptionsParser>::Type m_parser;
 #endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   std::string                   m_option_help;

--- a/src/stats/inc/StatisticalForwardProblemOptions.h
+++ b/src/stats/inc/StatisticalForwardProblemOptions.h
@@ -81,6 +81,15 @@ public:
   /*! It assigns the same options values from  \c src to \c this.*/
   SfpOptionsValues            (const SfpOptionsValues& src);
 
+  //! Set parameter option names to begin with prefix
+  void set_prefix(const std::string& prefix);
+
+  //! Set default values for parameter options
+  void set_defaults();
+
+  //! Given prefix, read the input file for parameters named "prefix"+*
+  void parse(const BaseEnvironment& env, const std::string& prefix);
+
   //! Destructor
   virtual ~SfpOptionsValues            ();
   //@}
@@ -109,7 +118,7 @@ public:
 
 private:
 #ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-  BoostInputOptionsParser * m_parser;
+  ScopedPtr<BoostInputOptionsParser>::Type m_parser;
 #endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 
   // The input options as strings so we can parse the input file later

--- a/src/stats/inc/StatisticalInverseProblemOptions.h
+++ b/src/stats/inc/StatisticalInverseProblemOptions.h
@@ -86,6 +86,15 @@ public:
   /*! It assigns the same options values from  \c src to \c this.*/
   SipOptionsValues            (const SipOptionsValues& src);
 
+  //! Set parameter option names to begin with prefix
+  void set_prefix(const std::string& prefix);
+
+  //! Set default values for parameter options
+  void set_defaults();
+
+  //! Given prefix, read the input file for parameters named "prefix"+*
+  void parse(const BaseEnvironment& env, const std::string& prefix);
+
   //! Destructor
   virtual ~SipOptionsValues            ();
   //@}

--- a/src/stats/src/MLSamplingLevelOptions.C
+++ b/src/stats/src/MLSamplingLevelOptions.C
@@ -31,176 +31,16 @@ namespace QUESO {
 MLSamplingLevelOptions::MLSamplingLevelOptions(
   const BaseEnvironment& env,
   const char*                   prefix)
-  :
-    m_prefix                                   ((std::string)(prefix) + ""),
-    m_help                                     (UQ_ML_SAMPLING_L_HELP),
-#ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY
-#else
-    m_checkpointOutputFileName                 (UQ_ML_SAMPLING_L_CHECKPOINT_OUTPUT_FILE_NAME_ODV),
-#endif
-    m_stopAtEnd                                (UQ_ML_SAMPLING_L_STOP_AT_END_ODV),
-    m_dataOutputFileName                       (UQ_ML_SAMPLING_L_DATA_OUTPUT_FILE_NAME_ODV),
-    m_dataOutputAllowAll                       (UQ_ML_SAMPLING_L_DATA_OUTPUT_ALLOW_ALL_ODV),
-  //m_dataOutputAllowedSet                     (),
-    m_str1                                     (""),
-    m_loadBalanceAlgorithmId                   (UQ_ML_SAMPLING_L_LOAD_BALANCE_ALGORITHM_ID_ODV),
-    m_loadBalanceTreshold                      (UQ_ML_SAMPLING_L_LOAD_BALANCE_TRESHOLD_ODV),
-    m_minEffectiveSizeRatio                    (UQ_ML_SAMPLING_L_MIN_EFFECTIVE_SIZE_RATIO_ODV),
-    m_maxEffectiveSizeRatio                    (UQ_ML_SAMPLING_L_MAX_EFFECTIVE_SIZE_RATIO_ODV),
-    m_scaleCovMatrix                           (UQ_ML_SAMPLING_L_SCALE_COV_MATRIX_ODV),
-    m_minRejectionRate                         (UQ_ML_SAMPLING_L_MIN_REJECTION_RATE_ODV),
-    m_maxRejectionRate                         (UQ_ML_SAMPLING_L_MAX_REJECTION_RATE_ODV),
-    m_covRejectionRate                         (UQ_ML_SAMPLING_L_COV_REJECTION_RATE_ODV),
-    m_minAcceptableEta                         (UQ_ML_SAMPLING_L_MIN_ACCEPTABLE_ETA_ODV), // gpmsa1
-    m_totallyMute                              (UQ_ML_SAMPLING_L_TOTALLY_MUTE_ODV),
-    m_initialPositionDataInputFileName         (UQ_ML_SAMPLING_L_INITIAL_POSITION_DATA_INPUT_FILE_NAME_ODV),
-    m_initialPositionDataInputFileType         (UQ_ML_SAMPLING_L_INITIAL_POSITION_DATA_INPUT_FILE_TYPE_ODV),
-    m_initialProposalCovMatrixDataInputFileName(UQ_ML_SAMPLING_L_INITIAL_PROPOSAL_COV_MATRIX_DATA_INPUT_FILE_NAME_ODV),
-    m_initialProposalCovMatrixDataInputFileType(UQ_ML_SAMPLING_L_INITIAL_PROPOSAL_COV_MATRIX_DATA_INPUT_FILE_TYPE_ODV),
-    m_initialPositionUsePreviousLevelLikelihood(UQ_ML_SAMPLING_L_INITIAL_POSITION_USE_PREVIOUS_LEVEL_LIKELIHOOD_ODV),  // ml_likelihood_caching
-  //m_parameterDisabledSet                     (), // gpmsa2
-    m_str2                                     (""),
-    m_initialValuesOfDisabledParameters        (0),
-    m_str3                                     (""),
-    m_rawChainDataInputFileName                (UQ_ML_SAMPLING_L_RAW_CHAIN_DATA_INPUT_FILE_NAME_ODV),
-    m_rawChainDataInputFileType                (UQ_ML_SAMPLING_L_RAW_CHAIN_DATA_INPUT_FILE_TYPE_ODV),
-    m_rawChainSize                             (UQ_ML_SAMPLING_L_RAW_CHAIN_SIZE_ODV),
-    m_rawChainGenerateExtra                    (UQ_ML_SAMPLING_L_RAW_CHAIN_GENERATE_EXTRA_ODV),
-    m_rawChainDisplayPeriod                    (UQ_ML_SAMPLING_L_RAW_CHAIN_DISPLAY_PERIOD_ODV),
-    m_rawChainMeasureRunTimes                  (UQ_ML_SAMPLING_L_RAW_CHAIN_MEASURE_RUN_TIMES_ODV),
-    m_rawChainDataOutputPeriod                 (UQ_ML_SAMPLING_L_RAW_CHAIN_DATA_OUTPUT_PERIOD_ODV),
-    m_rawChainDataOutputFileName               (UQ_ML_SAMPLING_L_RAW_CHAIN_DATA_OUTPUT_FILE_NAME_ODV),
-    m_rawChainDataOutputFileType               (UQ_ML_SAMPLING_L_RAW_CHAIN_DATA_OUTPUT_FILE_TYPE_ODV),
-    m_rawChainDataOutputAllowAll               (UQ_ML_SAMPLING_L_RAW_CHAIN_DATA_OUTPUT_ALLOW_ALL_ODV),
-  //m_rawChainDataOutputAllowedSet             (),
-    m_str4                                     (""),
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-    m_rawChainComputeStats                     (UQ_ML_SAMPLING_L_RAW_CHAIN_COMPUTE_STATS_ODV),
-    m_rawChainStatisticalOptionsObj            (NULL),
-    m_rawChainStatOptsInstantiated             (false),
-#endif
-    m_filteredChainGenerate                    (UQ_ML_SAMPLING_L_FILTERED_CHAIN_GENERATE_ODV),
-    m_filteredChainDiscardedPortion            (UQ_ML_SAMPLING_L_FILTERED_CHAIN_DISCARDED_PORTION_ODV),
-    m_filteredChainLag                         (UQ_ML_SAMPLING_L_FILTERED_CHAIN_LAG_ODV),
-    m_filteredChainDataOutputFileName          (UQ_ML_SAMPLING_L_FILTERED_CHAIN_DATA_OUTPUT_FILE_NAME_ODV),
-    m_filteredChainDataOutputFileType          (UQ_ML_SAMPLING_L_FILTERED_CHAIN_DATA_OUTPUT_FILE_TYPE_ODV),
-    m_filteredChainDataOutputAllowAll          (UQ_ML_SAMPLING_L_FILTERED_CHAIN_DATA_OUTPUT_ALLOW_ALL_ODV),
-  //m_filteredChainDataOutputAllowedSet        (),
-    m_str5                                     (""),
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-    m_filteredChainComputeStats                (UQ_ML_SAMPLING_L_FILTERED_CHAIN_COMPUTE_STATS_ODV),
-    m_filteredChainStatisticalOptionsObj       (NULL),
-    m_filteredChainStatOptsInstantiated        (false),
-#endif
-    m_displayCandidates                        (UQ_ML_SAMPLING_L_DISPLAY_CANDIDATES_ODV),
-    m_putOutOfBoundsInChain                    (UQ_ML_SAMPLING_L_PUT_OUT_OF_BOUNDS_IN_CHAIN_ODV),
-    m_tkUseLocalHessian                        (UQ_ML_SAMPLING_L_TK_USE_LOCAL_HESSIAN_ODV),
-    m_tkUseNewtonComponent                     (UQ_ML_SAMPLING_L_TK_USE_NEWTON_COMPONENT_ODV),
-    m_drMaxNumExtraStages                      (UQ_ML_SAMPLING_L_DR_MAX_NUM_EXTRA_STAGES_ODV),
-    m_drScalesForExtraStages                   (0),
-    m_str6                                     ("1. "),
-    m_drDuringAmNonAdaptiveInt                 (UQ_ML_SAMPLING_L_DR_DURING_AM_NON_ADAPTIVE_INT_ODV),
-    m_amKeepInitialMatrix                      (UQ_ML_SAMPLING_L_AM_KEEP_INITIAL_MATRIX_ODV),
-    m_amInitialNonAdaptInterval                (UQ_ML_SAMPLING_L_AM_INIT_NON_ADAPT_INT_ODV),
-    m_amAdaptInterval                          (UQ_ML_SAMPLING_L_AM_ADAPT_INTERVAL_ODV),
-    m_amAdaptedMatricesDataOutputPeriod        (UQ_ML_SAMPLING_L_AM_ADAPTED_MATRICES_DATA_OUTPUT_PERIOD_ODV),
-    m_amAdaptedMatricesDataOutputFileName      (UQ_ML_SAMPLING_L_AM_ADAPTED_MATRICES_DATA_OUTPUT_FILE_NAME_ODV),
-    m_amAdaptedMatricesDataOutputFileType      (UQ_ML_SAMPLING_L_AM_ADAPTED_MATRICES_DATA_OUTPUT_FILE_TYPE_ODV),
-    m_amAdaptedMatricesDataOutputAllowAll      (UQ_ML_SAMPLING_L_AM_ADAPTED_MATRICES_DATA_OUTPUT_ALLOW_ALL_ODV),
-  //m_amAdaptedMatricesDataOutputAllowedSet    (),
-    m_str7                                     (""),
-    m_amEta                                    (UQ_ML_SAMPLING_L_AM_ETA_ODV),
-    m_amEpsilon                                (UQ_ML_SAMPLING_L_AM_EPSILON_ODV),
-    m_env                                      (env),
-#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-    m_parser(new BoostInputOptionsParser(env.optionsInputFileName())),
-#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-    m_option_help                                      (m_prefix + "help"                                      ),
-#ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY
-#else
-    m_option_checkpointOutputFileName                  (m_prefix + "checkpointOutputFileName"                  ),
-#endif
-    m_option_stopAtEnd                                 (m_prefix + "stopAtEnd"                                 ),
-    m_option_dataOutputFileName                        (m_prefix + "dataOutputFileName"                        ),
-    m_option_dataOutputAllowAll                        (m_prefix + "dataOutputAllowAll"                        ),
-    m_option_dataOutputAllowedSet                      (m_prefix + "dataOutputAllowedSet"                      ),
-    m_option_loadBalanceAlgorithmId                    (m_prefix + "loadBalanceAlgorithmId"                    ),
-    m_option_loadBalanceTreshold                       (m_prefix + "loadBalanceTreshold"                       ),
-    m_option_minEffectiveSizeRatio                     (m_prefix + "minEffectiveSizeRatio"                     ),
-    m_option_maxEffectiveSizeRatio                     (m_prefix + "maxEffectiveSizeRatio"                     ),
-    m_option_scaleCovMatrix                            (m_prefix + "scaleCovMatrix"                            ),
-    m_option_minRejectionRate                          (m_prefix + "minRejectionRate"                          ),
-    m_option_maxRejectionRate                          (m_prefix + "maxRejectionRate"                          ),
-    m_option_covRejectionRate                          (m_prefix + "covRejectionRate"                          ),
-    m_option_minAcceptableEta                          (m_prefix + "minAcceptableEta"                          ), // gpmsa1
-    m_option_totallyMute                               (m_prefix + "totallyMute"                               ),
-    m_option_initialPosition_dataInputFileName         (m_prefix + "initialPosition_dataInputFileName"         ),
-    m_option_initialPosition_dataInputFileType         (m_prefix + "initialPosition_dataInputFileType"         ),
-    m_option_initialProposalCovMatrix_dataInputFileName(m_prefix + "initialProposalCovMatrix_dataInputFileName"),
-    m_option_initialProposalCovMatrix_dataInputFileType(m_prefix + "initialProposalCovMatrix_dataInputFileType"),
-    m_option_initialPositionUsePreviousLevelLikelihood (m_prefix + "initialPositionUsePreviousLevelLikelihood" ), // ml_likelihood_caching
-    m_option_listOfDisabledParameters                  (m_prefix + "listOfDisabledParameters"                  ), // gpmsa2
-    m_option_initialValuesOfDisabledParameters         (m_prefix + "initialValuesOfDisabledParameters"         ), // gpmsa2
-    m_option_rawChain_dataInputFileName                (m_prefix + "rawChain_dataInputFileName"                ),
-    m_option_rawChain_dataInputFileType                (m_prefix + "rawChain_dataInputFileType"                ),
-    m_option_rawChain_size                             (m_prefix + "rawChain_size"                             ),
-    m_option_rawChain_generateExtra                    (m_prefix + "rawChain_generateExtra"                    ),
-    m_option_rawChain_displayPeriod                    (m_prefix + "rawChain_displayPeriod"                    ),
-    m_option_rawChain_measureRunTimes                  (m_prefix + "rawChain_measureRunTimes"                  ),
-    m_option_rawChain_dataOutputPeriod                 (m_prefix + "rawChain_dataOutputPeriod"                 ),
-    m_option_rawChain_dataOutputFileName               (m_prefix + "rawChain_dataOutputFileName"               ),
-    m_option_rawChain_dataOutputFileType               (m_prefix + "rawChain_dataOutputFileType"               ),
-    m_option_rawChain_dataOutputAllowAll               (m_prefix + "rawChain_dataOutputAllowAll"               ),
-    m_option_rawChain_dataOutputAllowedSet             (m_prefix + "rawChain_dataOutputAllowedSet"             ),
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-    m_option_rawChain_computeStats                     (m_prefix + "rawChain_computeStats"                     ),
-#endif
-    m_option_filteredChain_generate                    (m_prefix + "filteredChain_generate"                    ),
-    m_option_filteredChain_discardedPortion            (m_prefix + "filteredChain_discardedPortion"            ),
-    m_option_filteredChain_lag                         (m_prefix + "filteredChain_lag"                         ),
-    m_option_filteredChain_dataOutputFileName          (m_prefix + "filteredChain_dataOutputFileName"          ),
-    m_option_filteredChain_dataOutputFileType          (m_prefix + "filteredChain_dataOutputFileType"          ),
-    m_option_filteredChain_dataOutputAllowAll          (m_prefix + "filteredChain_dataOutputAllowAll"          ),
-    m_option_filteredChain_dataOutputAllowedSet        (m_prefix + "filteredChain_dataOutputAllowedSet"        ),
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-    m_option_filteredChain_computeStats                (m_prefix + "filteredChain_computeStats"                ),
-#endif
-    m_option_displayCandidates                         (m_prefix + "displayCandidates"                         ),
-    m_option_putOutOfBoundsInChain                     (m_prefix + "putOutOfBoundsInChain"                     ),
-    m_option_tk_useLocalHessian                        (m_prefix + "tk_useLocalHessian"                        ),
-    m_option_tk_useNewtonComponent                     (m_prefix + "tk_useNewtonComponent"                     ),
-    m_option_dr_maxNumExtraStages                      (m_prefix + "dr_maxNumExtraStages"                      ),
-    m_option_dr_listOfScalesForExtraStages             (m_prefix + "dr_listOfScalesForExtraStages"             ),
-    m_option_dr_duringAmNonAdaptiveInt                 (m_prefix + "dr_duringAmNonAdaptiveInt"                 ),
-    m_option_am_keepInitialMatrix                      (m_prefix + "am_keepInitialMatrix"                      ),
-    m_option_am_initialNonAdaptInterval                (m_prefix + "am_initialNonAdaptInterval"                ),
-    m_option_am_adaptInterval                          (m_prefix + "am_adaptInterval"                          ),
-    m_option_am_adaptedMatrices_dataOutputPeriod       (m_prefix + "amAdaptedMatrices_dataOutputPeriod"        ),
-    m_option_am_adaptedMatrices_dataOutputFileName     (m_prefix + "amAdaptedMatrices_dataOutputFileName"      ),
-    m_option_am_adaptedMatrices_dataOutputFileType     (m_prefix + "amAdaptedMatrices_dataOutputFileType"      ),
-    m_option_am_adaptedMatrices_dataOutputAllowAll     (m_prefix + "amAdaptedMatrices_dataOutputAllowAll"      ),
-    m_option_am_adaptedMatrices_dataOutputAllowedSet   (m_prefix + "amAdaptedMatrices_dataOutputAllowedSet"    ),
-    m_option_am_eta                                    (m_prefix + "am_eta"                                    ),
-    m_option_am_epsilon                                (m_prefix + "am_epsilon"                                ),
-    m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          ),
-    m_option_algorithm                                 (m_prefix + "algorithm"                                 ),
-    m_option_tk                                        (m_prefix + "tk"                                        ),
-    m_option_updateInterval                            (m_prefix + "updateInterval"                            )
 {
-#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-  this->defineAllOptions();
-  m_parser->scanInputFile();
-#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-  this->getAllOptions();
-
-  checkOptions(&env);
+  this->set_defaults();
+  this->parse(env, prefix);
 }
 
 void
 MLSamplingLevelOptions::defineAllOptions()
 {
 #ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-  m_parser->registerOption<std::string >(m_option_help,                                       UQ_ML_SAMPLING_L_HELP                      , "produce help message for Bayesian Markov chain distr. calculator");
+  m_parser->registerOption<std::string >(m_option_help,                                       m_help                                     , "produce help message for Bayesian Markov chain distr. calculator");
 #ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY
 #else
   m_parser->registerOption<std::string >(m_option_checkpointOutputFileName,                   m_checkpointOutputFileName                 , "name of checpoint output file"                                   );
@@ -208,7 +48,7 @@ MLSamplingLevelOptions::defineAllOptions()
   m_parser->registerOption<bool        >(m_option_stopAtEnd,                                  m_stopAtEnd                                , "stop at end of such level"                                       );
   m_parser->registerOption<std::string >(m_option_dataOutputFileName,                         m_dataOutputFileName                       , "name of generic output file"                                     );
   m_parser->registerOption<bool        >(m_option_dataOutputAllowAll,                         m_dataOutputAllowAll                       , "subEnvs that will write to generic output file"                  );
-  m_parser->registerOption<std::string >(m_option_dataOutputAllowedSet,                       m_str1                                     , "subEnvs that will write to generic output file"                  );
+  m_parser->registerOption<std::string >(m_option_dataOutputAllowedSet,                       container_to_string(m_dataOutputAllowedSet)                                     , "subEnvs that will write to generic output file"                  );
   m_parser->registerOption<unsigned int>(m_option_loadBalanceAlgorithmId,                     m_loadBalanceAlgorithmId                   , "Perform load balancing with chosen algorithm (0 = no balancing)" );
   m_parser->registerOption<double      >(m_option_loadBalanceTreshold,                        m_loadBalanceTreshold                      , "Perform load balancing if load unbalancing ratio > treshold"     );
   m_parser->registerOption<double      >(m_option_minEffectiveSizeRatio,                      m_minEffectiveSizeRatio                    , "minimum allowed effective size ratio wrt previous level"         );
@@ -224,8 +64,8 @@ MLSamplingLevelOptions::defineAllOptions()
   m_parser->registerOption<std::string >(m_option_initialProposalCovMatrix_dataInputFileName, m_initialProposalCovMatrixDataInputFileName, "name of input file for initial proposal covariance matrix"       );
   m_parser->registerOption<std::string >(m_option_initialProposalCovMatrix_dataInputFileType, m_initialProposalCovMatrixDataInputFileType, "type of input file for initial proposal covariance matrix"       );
   m_parser->registerOption<bool        >(m_option_initialPositionUsePreviousLevelLikelihood,  m_initialPositionUsePreviousLevelLikelihood, "use previous level likelihood for initial chain position instead of re-computing from target pdf");
-  m_parser->registerOption<std::string >(m_option_listOfDisabledParameters,                   m_str2                                     , "list of disabled parameters"                                     );  // gpmsa2
-  m_parser->registerOption<std::string >(m_option_initialValuesOfDisabledParameters,          m_str3                                     , "initial values of disabled parameters"                           );  // gpmsa2
+  m_parser->registerOption<std::string >(m_option_listOfDisabledParameters,                   container_to_string(m_parameterDisabledSet)                                     , "list of disabled parameters"                                     );  // gpmsa2
+  m_parser->registerOption<std::string >(m_option_initialValuesOfDisabledParameters,          container_to_string(m_initialValuesOfDisabledParameters)                                     , "initial values of disabled parameters"                           );  // gpmsa2
   m_parser->registerOption<std::string >(m_option_rawChain_dataInputFileName,                 m_rawChainDataInputFileName                , "name of input file for raw chain "                               );
   m_parser->registerOption<std::string >(m_option_rawChain_dataInputFileType,                 m_rawChainDataInputFileType                , "type of input file for raw chain "                               );
   m_parser->registerOption<unsigned int>(m_option_rawChain_size,                              m_rawChainSize                             , "size of raw chain"                                               );
@@ -236,7 +76,7 @@ MLSamplingLevelOptions::defineAllOptions()
   m_parser->registerOption<std::string >(m_option_rawChain_dataOutputFileName,                m_rawChainDataOutputFileName               , "name of output file for raw chain "                              );
   m_parser->registerOption<std::string >(m_option_rawChain_dataOutputFileType,                m_rawChainDataOutputFileType               , "type of output file for raw chain "                              );
   m_parser->registerOption<bool        >(m_option_rawChain_dataOutputAllowAll,                m_rawChainDataOutputAllowAll               , "subEnvs that will write to output file for raw chain"            );
-  m_parser->registerOption<std::string >(m_option_rawChain_dataOutputAllowedSet,              m_str4                                     , "subEnvs that will write to output file for raw chain"            );
+  m_parser->registerOption<std::string >(m_option_rawChain_dataOutputAllowedSet,              container_to_string(m_rawChainDataOutputAllowedSet)                                     , "subEnvs that will write to output file for raw chain"            );
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
   m_parser->registerOption<bool        >(m_option_rawChain_computeStats,                      m_rawChainComputeStats                     , "compute statistics on raw chain"                                 );
 #endif
@@ -246,7 +86,7 @@ MLSamplingLevelOptions::defineAllOptions()
   m_parser->registerOption<std::string >(m_option_filteredChain_dataOutputFileName,           m_filteredChainDataOutputFileName          , "name of output file for filtered chain"                          );
   m_parser->registerOption<std::string >(m_option_filteredChain_dataOutputFileType,           m_filteredChainDataOutputFileType          , "type of output file for filtered chain"                          );
   m_parser->registerOption<bool        >(m_option_filteredChain_dataOutputAllowAll,           m_filteredChainDataOutputAllowAll          , "subEnvs that will write to output file for filtered chain"       );
-  m_parser->registerOption<std::string >(m_option_filteredChain_dataOutputAllowedSet,         m_str5                                     , "subEnvs that will write to output file for filtered chain"       );
+  m_parser->registerOption<std::string >(m_option_filteredChain_dataOutputAllowedSet,         container_to_string(m_filteredChainDataOutputAllowedSet)                                     , "subEnvs that will write to output file for filtered chain"       );
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
   m_parser->registerOption<bool        >(m_option_filteredChain_computeStats,                 m_filteredChainComputeStats                , "compute statistics on filtered chain"                            );
 #endif
@@ -255,7 +95,7 @@ MLSamplingLevelOptions::defineAllOptions()
   m_parser->registerOption<bool        >(m_option_tk_useLocalHessian,                         m_tkUseLocalHessian                        , "'proposal' use local Hessian"                                    );
   m_parser->registerOption<bool        >(m_option_tk_useNewtonComponent,                      m_tkUseNewtonComponent                     , "'proposal' use Newton component"                                 );
   m_parser->registerOption<unsigned int>(m_option_dr_maxNumExtraStages,                       m_drMaxNumExtraStages                      , "'dr' maximum number of extra stages"                             );
-  m_parser->registerOption<std::string >(m_option_dr_listOfScalesForExtraStages,              m_str6                                     , "'dr' list of scales for proposal cov matrices from 2nd stage on" );
+  m_parser->registerOption<std::string >(m_option_dr_listOfScalesForExtraStages,              container_to_string(m_drScalesForExtraStages)                                     , "'dr' list of scales for proposal cov matrices from 2nd stage on" );
   m_parser->registerOption<bool        >(m_option_dr_duringAmNonAdaptiveInt,                  m_drDuringAmNonAdaptiveInt                 , "'dr' used during 'am' non adaptive interval"                     );
   m_parser->registerOption<bool        >(m_option_am_keepInitialMatrix,                       m_amKeepInitialMatrix                      , "'am' keep initial (given) matrix"                                );
   m_parser->registerOption<unsigned int>(m_option_am_initialNonAdaptInterval,                 m_amInitialNonAdaptInterval                , "'am' initial non adaptation interval"                            );
@@ -264,13 +104,13 @@ MLSamplingLevelOptions::defineAllOptions()
   m_parser->registerOption<std::string >(m_option_am_adaptedMatrices_dataOutputFileName,      m_amAdaptedMatricesDataOutputFileName      , "name of output file for 'am' adapted matrices"                   );
   m_parser->registerOption<std::string >(m_option_am_adaptedMatrices_dataOutputFileType,      m_amAdaptedMatricesDataOutputFileType      , "type of output file for 'am' adapted matrices"                   );
   m_parser->registerOption<bool        >(m_option_am_adaptedMatrices_dataOutputAllowAll,      m_amAdaptedMatricesDataOutputAllowAll      , "type of output file for 'am' adapted matrices"                   );
-  m_parser->registerOption<std::string >(m_option_am_adaptedMatrices_dataOutputAllowedSet,    m_str7                                     , "type of output file for 'am' adapted matrices"                   );
+  m_parser->registerOption<std::string >(m_option_am_adaptedMatrices_dataOutputAllowedSet,    container_to_string(m_amAdaptedMatricesDataOutputAllowedSet)                                     , "type of output file for 'am' adapted matrices"                   );
   m_parser->registerOption<double      >(m_option_am_eta,                                     m_amEta                                    , "'am' eta"                                                        );
   m_parser->registerOption<double      >(m_option_am_epsilon,                                 m_amEpsilon                                , "'am' epsilon"                                                    );
-  m_parser->registerOption<bool        >(m_option_doLogitTransform,                           UQ_ML_SAMPLING_L_DO_LOGIT_TRANSFORM        , "flag for doing logit transform for bounded domains"              );
-  m_parser->registerOption<std::string >(m_option_algorithm,                                  UQ_ML_SAMPLING_L_ALGORITHM                 , "which algorithm to use for sampling"                             );
-  m_parser->registerOption<std::string >(m_option_tk,                                         UQ_ML_SAMPLING_L_TK                        , "which transition kernel to use for sampling"                     );
-  m_parser->registerOption<unsigned int>(m_option_updateInterval,                             UQ_ML_SAMPLING_L_UPDATE_INTERVAL           , "how often to call TK's updateTK method"                          );
+  m_parser->registerOption<bool        >(m_option_doLogitTransform,                           m_doLogitTransform                         , "flag for doing logit transform for bounded domains"              );
+  m_parser->registerOption<std::string >(m_option_algorithm,                                  m_algorithm                                , "which algorithm to use for sampling"                             );
+  m_parser->registerOption<std::string >(m_option_tk,                                         m_tk                                       , "which transition kernel to use for sampling"                     );
+  m_parser->registerOption<unsigned int>(m_option_updateInterval,                             m_updateInterval                           , "how often to call TK's updateTK method"                          );
 #endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 }
 
@@ -350,138 +190,138 @@ MLSamplingLevelOptions::getAllOptions()
   m_parser->getOption<std::string >(m_option_tk,                                         m_tk);
   m_parser->getOption<unsigned int>(m_option_updateInterval,                             m_updateInterval);
 #else
-  m_help = m_env.input()(m_option_help,                                       UQ_ML_SAMPLING_L_HELP                      );
+  m_help = m_env->input()(m_option_help, m_help);
 #ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY
 #else
-  m_checkpointOutputFileName                  = m_env.input()(m_option_checkpointOutputFileName,                   m_checkpointOutputFileName                 );
+  m_checkpointOutputFileName                  = m_env->input()(m_option_checkpointOutputFileName,                   m_checkpointOutputFileName                 );
 #endif
-  m_stopAtEnd                                 = m_env.input()(m_option_stopAtEnd,                                  m_stopAtEnd                                );
-  m_dataOutputFileName                        = m_env.input()(m_option_dataOutputFileName,                         m_dataOutputFileName                       );
-  m_dataOutputAllowAll                        = m_env.input()(m_option_dataOutputAllowAll,                         m_dataOutputAllowAll                       );
+  m_stopAtEnd                                 = m_env->input()(m_option_stopAtEnd,                                  m_stopAtEnd                                );
+  m_dataOutputFileName                        = m_env->input()(m_option_dataOutputFileName,                         m_dataOutputFileName                       );
+  m_dataOutputAllowAll                        = m_env->input()(m_option_dataOutputAllowAll,                         m_dataOutputAllowAll                       );
 
   // Is the empty set (string) by default
-  unsigned int size = m_env.input().vector_variable_size(m_option_dataOutputAllowedSet);
+  unsigned int size = m_env->input().vector_variable_size(m_option_dataOutputAllowedSet);
   for (unsigned int i = 0; i < size; i++) {
     // We default to empty set, so the default values are actually never
     // used here
-    unsigned int allowed = m_env.input()(m_option_dataOutputAllowedSet, i, i);
+    unsigned int allowed = m_env->input()(m_option_dataOutputAllowedSet, i, i);
     m_dataOutputAllowedSet.insert(allowed);
   }
 
-  m_loadBalanceAlgorithmId                    = m_env.input()(m_option_loadBalanceAlgorithmId,                     m_loadBalanceAlgorithmId                   );
-  m_loadBalanceTreshold                       = m_env.input()(m_option_loadBalanceTreshold,                        m_loadBalanceTreshold                      );
-  m_minEffectiveSizeRatio                     = m_env.input()(m_option_minEffectiveSizeRatio,                      m_minEffectiveSizeRatio                    );
-  m_maxEffectiveSizeRatio                     = m_env.input()(m_option_maxEffectiveSizeRatio,                      m_maxEffectiveSizeRatio                    );
-  m_scaleCovMatrix                            = m_env.input()(m_option_scaleCovMatrix,                             m_scaleCovMatrix                           );
-  m_minRejectionRate                          = m_env.input()(m_option_minRejectionRate,                           m_minRejectionRate                         );
-  m_maxRejectionRate                          = m_env.input()(m_option_maxRejectionRate,                           m_maxRejectionRate                         );
-  m_covRejectionRate                          = m_env.input()(m_option_covRejectionRate,                           m_covRejectionRate                         );
-  m_minAcceptableEta                          = m_env.input()(m_option_minAcceptableEta,                           m_minAcceptableEta                         );
-  m_totallyMute                               = m_env.input()(m_option_totallyMute,                                m_totallyMute                              );
-  m_initialPositionDataInputFileName          = m_env.input()(m_option_initialPosition_dataInputFileName,          m_initialPositionDataInputFileName         );
-  m_initialPositionDataInputFileType          = m_env.input()(m_option_initialPosition_dataInputFileType,          m_initialPositionDataInputFileType         );
-  m_initialProposalCovMatrixDataInputFileName = m_env.input()(m_option_initialProposalCovMatrix_dataInputFileName, m_initialProposalCovMatrixDataInputFileName);
-  m_initialProposalCovMatrixDataInputFileType = m_env.input()(m_option_initialProposalCovMatrix_dataInputFileType, m_initialProposalCovMatrixDataInputFileType);
-  m_initialPositionUsePreviousLevelLikelihood = m_env.input()(m_option_initialPositionUsePreviousLevelLikelihood,  m_initialPositionUsePreviousLevelLikelihood);
+  m_loadBalanceAlgorithmId                    = m_env->input()(m_option_loadBalanceAlgorithmId,                     m_loadBalanceAlgorithmId                   );
+  m_loadBalanceTreshold                       = m_env->input()(m_option_loadBalanceTreshold,                        m_loadBalanceTreshold                      );
+  m_minEffectiveSizeRatio                     = m_env->input()(m_option_minEffectiveSizeRatio,                      m_minEffectiveSizeRatio                    );
+  m_maxEffectiveSizeRatio                     = m_env->input()(m_option_maxEffectiveSizeRatio,                      m_maxEffectiveSizeRatio                    );
+  m_scaleCovMatrix                            = m_env->input()(m_option_scaleCovMatrix,                             m_scaleCovMatrix                           );
+  m_minRejectionRate                          = m_env->input()(m_option_minRejectionRate,                           m_minRejectionRate                         );
+  m_maxRejectionRate                          = m_env->input()(m_option_maxRejectionRate,                           m_maxRejectionRate                         );
+  m_covRejectionRate                          = m_env->input()(m_option_covRejectionRate,                           m_covRejectionRate                         );
+  m_minAcceptableEta                          = m_env->input()(m_option_minAcceptableEta,                           m_minAcceptableEta                         );
+  m_totallyMute                               = m_env->input()(m_option_totallyMute,                                m_totallyMute                              );
+  m_initialPositionDataInputFileName          = m_env->input()(m_option_initialPosition_dataInputFileName,          m_initialPositionDataInputFileName         );
+  m_initialPositionDataInputFileType          = m_env->input()(m_option_initialPosition_dataInputFileType,          m_initialPositionDataInputFileType         );
+  m_initialProposalCovMatrixDataInputFileName = m_env->input()(m_option_initialProposalCovMatrix_dataInputFileName, m_initialProposalCovMatrixDataInputFileName);
+  m_initialProposalCovMatrixDataInputFileType = m_env->input()(m_option_initialProposalCovMatrix_dataInputFileType, m_initialProposalCovMatrixDataInputFileType);
+  m_initialPositionUsePreviousLevelLikelihood = m_env->input()(m_option_initialPositionUsePreviousLevelLikelihood,  m_initialPositionUsePreviousLevelLikelihood);
 
   // Is the empty set (string) by default
-  size = m_env.input().vector_variable_size(m_option_listOfDisabledParameters);
+  size = m_env->input().vector_variable_size(m_option_listOfDisabledParameters);
   for (unsigned int i = 0; i < size; i++) {
     // We default to empty set, so the default values are actually never
     // used here
-    unsigned int allowed = m_env.input()(m_option_listOfDisabledParameters, i, i);
+    unsigned int allowed = m_env->input()(m_option_listOfDisabledParameters, i, i);
     m_parameterDisabledSet.insert(allowed);
   }
 
   // Is the empty set (string) by default
-  size = m_env.input().vector_variable_size(m_option_initialValuesOfDisabledParameters);
+  size = m_env->input().vector_variable_size(m_option_initialValuesOfDisabledParameters);
   for (unsigned int i = 0; i < size; i++) {
     // We default to empty set, so the default values are actually never
     // used here
-    unsigned int value = m_env.input()(m_option_initialValuesOfDisabledParameters, i, i);
+    unsigned int value = m_env->input()(m_option_initialValuesOfDisabledParameters, i, i);
     m_initialValuesOfDisabledParameters.push_back(value);
   }
 
-  m_rawChainDataInputFileName                 = m_env.input()(m_option_rawChain_dataInputFileName,                 m_rawChainDataInputFileName                );
-  m_rawChainDataInputFileType                 = m_env.input()(m_option_rawChain_dataInputFileType,                 m_rawChainDataInputFileType                );
-  m_rawChainSize                              = m_env.input()(m_option_rawChain_size,                              m_rawChainSize                             );
-  m_rawChainGenerateExtra                     = m_env.input()(m_option_rawChain_generateExtra,                     m_rawChainGenerateExtra                    );
-  m_rawChainDisplayPeriod                     = m_env.input()(m_option_rawChain_displayPeriod,                     m_rawChainDisplayPeriod                    );
-  m_rawChainMeasureRunTimes                   = m_env.input()(m_option_rawChain_measureRunTimes,                   m_rawChainMeasureRunTimes                  );
-  m_rawChainDataOutputPeriod                  = m_env.input()(m_option_rawChain_dataOutputPeriod,                  m_rawChainDataOutputPeriod                 );
-  m_rawChainDataOutputFileName                = m_env.input()(m_option_rawChain_dataOutputFileName,                m_rawChainDataOutputFileName               );
-  m_rawChainDataOutputFileType                = m_env.input()(m_option_rawChain_dataOutputFileType,                m_rawChainDataOutputFileType               );
-  m_rawChainDataOutputAllowAll                = m_env.input()(m_option_rawChain_dataOutputAllowAll,                m_rawChainDataOutputAllowAll               );
+  m_rawChainDataInputFileName                 = m_env->input()(m_option_rawChain_dataInputFileName,                 m_rawChainDataInputFileName                );
+  m_rawChainDataInputFileType                 = m_env->input()(m_option_rawChain_dataInputFileType,                 m_rawChainDataInputFileType                );
+  m_rawChainSize                              = m_env->input()(m_option_rawChain_size,                              m_rawChainSize                             );
+  m_rawChainGenerateExtra                     = m_env->input()(m_option_rawChain_generateExtra,                     m_rawChainGenerateExtra                    );
+  m_rawChainDisplayPeriod                     = m_env->input()(m_option_rawChain_displayPeriod,                     m_rawChainDisplayPeriod                    );
+  m_rawChainMeasureRunTimes                   = m_env->input()(m_option_rawChain_measureRunTimes,                   m_rawChainMeasureRunTimes                  );
+  m_rawChainDataOutputPeriod                  = m_env->input()(m_option_rawChain_dataOutputPeriod,                  m_rawChainDataOutputPeriod                 );
+  m_rawChainDataOutputFileName                = m_env->input()(m_option_rawChain_dataOutputFileName,                m_rawChainDataOutputFileName               );
+  m_rawChainDataOutputFileType                = m_env->input()(m_option_rawChain_dataOutputFileType,                m_rawChainDataOutputFileType               );
+  m_rawChainDataOutputAllowAll                = m_env->input()(m_option_rawChain_dataOutputAllowAll,                m_rawChainDataOutputAllowAll               );
 
   // Is the empty set (string) by default
-  size = m_env.input().vector_variable_size(m_option_rawChain_dataOutputAllowedSet);
+  size = m_env->input().vector_variable_size(m_option_rawChain_dataOutputAllowedSet);
   for (unsigned int i = 0; i < size; i++) {
     // We default to empty set, so the default values are actually never
     // used here
-    unsigned int allowed = m_env.input()(m_option_rawChain_dataOutputAllowedSet, i, i);
+    unsigned int allowed = m_env->input()(m_option_rawChain_dataOutputAllowedSet, i, i);
     m_rawChainDataOutputAllowedSet.insert(allowed);
   }
 
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-  m_rawChainComputeStats                      = m_env.input()(m_option_rawChain_computeStats,                      m_rawChainComputeStats                     );
+  m_rawChainComputeStats                      = m_env->input()(m_option_rawChain_computeStats,                      m_rawChainComputeStats                     );
 #endif
-  m_filteredChainGenerate                     = m_env.input()(m_option_filteredChain_generate,                     m_filteredChainGenerate                    );
-  m_filteredChainDiscardedPortion             = m_env.input()(m_option_filteredChain_discardedPortion,             m_filteredChainDiscardedPortion            );
-  m_filteredChainLag                          = m_env.input()(m_option_filteredChain_lag,                          m_filteredChainLag                         );
-  m_filteredChainDataOutputFileName           = m_env.input()(m_option_filteredChain_dataOutputFileName,           m_filteredChainDataOutputFileName          );
-  m_filteredChainDataOutputFileType           = m_env.input()(m_option_filteredChain_dataOutputFileType,           m_filteredChainDataOutputFileType          );
-  m_filteredChainDataOutputAllowAll           = m_env.input()(m_option_filteredChain_dataOutputAllowAll,           m_filteredChainDataOutputAllowAll          );
+  m_filteredChainGenerate                     = m_env->input()(m_option_filteredChain_generate,                     m_filteredChainGenerate                    );
+  m_filteredChainDiscardedPortion             = m_env->input()(m_option_filteredChain_discardedPortion,             m_filteredChainDiscardedPortion            );
+  m_filteredChainLag                          = m_env->input()(m_option_filteredChain_lag,                          m_filteredChainLag                         );
+  m_filteredChainDataOutputFileName           = m_env->input()(m_option_filteredChain_dataOutputFileName,           m_filteredChainDataOutputFileName          );
+  m_filteredChainDataOutputFileType           = m_env->input()(m_option_filteredChain_dataOutputFileType,           m_filteredChainDataOutputFileType          );
+  m_filteredChainDataOutputAllowAll           = m_env->input()(m_option_filteredChain_dataOutputAllowAll,           m_filteredChainDataOutputAllowAll          );
 
   // Is the empty set (string) by default
-  size = m_env.input().vector_variable_size(m_option_filteredChain_dataOutputAllowedSet);
+  size = m_env->input().vector_variable_size(m_option_filteredChain_dataOutputAllowedSet);
   for (unsigned int i = 0; i < size; i++) {
     // We default to empty set, so the default values are actually never
     // used here
-    unsigned int allowed = m_env.input()(m_option_filteredChain_dataOutputAllowedSet, i, i);
+    unsigned int allowed = m_env->input()(m_option_filteredChain_dataOutputAllowedSet, i, i);
     m_filteredChainDataOutputAllowedSet.insert(allowed);
   }
 
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-  m_filteredChainComputeStats                 = m_env.input()(m_option_filteredChain_computeStats,                 m_filteredChainComputeStats                );
+  m_filteredChainComputeStats                 = m_env->input()(m_option_filteredChain_computeStats,                 m_filteredChainComputeStats                );
 #endif
-  m_displayCandidates                         = m_env.input()(m_option_displayCandidates,                          m_displayCandidates                        );
-  m_putOutOfBoundsInChain                     = m_env.input()(m_option_putOutOfBoundsInChain,                      m_putOutOfBoundsInChain                    );
-  m_tkUseLocalHessian                         = m_env.input()(m_option_tk_useLocalHessian,                         m_tkUseLocalHessian                        );
-  m_tkUseNewtonComponent                      = m_env.input()(m_option_tk_useNewtonComponent,                      m_tkUseNewtonComponent                     );
-  m_drMaxNumExtraStages                       = m_env.input()(m_option_dr_maxNumExtraStages,                       m_drMaxNumExtraStages                      );
+  m_displayCandidates                         = m_env->input()(m_option_displayCandidates,                          m_displayCandidates                        );
+  m_putOutOfBoundsInChain                     = m_env->input()(m_option_putOutOfBoundsInChain,                      m_putOutOfBoundsInChain                    );
+  m_tkUseLocalHessian                         = m_env->input()(m_option_tk_useLocalHessian,                         m_tkUseLocalHessian                        );
+  m_tkUseNewtonComponent                      = m_env->input()(m_option_tk_useNewtonComponent,                      m_tkUseNewtonComponent                     );
+  m_drMaxNumExtraStages                       = m_env->input()(m_option_dr_maxNumExtraStages,                       m_drMaxNumExtraStages                      );
 
   // Is the empty set (string) by default
-  size = m_env.input().vector_variable_size(m_option_dr_listOfScalesForExtraStages);
+  size = m_env->input().vector_variable_size(m_option_dr_listOfScalesForExtraStages);
 
   m_drScalesForExtraStages.clear();
   for (unsigned int i = 0; i < size; i++) {
-    unsigned int value = m_env.input()(m_option_dr_listOfScalesForExtraStages, i, i);
+    unsigned int value = m_env->input()(m_option_dr_listOfScalesForExtraStages, i, i);
     m_drScalesForExtraStages.push_back(value);
   }
 
-  m_drDuringAmNonAdaptiveInt                  = m_env.input()(m_option_dr_duringAmNonAdaptiveInt,                  m_drDuringAmNonAdaptiveInt                 );
-  m_amKeepInitialMatrix                       = m_env.input()(m_option_am_keepInitialMatrix,                       m_amKeepInitialMatrix                      );
-  m_amInitialNonAdaptInterval                 = m_env.input()(m_option_am_initialNonAdaptInterval,                 m_amInitialNonAdaptInterval                );
-  m_amAdaptInterval                           = m_env.input()(m_option_am_adaptInterval,                           m_amAdaptInterval                          );
-  m_amAdaptedMatricesDataOutputPeriod         = m_env.input()(m_option_am_adaptedMatrices_dataOutputPeriod,        m_amAdaptedMatricesDataOutputPeriod        );
-  m_amAdaptedMatricesDataOutputFileName       = m_env.input()(m_option_am_adaptedMatrices_dataOutputFileName,      m_amAdaptedMatricesDataOutputFileName      );
-  m_amAdaptedMatricesDataOutputFileType       = m_env.input()(m_option_am_adaptedMatrices_dataOutputFileType,      m_amAdaptedMatricesDataOutputFileType      );
-  m_amAdaptedMatricesDataOutputAllowAll       = m_env.input()(m_option_am_adaptedMatrices_dataOutputAllowAll,      m_amAdaptedMatricesDataOutputAllowAll      );
+  m_drDuringAmNonAdaptiveInt                  = m_env->input()(m_option_dr_duringAmNonAdaptiveInt,                  m_drDuringAmNonAdaptiveInt                 );
+  m_amKeepInitialMatrix                       = m_env->input()(m_option_am_keepInitialMatrix,                       m_amKeepInitialMatrix                      );
+  m_amInitialNonAdaptInterval                 = m_env->input()(m_option_am_initialNonAdaptInterval,                 m_amInitialNonAdaptInterval                );
+  m_amAdaptInterval                           = m_env->input()(m_option_am_adaptInterval,                           m_amAdaptInterval                          );
+  m_amAdaptedMatricesDataOutputPeriod         = m_env->input()(m_option_am_adaptedMatrices_dataOutputPeriod,        m_amAdaptedMatricesDataOutputPeriod        );
+  m_amAdaptedMatricesDataOutputFileName       = m_env->input()(m_option_am_adaptedMatrices_dataOutputFileName,      m_amAdaptedMatricesDataOutputFileName      );
+  m_amAdaptedMatricesDataOutputFileType       = m_env->input()(m_option_am_adaptedMatrices_dataOutputFileType,      m_amAdaptedMatricesDataOutputFileType      );
+  m_amAdaptedMatricesDataOutputAllowAll       = m_env->input()(m_option_am_adaptedMatrices_dataOutputAllowAll,      m_amAdaptedMatricesDataOutputAllowAll      );
 
-  size = m_env.input().vector_variable_size(m_option_am_adaptedMatrices_dataOutputAllowedSet);
+  size = m_env->input().vector_variable_size(m_option_am_adaptedMatrices_dataOutputAllowedSet);
   for (unsigned int i = 0; i < size; i++) {
     // We default to empty set, so the default values are actually never
     // used here
-    unsigned int allowed = m_env.input()(m_option_am_adaptedMatrices_dataOutputAllowedSet, i, i);
+    unsigned int allowed = m_env->input()(m_option_am_adaptedMatrices_dataOutputAllowedSet, i, i);
     m_amAdaptedMatricesDataOutputAllowedSet.insert(allowed);
   }
 
-  m_amEta                                     = m_env.input()(m_option_am_eta,                                     m_amEta                                    );
-  m_amEpsilon                                 = m_env.input()(m_option_am_epsilon,                                 m_amEpsilon                                );
-  m_doLogitTransform                          = m_env.input()(m_option_doLogitTransform,                           UQ_ML_SAMPLING_L_DO_LOGIT_TRANSFORM        );
-  m_algorithm                                 = m_env.input()(m_option_algorithm,                                  UQ_ML_SAMPLING_L_ALGORITHM                 );
-  m_tk                                        = m_env.input()(m_option_tk,                                         UQ_ML_SAMPLING_L_TK                        );
-  m_updateInterval                            = m_env.input()(m_option_updateInterval,                             UQ_ML_SAMPLING_L_UPDATE_INTERVAL           );
+  m_amEta                                     = m_env->input()(m_option_am_eta,                                     m_amEta                                    );
+  m_amEpsilon                                 = m_env->input()(m_option_am_epsilon,                                 m_amEpsilon                                );
+  m_doLogitTransform                          = m_env->input()(m_option_doLogitTransform,                           m_doLogitTransform                         );
+  m_algorithm                                 = m_env->input()(m_option_algorithm,                                  m_algorithm                                );
+  m_tk                                        = m_env->input()(m_option_tk,                                         m_tk                                       );
+  m_updateInterval                            = m_env->input()(m_option_updateInterval,                             m_updateInterval                           );
 #endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 }
 
@@ -496,7 +336,6 @@ MLSamplingLevelOptions::copyOptionsValues(const MLSamplingLevelOptions& srcOptio
   m_dataOutputFileName                        = srcOptions.m_dataOutputFileName;
   m_dataOutputAllowAll                        = srcOptions.m_dataOutputAllowAll;
   m_dataOutputAllowedSet                      = srcOptions.m_dataOutputAllowedSet;
-  m_str1                                      = srcOptions.m_str1;
   m_loadBalanceAlgorithmId                    = srcOptions.m_loadBalanceAlgorithmId;
   m_loadBalanceTreshold                       = srcOptions.m_loadBalanceTreshold;
   m_minEffectiveSizeRatio                     = srcOptions.m_minEffectiveSizeRatio;
@@ -513,9 +352,7 @@ MLSamplingLevelOptions::copyOptionsValues(const MLSamplingLevelOptions& srcOptio
   m_initialProposalCovMatrixDataInputFileType = srcOptions.m_initialProposalCovMatrixDataInputFileType;
   m_initialPositionUsePreviousLevelLikelihood = srcOptions.m_initialPositionUsePreviousLevelLikelihood;
   m_parameterDisabledSet                      = srcOptions.m_parameterDisabledSet; // gpmsa2
-  m_str2                                      = srcOptions.m_str2; // gpmsa2
   m_initialValuesOfDisabledParameters         = srcOptions.m_initialValuesOfDisabledParameters;
-  m_str3                                      = srcOptions.m_str3;
   m_rawChainDataInputFileName                 = srcOptions.m_rawChainDataInputFileName;
   m_rawChainDataInputFileType                 = srcOptions.m_rawChainDataInputFileType;
   m_rawChainSize                              = srcOptions.m_rawChainSize;
@@ -528,7 +365,6 @@ MLSamplingLevelOptions::copyOptionsValues(const MLSamplingLevelOptions& srcOptio
   m_rawChainDataOutputFileType                = srcOptions.m_rawChainDataOutputFileType;
   m_rawChainDataOutputAllowAll                = srcOptions.m_rawChainDataOutputAllowAll;
   m_rawChainDataOutputAllowedSet              = srcOptions.m_rawChainDataOutputAllowedSet;
-  m_str4                                      = srcOptions.m_str4;
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
   m_rawChainComputeStats                      = srcOptions.m_rawChainComputeStats;
   m_rawChainStatisticalOptionsObj             = NULL; // Yes, 'NULL'
@@ -541,7 +377,6 @@ MLSamplingLevelOptions::copyOptionsValues(const MLSamplingLevelOptions& srcOptio
   m_filteredChainDataOutputFileType           = srcOptions.m_filteredChainDataOutputFileType;
   m_filteredChainDataOutputAllowAll           = srcOptions.m_filteredChainDataOutputAllowAll;
   m_filteredChainDataOutputAllowedSet         = srcOptions.m_filteredChainDataOutputAllowedSet;
-  m_str5                                      = srcOptions.m_str5;
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
   m_filteredChainComputeStats                 = srcOptions.m_filteredChainComputeStats;
   m_filteredChainStatisticalOptionsObj        = NULL; // Yes, 'NULL'
@@ -553,7 +388,6 @@ MLSamplingLevelOptions::copyOptionsValues(const MLSamplingLevelOptions& srcOptio
   m_tkUseNewtonComponent                      = srcOptions.m_tkUseNewtonComponent;
   m_drMaxNumExtraStages                       = srcOptions.m_drMaxNumExtraStages;
   m_drScalesForExtraStages                    = srcOptions.m_drScalesForExtraStages;
-  m_str6                                      = srcOptions.m_str6;
   m_drDuringAmNonAdaptiveInt                  = srcOptions.m_drDuringAmNonAdaptiveInt;
   m_amKeepInitialMatrix                       = srcOptions.m_amKeepInitialMatrix;
   m_amInitialNonAdaptInterval                 = srcOptions.m_amInitialNonAdaptInterval;
@@ -563,7 +397,6 @@ MLSamplingLevelOptions::copyOptionsValues(const MLSamplingLevelOptions& srcOptio
   m_amAdaptedMatricesDataOutputFileType       = srcOptions.m_amAdaptedMatricesDataOutputFileType;
   m_amAdaptedMatricesDataOutputAllowAll       = srcOptions.m_amAdaptedMatricesDataOutputAllowAll;
   m_amAdaptedMatricesDataOutputAllowedSet     = srcOptions.m_amAdaptedMatricesDataOutputAllowedSet;
-  m_str7                                      = srcOptions.m_str7;
   m_amEta                                     = srcOptions.m_amEta;
   m_amEpsilon                                 = srcOptions.m_amEpsilon;
   m_doLogitTransform                          = srcOptions.m_doLogitTransform;
@@ -597,10 +430,7 @@ MLSamplingLevelOptions::scanOptionsValues(const MLSamplingLevelOptions* defaultO
 
 #ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   // Replace the parser since default values changed
-  if (m_parser) {
-    delete m_parser;
-    m_parser = new BoostInputOptionsParser(m_env.optionsInputFileName());
-  }
+  m_parser.reset(new BoostInputOptionsParser(m_env->optionsInputFileName()));
 
   // FIXME: Does this work with GetPot?
   this->defineAllOptions();
@@ -619,28 +449,18 @@ MLSamplingLevelOptions::scanOptionsValues(const MLSamplingLevelOptions* defaultO
 }
 
 void
-MLSamplingLevelOptions::checkOptions(const BaseEnvironment * /* env */)
+MLSamplingLevelOptions::checkOptions()
 {
-  char tmpStr[64];
-
   // DM: Print here because I don't know where the class is instantiated
   if (m_help != "") {
-    if (m_env.subDisplayFile()) {
-      *m_env.subDisplayFile() << (*this) << std::endl;
+    if (m_env->subDisplayFile()) {
+      *m_env->subDisplayFile() << (*this) << std::endl;
     }
   }
 
   if (m_dataOutputAllowAll) {
     m_dataOutputAllowedSet.clear();
-    m_dataOutputAllowedSet.insert(m_env.subId());
-  }
-
-  // DM: Not sure what this is for
-  m_str1.clear();
-  for (std::set<unsigned int>::iterator setIt = m_dataOutputAllowedSet.begin(); setIt != m_dataOutputAllowedSet.end(); ++setIt) {
-    sprintf(tmpStr,"%d",(int)(*setIt));
-    m_str1 += tmpStr;
-    m_str1 += " ";
+    m_dataOutputAllowedSet.insert(m_env->subId());
   }
 
   queso_require_less_msg(m_minEffectiveSizeRatio, 1.0, "option `" << m_option_minEffectiveSizeRatio << "` must be less than 1.0");
@@ -649,33 +469,9 @@ MLSamplingLevelOptions::checkOptions(const BaseEnvironment * /* env */)
   queso_require_less_msg(m_maxRejectionRate, 1.0, "option `" << m_option_maxRejectionRate << "` must be less than 1.0");
   queso_require_less_msg(m_covRejectionRate, 1.0, "option `" << m_option_covRejectionRate << "` must be less than 1.0");
 
-  // DM: Not sure what this is for
-  m_str2.clear();
-  for (std::set<unsigned int>::iterator setIt = m_parameterDisabledSet.begin(); setIt != m_parameterDisabledSet.end(); ++setIt) { // gpmsa2
-    sprintf(tmpStr,"%d",(int)(*setIt));
-    m_str2 += tmpStr;
-    m_str2 += " ";
-  }
-
-  // DM: Not sure what this is for
-  m_str3.clear();
-  for (unsigned int i = 0; i < m_initialValuesOfDisabledParameters.size(); ++i) {
-    sprintf(tmpStr,"%e",m_initialValuesOfDisabledParameters[i]);
-    m_str3 += tmpStr;
-    m_str3 += " ";
-  }
-
   if (m_rawChainDataOutputAllowAll) {
     m_rawChainDataOutputAllowedSet.clear();
-    m_rawChainDataOutputAllowedSet.insert(m_env.subId());
-  }
-
-  // DM: Not sure what this is for
-  m_str4.clear();
-  for (std::set<unsigned int>::iterator setIt = m_rawChainDataOutputAllowedSet.begin(); setIt != m_rawChainDataOutputAllowedSet.end(); ++setIt) {
-    sprintf(tmpStr,"%d",(int)(*setIt));
-    m_str4 += tmpStr;
-    m_str4 += " ";
+    m_rawChainDataOutputAllowedSet.insert(m_env->subId());
   }
 
   if (m_filteredChainGenerate == true) {
@@ -684,15 +480,7 @@ MLSamplingLevelOptions::checkOptions(const BaseEnvironment * /* env */)
 
   if (m_filteredChainDataOutputAllowAll) {
     m_filteredChainDataOutputAllowedSet.clear();
-    m_filteredChainDataOutputAllowedSet.insert(m_env.subId());
-  }
-
-  // DM: Not sure what this is for
-  m_str5.clear();
-  for (std::set<unsigned int>::iterator setIt = m_filteredChainDataOutputAllowedSet.begin(); setIt != m_filteredChainDataOutputAllowedSet.end(); ++setIt) {
-    sprintf(tmpStr,"%d",(int)(*setIt));
-    m_str5 += tmpStr;
-    m_str5 += " ";
+    m_filteredChainDataOutputAllowedSet.insert(m_env->subId());
   }
 
   if (m_drMaxNumExtraStages > 0) {
@@ -707,26 +495,11 @@ MLSamplingLevelOptions::checkOptions(const BaseEnvironment * /* env */)
     }
   }
 
-  // DM: Not sure what this is for
-  m_str6.clear();
-  for (unsigned int i = 0; i < m_drScalesForExtraStages.size(); ++i) {
-    sprintf(tmpStr,"%e",m_drScalesForExtraStages[i]);
-    m_str6 += tmpStr;
-    m_str6 += " ";
-  }
-
   if (m_amAdaptedMatricesDataOutputAllowAll) {
     m_amAdaptedMatricesDataOutputAllowedSet.clear();
-    m_amAdaptedMatricesDataOutputAllowedSet.insert(m_env.subId());
+    m_amAdaptedMatricesDataOutputAllowedSet.insert(m_env->subId());
   }
 
-  // DM: Not sure what this is for
-  m_str7.clear();
-  for (std::set<unsigned int>::iterator setIt = m_amAdaptedMatricesDataOutputAllowedSet.begin(); setIt != m_amAdaptedMatricesDataOutputAllowedSet.end(); ++setIt) {
-    sprintf(tmpStr,"%d",(int)(*setIt));
-    m_str7 += tmpStr;
-    m_str7 += " ";
-  }
 }
 
 void
@@ -834,7 +607,7 @@ MLSamplingLevelOptions::print(std::ostream& os) const
 const BaseEnvironment&
 MLSamplingLevelOptions::env() const
 {
-  return m_env;
+  return *m_env;
 }
 
 std::ostream& operator<<(std::ostream& os, const MLSamplingLevelOptions& obj)
@@ -844,6 +617,182 @@ std::ostream& operator<<(std::ostream& os, const MLSamplingLevelOptions& obj)
 #endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
   obj.print(os);
   return os;
+}
+
+void MLSamplingLevelOptions::set_defaults()
+{
+  m_help                                     = UQ_ML_SAMPLING_L_HELP;
+#ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY
+#else
+  m_checkpointOutputFileName                 = UQ_ML_SAMPLING_L_CHECKPOINT_OUTPUT_FILE_NAME_ODV;
+#endif
+  m_stopAtEnd                                = UQ_ML_SAMPLING_L_STOP_AT_END_ODV;
+  m_dataOutputFileName                       = UQ_ML_SAMPLING_L_DATA_OUTPUT_FILE_NAME_ODV;
+  m_dataOutputAllowAll                       = UQ_ML_SAMPLING_L_DATA_OUTPUT_ALLOW_ALL_ODV;
+  //m_dataOutputAllowedSet                     = ;
+  m_loadBalanceAlgorithmId                   = UQ_ML_SAMPLING_L_LOAD_BALANCE_ALGORITHM_ID_ODV;
+  m_loadBalanceTreshold                      = UQ_ML_SAMPLING_L_LOAD_BALANCE_TRESHOLD_ODV;
+  m_minEffectiveSizeRatio                    = UQ_ML_SAMPLING_L_MIN_EFFECTIVE_SIZE_RATIO_ODV;
+  m_maxEffectiveSizeRatio                    = UQ_ML_SAMPLING_L_MAX_EFFECTIVE_SIZE_RATIO_ODV;
+  m_scaleCovMatrix                           = UQ_ML_SAMPLING_L_SCALE_COV_MATRIX_ODV;
+  m_minRejectionRate                         = UQ_ML_SAMPLING_L_MIN_REJECTION_RATE_ODV;
+  m_maxRejectionRate                         = UQ_ML_SAMPLING_L_MAX_REJECTION_RATE_ODV;
+  m_covRejectionRate                         = UQ_ML_SAMPLING_L_COV_REJECTION_RATE_ODV;
+  m_minAcceptableEta                         = UQ_ML_SAMPLING_L_MIN_ACCEPTABLE_ETA_ODV; // gpmsa1
+  m_totallyMute                              = UQ_ML_SAMPLING_L_TOTALLY_MUTE_ODV;
+  m_initialPositionDataInputFileName         = UQ_ML_SAMPLING_L_INITIAL_POSITION_DATA_INPUT_FILE_NAME_ODV;
+  m_initialPositionDataInputFileType         = UQ_ML_SAMPLING_L_INITIAL_POSITION_DATA_INPUT_FILE_TYPE_ODV;
+  m_initialProposalCovMatrixDataInputFileName=UQ_ML_SAMPLING_L_INITIAL_PROPOSAL_COV_MATRIX_DATA_INPUT_FILE_NAME_ODV;
+  m_initialProposalCovMatrixDataInputFileType=UQ_ML_SAMPLING_L_INITIAL_PROPOSAL_COV_MATRIX_DATA_INPUT_FILE_TYPE_ODV;
+  m_initialPositionUsePreviousLevelLikelihood=UQ_ML_SAMPLING_L_INITIAL_POSITION_USE_PREVIOUS_LEVEL_LIKELIHOOD_ODV;  // ml_likelihood_caching
+  //m_parameterDisabledSet                     = ; // gpmsa2
+  //    m_initialValuesOfDisabledParameters        = 0;
+  m_rawChainDataInputFileName                = UQ_ML_SAMPLING_L_RAW_CHAIN_DATA_INPUT_FILE_NAME_ODV;
+  m_rawChainDataInputFileType                = UQ_ML_SAMPLING_L_RAW_CHAIN_DATA_INPUT_FILE_TYPE_ODV;
+  m_rawChainSize                             = UQ_ML_SAMPLING_L_RAW_CHAIN_SIZE_ODV;
+  m_rawChainGenerateExtra                    = UQ_ML_SAMPLING_L_RAW_CHAIN_GENERATE_EXTRA_ODV;
+  m_rawChainDisplayPeriod                    = UQ_ML_SAMPLING_L_RAW_CHAIN_DISPLAY_PERIOD_ODV;
+  m_rawChainMeasureRunTimes                  = UQ_ML_SAMPLING_L_RAW_CHAIN_MEASURE_RUN_TIMES_ODV;
+  m_rawChainDataOutputPeriod                 = UQ_ML_SAMPLING_L_RAW_CHAIN_DATA_OUTPUT_PERIOD_ODV;
+  m_rawChainDataOutputFileName               = UQ_ML_SAMPLING_L_RAW_CHAIN_DATA_OUTPUT_FILE_NAME_ODV;
+  m_rawChainDataOutputFileType               = UQ_ML_SAMPLING_L_RAW_CHAIN_DATA_OUTPUT_FILE_TYPE_ODV;
+  m_rawChainDataOutputAllowAll               = UQ_ML_SAMPLING_L_RAW_CHAIN_DATA_OUTPUT_ALLOW_ALL_ODV;
+  //m_rawChainDataOutputAllowedSet             = ;
+#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  m_rawChainComputeStats                     = UQ_ML_SAMPLING_L_RAW_CHAIN_COMPUTE_STATS_ODV;
+  m_rawChainStatisticalOptionsObj            = NULL;
+  m_rawChainStatOptsInstantiated             = false;
+#endif
+  m_filteredChainGenerate                    = UQ_ML_SAMPLING_L_FILTERED_CHAIN_GENERATE_ODV;
+  m_filteredChainDiscardedPortion            = UQ_ML_SAMPLING_L_FILTERED_CHAIN_DISCARDED_PORTION_ODV;
+  m_filteredChainLag                         = UQ_ML_SAMPLING_L_FILTERED_CHAIN_LAG_ODV;
+  m_filteredChainDataOutputFileName          = UQ_ML_SAMPLING_L_FILTERED_CHAIN_DATA_OUTPUT_FILE_NAME_ODV;
+  m_filteredChainDataOutputFileType          = UQ_ML_SAMPLING_L_FILTERED_CHAIN_DATA_OUTPUT_FILE_TYPE_ODV;
+  m_filteredChainDataOutputAllowAll          = UQ_ML_SAMPLING_L_FILTERED_CHAIN_DATA_OUTPUT_ALLOW_ALL_ODV;
+  //m_filteredChainDataOutputAllowedSet        = ;
+#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  m_filteredChainComputeStats                = UQ_ML_SAMPLING_L_FILTERED_CHAIN_COMPUTE_STATS_ODV;
+  m_filteredChainStatisticalOptionsObj       = NULL;
+  m_filteredChainStatOptsInstantiated        = false;
+#endif
+  m_displayCandidates                        = UQ_ML_SAMPLING_L_DISPLAY_CANDIDATES_ODV;
+  m_putOutOfBoundsInChain                    = UQ_ML_SAMPLING_L_PUT_OUT_OF_BOUNDS_IN_CHAIN_ODV;
+  m_tkUseLocalHessian                        = UQ_ML_SAMPLING_L_TK_USE_LOCAL_HESSIAN_ODV;
+  m_tkUseNewtonComponent                     = UQ_ML_SAMPLING_L_TK_USE_NEWTON_COMPONENT_ODV;
+  m_drMaxNumExtraStages                      = UQ_ML_SAMPLING_L_DR_MAX_NUM_EXTRA_STAGES_ODV;
+  //    m_drScalesForExtraStages                   = 0;
+  m_drDuringAmNonAdaptiveInt                 = UQ_ML_SAMPLING_L_DR_DURING_AM_NON_ADAPTIVE_INT_ODV;
+  m_amKeepInitialMatrix                      = UQ_ML_SAMPLING_L_AM_KEEP_INITIAL_MATRIX_ODV;
+  m_amInitialNonAdaptInterval                = UQ_ML_SAMPLING_L_AM_INIT_NON_ADAPT_INT_ODV;
+  m_amAdaptInterval                          = UQ_ML_SAMPLING_L_AM_ADAPT_INTERVAL_ODV;
+  m_amAdaptedMatricesDataOutputPeriod        = UQ_ML_SAMPLING_L_AM_ADAPTED_MATRICES_DATA_OUTPUT_PERIOD_ODV;
+  m_amAdaptedMatricesDataOutputFileName      = UQ_ML_SAMPLING_L_AM_ADAPTED_MATRICES_DATA_OUTPUT_FILE_NAME_ODV;
+  m_amAdaptedMatricesDataOutputFileType      = UQ_ML_SAMPLING_L_AM_ADAPTED_MATRICES_DATA_OUTPUT_FILE_TYPE_ODV;
+  m_amAdaptedMatricesDataOutputAllowAll      = UQ_ML_SAMPLING_L_AM_ADAPTED_MATRICES_DATA_OUTPUT_ALLOW_ALL_ODV;
+  //m_amAdaptedMatricesDataOutputAllowedSet    = ;
+  m_amEta                                    = UQ_ML_SAMPLING_L_AM_ETA_ODV;
+  m_amEpsilon                                = UQ_ML_SAMPLING_L_AM_EPSILON_ODV;
+  m_doLogitTransform                         = UQ_ML_SAMPLING_L_DO_LOGIT_TRANSFORM;
+  m_algorithm                                = UQ_ML_SAMPLING_L_ALGORITHM;
+  m_tk                                       = UQ_ML_SAMPLING_L_TK;
+  m_updateInterval                           = UQ_ML_SAMPLING_L_UPDATE_INTERVAL;
+}
+
+
+void MLSamplingLevelOptions::set_prefix(const std::string& prefix)
+{
+  m_prefix = prefix + "";
+
+  m_option_help                                       = m_prefix + "help"                                      ;
+#ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY
+#else
+  m_option_checkpointOutputFileName                   = m_prefix + "checkpointOutputFileName"                  ;
+#endif
+  m_option_stopAtEnd                                  = m_prefix + "stopAtEnd"                                 ;
+  m_option_dataOutputFileName                         = m_prefix + "dataOutputFileName"                        ;
+  m_option_dataOutputAllowAll                         = m_prefix + "dataOutputAllowAll"                        ;
+  m_option_dataOutputAllowedSet                       = m_prefix + "dataOutputAllowedSet"                      ;
+  m_option_loadBalanceAlgorithmId                     = m_prefix + "loadBalanceAlgorithmId"                    ;
+  m_option_loadBalanceTreshold                        = m_prefix + "loadBalanceTreshold"                       ;
+  m_option_minEffectiveSizeRatio                      = m_prefix + "minEffectiveSizeRatio"                     ;
+  m_option_maxEffectiveSizeRatio                      = m_prefix + "maxEffectiveSizeRatio"                     ;
+  m_option_scaleCovMatrix                             = m_prefix + "scaleCovMatrix"                            ;
+  m_option_minRejectionRate                           = m_prefix + "minRejectionRate"                          ;
+  m_option_maxRejectionRate                           = m_prefix + "maxRejectionRate"                          ;
+  m_option_covRejectionRate                           = m_prefix + "covRejectionRate"                          ;
+  m_option_minAcceptableEta                           = m_prefix + "minAcceptableEta"                          ; // gpmsa1
+  m_option_totallyMute                                = m_prefix + "totallyMute"                               ;
+  m_option_initialPosition_dataInputFileName          = m_prefix + "initialPosition_dataInputFileName"         ;
+  m_option_initialPosition_dataInputFileType          = m_prefix + "initialPosition_dataInputFileType"         ;
+  m_option_initialProposalCovMatrix_dataInputFileName = m_prefix + "initialProposalCovMatrix_dataInputFileName";
+  m_option_initialProposalCovMatrix_dataInputFileType = m_prefix + "initialProposalCovMatrix_dataInputFileType";
+  m_option_initialPositionUsePreviousLevelLikelihood  = m_prefix + "initialPositionUsePreviousLevelLikelihood" ; // ml_likelihood_caching
+  m_option_listOfDisabledParameters                   = m_prefix + "listOfDisabledParameters"                  ; // gpmsa2
+  m_option_initialValuesOfDisabledParameters          = m_prefix + "initialValuesOfDisabledParameters"         ; // gpmsa2
+  m_option_rawChain_dataInputFileName                 = m_prefix + "rawChain_dataInputFileName"                ;
+  m_option_rawChain_dataInputFileType                 = m_prefix + "rawChain_dataInputFileType"                ;
+  m_option_rawChain_size                              = m_prefix + "rawChain_size"                             ;
+  m_option_rawChain_generateExtra                     = m_prefix + "rawChain_generateExtra"                    ;
+  m_option_rawChain_displayPeriod                     = m_prefix + "rawChain_displayPeriod"                    ;
+  m_option_rawChain_measureRunTimes                   = m_prefix + "rawChain_measureRunTimes"                  ;
+  m_option_rawChain_dataOutputPeriod                  = m_prefix + "rawChain_dataOutputPeriod"                 ;
+  m_option_rawChain_dataOutputFileName                = m_prefix + "rawChain_dataOutputFileName"               ;
+  m_option_rawChain_dataOutputFileType                = m_prefix + "rawChain_dataOutputFileType"               ;
+  m_option_rawChain_dataOutputAllowAll                = m_prefix + "rawChain_dataOutputAllowAll"               ;
+  m_option_rawChain_dataOutputAllowedSet              = m_prefix + "rawChain_dataOutputAllowedSet"             ;
+#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  m_option_rawChain_computeStats                      = m_prefix + "rawChain_computeStats"                     ;
+#endif
+  m_option_filteredChain_generate                     = m_prefix + "filteredChain_generate"                    ;
+  m_option_filteredChain_discardedPortion             = m_prefix + "filteredChain_discardedPortion"            ;
+  m_option_filteredChain_lag                          = m_prefix + "filteredChain_lag"                         ;
+  m_option_filteredChain_dataOutputFileName           = m_prefix + "filteredChain_dataOutputFileName"          ;
+  m_option_filteredChain_dataOutputFileType           = m_prefix + "filteredChain_dataOutputFileType"          ;
+  m_option_filteredChain_dataOutputAllowAll           = m_prefix + "filteredChain_dataOutputAllowAll"          ;
+  m_option_filteredChain_dataOutputAllowedSet         = m_prefix + "filteredChain_dataOutputAllowedSet"        ;
+#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  m_option_filteredChain_computeStats                 = m_prefix + "filteredChain_computeStats"                ;
+#endif
+  m_option_displayCandidates                          = m_prefix + "displayCandidates"                         ;
+  m_option_putOutOfBoundsInChain                      = m_prefix + "putOutOfBoundsInChain"                     ;
+  m_option_tk_useLocalHessian                         = m_prefix + "tk_useLocalHessian"                        ;
+  m_option_tk_useNewtonComponent                      = m_prefix + "tk_useNewtonComponent"                     ;
+  m_option_dr_maxNumExtraStages                       = m_prefix + "dr_maxNumExtraStages"                      ;
+  m_option_dr_listOfScalesForExtraStages              = m_prefix + "dr_listOfScalesForExtraStages"             ;
+  m_option_dr_duringAmNonAdaptiveInt                  = m_prefix + "dr_duringAmNonAdaptiveInt"                 ;
+  m_option_am_keepInitialMatrix                       = m_prefix + "am_keepInitialMatrix"                      ;
+  m_option_am_initialNonAdaptInterval                 = m_prefix + "am_initialNonAdaptInterval"                ;
+  m_option_am_adaptInterval                           = m_prefix + "am_adaptInterval"                          ;
+  m_option_am_adaptedMatrices_dataOutputPeriod        = m_prefix + "amAdaptedMatrices_dataOutputPeriod"        ;
+  m_option_am_adaptedMatrices_dataOutputFileName      = m_prefix + "amAdaptedMatrices_dataOutputFileName"      ;
+  m_option_am_adaptedMatrices_dataOutputFileType      = m_prefix + "amAdaptedMatrices_dataOutputFileType"      ;
+  m_option_am_adaptedMatrices_dataOutputAllowAll      = m_prefix + "amAdaptedMatrices_dataOutputAllowAll"      ;
+  m_option_am_adaptedMatrices_dataOutputAllowedSet    = m_prefix + "amAdaptedMatrices_dataOutputAllowedSet"    ;
+  m_option_am_eta                                     = m_prefix + "am_eta"                                    ;
+  m_option_am_epsilon                                 = m_prefix + "am_epsilon"                                ;
+  m_option_doLogitTransform                           = m_prefix + "doLogitTransform"                          ;
+  m_option_algorithm                                  = m_prefix + "algorithm"                                 ;
+  m_option_tk                                         = m_prefix + "tk"                                        ;
+  m_option_updateInterval                             = m_prefix + "updateInterval"                            ;
+}
+
+
+void MLSamplingLevelOptions::
+parse(const BaseEnvironment& env, const std::string& prefix)
+{
+  m_env = &env;
+
+  this->set_prefix(prefix);
+
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+  m_parser.reset(new BoostInputOptionsParser(env.optionsInputFileName())),
+  this->defineAllOptions();
+  m_parser->scanInputFile();
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+
+  this->getAllOptions();
+
+  checkOptions();
 }
 
 }  // End namespace QUESO

--- a/src/stats/src/MLSamplingLevelOptions.C
+++ b/src/stats/src/MLSamplingLevelOptions.C
@@ -28,6 +28,17 @@
 
 namespace QUESO {
 
+MLSamplingLevelOptions::MLSamplingLevelOptions()
+  :
+  m_env(NULL)
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+  , m_parser(new BoostInputOptionsParser())
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+{
+  this->set_defaults();
+  this->set_prefix("");
+}
+
 MLSamplingLevelOptions::MLSamplingLevelOptions(
   const BaseEnvironment& env,
   const char*                   prefix)

--- a/src/stats/src/MLSamplingOptions.C
+++ b/src/stats/src/MLSamplingOptions.C
@@ -28,6 +28,17 @@
 
 namespace QUESO {
 
+MLSamplingOptions::MLSamplingOptions()
+  :
+  m_env(NULL)
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+  , m_parser(new BoostInputOptionsParser())
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+{
+  this->set_defaults();
+  this->set_prefix("");
+}
+
 MLSamplingOptions::
 MLSamplingOptions(const BaseEnvironment& env, const char* prefix)
 {

--- a/src/stats/src/MLSamplingOptions.C
+++ b/src/stats/src/MLSamplingOptions.C
@@ -28,102 +28,11 @@
 
 namespace QUESO {
 
-MLSamplingOptions::MLSamplingOptions(const BaseEnvironment& env, const char* prefix)
-  :
-    m_prefix                               ((std::string)(prefix) + "ml_"                        ),
-    m_help            (UQ_ML_SAMPLING_HELP),
-#ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY
-    m_restartOutput_levelPeriod            (UQ_ML_SAMPLING_RESTART_OUTPUT_LEVEL_PERIOD_ODV       ),
-    m_restartOutput_baseNameForFiles       (UQ_ML_SAMPLING_RESTART_OUTPUT_BASE_NAME_FOR_FILES_ODV),
-    m_restartOutput_fileType               (UQ_ML_SAMPLING_RESTART_OUTPUT_FILE_TYPE_ODV          ),
-    m_restartInput_baseNameForFiles        (UQ_ML_SAMPLING_RESTART_INPUT_BASE_NAME_FOR_FILES_ODV ),
-    m_restartInput_fileType                (UQ_ML_SAMPLING_RESTART_INPUT_FILE_TYPE_ODV           ),
-#else
-    m_restartInputFileName                 (UQ_ML_SAMPLING_RESTART_INPUT_FILE_NAME_ODV),
-    m_restartInputFileType                 (UQ_ML_SAMPLING_RESTART_INPUT_FILE_TYPE_ODV),
-    m_restartChainSize                     (UQ_ML_SAMPLING_RESTART_CHAIN_SIZE_ODV     ),
-#endif
-    m_dataOutputFileName                   (UQ_ML_SAMPLING_DATA_OUTPUT_FILE_NAME_ODV  ),
-  //m_dataOutputAllowedSet                 (),
-    m_env                                  (env),
-#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-    m_parser(new BoostInputOptionsParser(env.optionsInputFileName())),
-#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-    m_option_help                          (m_prefix + "help"                          ),
-#ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY
-    m_option_restartOutput_levelPeriod     (m_prefix + "restartOutput_levelPeriod"     ),
-    m_option_restartOutput_baseNameForFiles(m_prefix + "restartOutput_baseNameForFiles"),
-    m_option_restartOutput_fileType        (m_prefix + "restartOutput_fileType"        ),
-    m_option_restartInput_baseNameForFiles (m_prefix + "restartInput_baseNameForFiles" ),
-    m_option_restartInput_fileType         (m_prefix + "restartInput_fileType"         ),
-#else
-    m_option_restartInputFileName          (m_prefix + "restartInputFileName"),
-    m_option_restartInputFileType          (m_prefix + "restartInputFileType"),
-    m_option_restartChainSize              (m_prefix + "restartChainSize"    ),
-#endif
-    m_option_dataOutputFileName            (m_prefix + "dataOutputFileName"  ),
-    m_option_dataOutputAllowedSet          (m_prefix + "dataOutputAllowedSet")
+MLSamplingOptions::
+MLSamplingOptions(const BaseEnvironment& env, const char* prefix)
 {
-#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-  m_parser->registerOption<std::string >(m_option_help,                           UQ_ML_SAMPLING_HELP,                                   "produce help msg for ML sampling options"      );
-#ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY
-  m_parser->registerOption<unsigned int>(m_option_restartOutput_levelPeriod,      UQ_ML_SAMPLING_RESTART_OUTPUT_LEVEL_PERIOD_ODV,        "restartOutput_levelPeriod"                     );
-  m_parser->registerOption<std::string >(m_option_restartOutput_baseNameForFiles, UQ_ML_SAMPLING_RESTART_OUTPUT_BASE_NAME_FOR_FILES_ODV, "restartOutput_baseNameForFiles"                );
-  m_parser->registerOption<std::string >(m_option_restartOutput_fileType,         UQ_ML_SAMPLING_RESTART_OUTPUT_FILE_TYPE_ODV,           "restartOutput_fileType"                        );
-  m_parser->registerOption<std::string >(m_option_restartInput_baseNameForFiles,  UQ_ML_SAMPLING_RESTART_INPUT_BASE_NAME_FOR_FILES_ODV,  "restartInput_baseNameForFiles"                 );
-  m_parser->registerOption<std::string >(m_option_restartInput_fileType,          UQ_ML_SAMPLING_RESTART_INPUT_FILE_TYPE_ODV,            "restartInput_fileType"                         );
-#else
-  m_parser->registerOption<std::string >(m_option_restartInputFileName,           UQ_ML_SAMPLING_RESTART_INPUT_FILE_NAME_ODV,            "name of restart input file"                    );
-  m_parser->registerOption<std::string >(m_option_restartInputFileType,           UQ_ML_SAMPLING_RESTART_INPUT_FILE_TYPE_ODV,            "type of restart input file"                    );
-  m_parser->registerOption<unsigned int>(m_option_restartChainSize,               UQ_ML_SAMPLING_RESTART_CHAIN_SIZE_ODV,                 "size of restart chain"                         );
-#endif
-  m_parser->registerOption<std::string >(m_option_dataOutputFileName,             UQ_ML_SAMPLING_DATA_OUTPUT_FILE_NAME_ODV  ,            "name of generic output file"                   );
-  m_parser->registerOption<std::string >(m_option_dataOutputAllowedSet,           UQ_ML_SAMPLING_DATA_OUTPUT_ALLOWED_SET_ODV,            "subEnvs that will write to generic output file");
-
-  m_parser->scanInputFile();
-
-  m_parser->getOption<std::string >(m_option_help,                           m_help);
-#ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY
-  m_parser->getOption<unsigned int>(m_option_restartOutput_levelPeriod,      m_restartOutput_levelPeriod);
-  m_parser->getOption<std::string >(m_option_restartOutput_baseNameForFiles, m_restartOutput_baseNameForFiles);
-  m_parser->getOption<std::string >(m_option_restartOutput_fileType,         m_restartOutput_fileType);
-  m_parser->getOption<std::string >(m_option_restartInput_baseNameForFiles,  m_restartInput_baseNameForFiles);
-  m_parser->getOption<std::string >(m_option_restartInput_fileType,          m_restartInput_fileType);
-#else
-  m_parser->getOption<std::string >(m_option_restartInputFileName,           m_restartInputFileName);
-  m_parser->getOption<std::string >(m_option_restartInputFileType,           m_restartInputFileType);
-  m_parser->getOption<unsigned int>(m_option_restartChainSize,               m_restartChainSize);
-#endif
-  m_parser->getOption<std::string >(m_option_dataOutputFileName,             m_dataOutputFileName);
-  m_parser->getOption<std::set<unsigned int> >(m_option_dataOutputAllowedSet,           m_dataOutputAllowedSet);
-#else
-  m_help = m_env.input()(m_option_help, UQ_ML_SAMPLING_HELP);
-#ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY
-  m_restartOutput_levelPeriod = m_env.input()(m_option_restartOutput_levelPeriod, UQ_ML_SAMPLING_RESTART_OUTPUT_LEVEL_PERIOD_ODV);
-  m_restartOutput_baseNameForFiles = m_env.input()(m_option_restartOutput_baseNameForFiles, UQ_ML_SAMPLING_RESTART_OUTPUT_BASE_NAME_FOR_FILES_ODV);
-  m_restartOutput_fileType = m_env.input()(m_option_restartOutput_fileType, UQ_ML_SAMPLING_RESTART_OUTPUT_FILE_TYPE_ODV);
-  m_restartInput_baseNameForFiles = m_env.input()(m_option_restartInput_baseNameForFiles, UQ_ML_SAMPLING_RESTART_INPUT_BASE_NAME_FOR_FILES_ODV);
-  m_restartInput_fileType = m_env.input()(m_option_restartInput_fileType, UQ_ML_SAMPLING_RESTART_INPUT_FILE_TYPE_ODV);
-#else
-  m_restartInputFileName = m_env.input()(m_option_restartInputFileName, UQ_ML_SAMPLING_RESTART_INPUT_FILE_NAME_ODV);
-  m_restartInputFileType = m_env.input()(m_option_restartInputFileType, UQ_ML_SAMPLING_RESTART_INPUT_FILE_TYPE_ODV);
-  m_restartChainSize = m_env.input()(m_option_restartChainSize, UQ_ML_SAMPLING_RESTART_CHAIN_SIZE_ODV);
-#endif
-  m_dataOutputFileName = m_env.input()(m_option_dataOutputFileName, UQ_ML_SAMPLING_DATA_OUTPUT_FILE_NAME_ODV  );
-
-  // UQ_ML_SAMPLING_DATA_OUTPUT_ALLOWED_SET_ODV is the empty set (string) by
-  // default
-  unsigned int size = m_env.input().vector_variable_size(m_option_dataOutputAllowedSet);
-  for (unsigned int i = 0; i < size; i++) {
-    // We default to empty set, so the default values are actually never used
-    // here
-    unsigned int allowed = m_env.input()(m_option_dataOutputAllowedSet, i, i);
-    m_dataOutputAllowedSet.insert(allowed);
-  }
-
-#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-
-  checkOptions(&env);
+  this->set_defaults();
+  this->parse(env, prefix);
 }
 
 MLSamplingOptions::~MLSamplingOptions()
@@ -131,13 +40,13 @@ MLSamplingOptions::~MLSamplingOptions()
 }
 
 void
-MLSamplingOptions::checkOptions(const BaseEnvironment * env)
+MLSamplingOptions::checkOptions()
 {
   // DM: I'm printing here because I'm not sure where this object is created
   //     in the statistical inverse problem
   if (m_help != "") {
-    if (env->subDisplayFile()) {
-      *(env->subDisplayFile()) << (*this) << std::endl;
+    if (m_env->subDisplayFile()) {
+      *(m_env->subDisplayFile()) << (*this) << std::endl;
     }
   }
 
@@ -178,6 +87,155 @@ std::ostream& operator<<(std::ostream& os, const MLSamplingOptions& obj)
 
   obj.print(os);
   return os;
+}
+
+
+void MLSamplingOptions::set_defaults()
+{
+  m_help = UQ_ML_SAMPLING_HELP;
+#ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY
+  m_restartOutput_levelPeriod = UQ_ML_SAMPLING_RESTART_OUTPUT_LEVEL_PERIOD_ODV;
+  m_restartOutput_baseNameForFiles = UQ_ML_SAMPLING_RESTART_OUTPUT_BASE_NAME_FOR_FILES_ODV;
+  m_restartOutput_fileType = UQ_ML_SAMPLING_RESTART_OUTPUT_FILE_TYPE_ODV;
+  m_restartInput_baseNameForFiles = UQ_ML_SAMPLING_RESTART_INPUT_BASE_NAME_FOR_FILES_ODV;
+  m_restartInput_fileType = UQ_ML_SAMPLING_RESTART_INPUT_FILE_TYPE_ODV;
+#else
+  m_restartInputFileName = UQ_ML_SAMPLING_RESTART_INPUT_FILE_NAME_ODV;
+  m_restartInputFileType = UQ_ML_SAMPLING_RESTART_INPUT_FILE_TYPE_ODV;
+  m_restartChainSize = UQ_ML_SAMPLING_RESTART_CHAIN_SIZE_ODV;
+#endif
+  m_dataOutputFileName = UQ_ML_SAMPLING_DATA_OUTPUT_FILE_NAME_ODV;
+  //m_dataOutputAllowedSet
+}
+
+void MLSamplingOptions::set_prefix(const std::string& prefix)
+{
+  m_prefix = prefix + "ml_";
+
+  m_option_help = m_prefix + "help";
+#ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY
+  m_option_restartOutput_levelPeriod = m_prefix + "restartOutput_levelPeriod";
+  m_option_restartOutput_baseNameForFiles = m_prefix + "restartOutput_baseNameForFiles";
+  m_option_restartOutput_fileType = m_prefix + "restartOutput_fileType";
+  m_option_restartInput_baseNameForFiles = m_prefix + "restartInput_baseNameForFiles";
+  m_option_restartInput_fileType = m_prefix + "restartInput_fileType";
+#else
+  m_option_restartInputFileName = m_prefix + "restartInputFileName";
+  m_option_restartInputFileType = m_prefix + "restartInputFileType";
+  m_option_restartChainSize = m_prefix + "restartChainSize";
+#endif
+  m_option_dataOutputFileName = m_prefix + "dataOutputFileName";
+  m_option_dataOutputAllowedSet = m_prefix + "dataOutputAllowedSet";
+}
+
+void MLSamplingOptions::parse(const BaseEnvironment& env, const std::string& prefix)
+{
+  m_env = &env;
+
+  this->set_prefix(prefix);
+
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+  m_parser.reset(new BoostInputOptionsParser(env.optionsInputFileName()));
+
+  m_parser->registerOption<std::string>
+    (m_option_help, m_help, "produce help msg for ML sampling options");
+#ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY
+  m_parser->registerOption<unsigned int>
+    (m_option_restartOutput_levelPeriod, m_restartOutput_levelPeriod,
+     "restartOutput_levelPeriod");
+  m_parser->registerOption<std::string>
+    (m_option_restartOutput_baseNameForFiles, m_restartOutput_baseNameForFiles,
+     "restartOutput_baseNameForFiles");
+  m_parser->registerOption<std::string>
+    (m_option_restartOutput_fileType, m_restartOutput_fileType,
+     "restartOutput_fileType");
+  m_parser->registerOption<std::string>
+    (m_option_restartInput_baseNameForFiles, m_restartInput_baseNameForFiles,
+     "restartInput_baseNameForFiles");
+  m_parser->registerOption<std::string>
+    (m_option_restartInput_fileType, m_restartInput_fileType,
+     "restartInput_fileType");
+#else
+  m_parser->registerOption<std::string>
+    (m_option_restartInputFileName, m_restartInputFileName,
+     "name of restart input file");
+  m_parser->registerOption<std::string>
+    (m_option_restartInputFileType, m_restartInputFileType,
+     "type of restart input file");
+  m_parser->registerOption<unsigned int>
+    (m_option_restartChainSize, m_restartChainSize, "size of restart chain");
+#endif
+  m_parser->registerOption<std::string>
+    (m_option_dataOutputFileName, m_dataOutputFileName,
+    "name of generic output file");
+  m_parser->registerOption<std::string>
+    (m_option_dataOutputAllowedSet, container_to_string(m_dataOutputAllowedSet),
+    "subEnvs that will write to generic output file");
+
+  m_parser->scanInputFile();
+
+  m_parser->getOption<std::string>(m_option_help, m_help);
+#ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY
+  m_parser->getOption<unsigned int>
+    (m_option_restartOutput_levelPeriod, m_restartOutput_levelPeriod);
+  m_parser->getOption<std::string>
+    (m_option_restartOutput_baseNameForFiles, m_restartOutput_baseNameForFiles);
+  m_parser->getOption<std::string>
+    (m_option_restartOutput_fileType, m_restartOutput_fileType);
+  m_parser->getOption<std::string>
+    (m_option_restartInput_baseNameForFiles, m_restartInput_baseNameForFiles);
+  m_parser->getOption<std::string>
+    (m_option_restartInput_fileType, m_restartInput_fileType);
+#else
+  m_parser->getOption<std::string>
+    (m_option_restartInputFileName, m_restartInputFileName);
+  m_parser->getOption<std::string>
+    (m_option_restartInputFileType, m_restartInputFileType);
+  m_parser->getOption<unsigned int>
+    (m_option_restartChainSize, m_restartChainSize);
+#endif
+  m_parser->getOption<std::string>
+    (m_option_dataOutputFileName, m_dataOutputFileName);
+  m_parser->getOption<std::set<unsigned int> >
+    (m_option_dataOutputAllowedSet, m_dataOutputAllowedSet);
+#else
+  m_help = m_env->input()(m_option_help, m_help);
+#ifdef ML_CODE_HAS_NEW_RESTART_CAPABILITY
+  m_restartOutput_levelPeriod = m_env->input()
+    (m_option_restartOutput_levelPeriod, m_restartOutput_levelPeriod);
+  m_restartOutput_baseNameForFiles = m_env->input()
+    (m_option_restartOutput_baseNameForFiles, m_restartOutput_baseNameForFiles);
+  m_restartOutput_fileType = m_env->input()
+    (m_option_restartOutput_fileType, m_restartOutput_fileType);
+  m_restartInput_baseNameForFiles = m_env->input()
+    (m_option_restartInput_baseNameForFiles, m_restartInput_baseNameForFiles);
+  m_restartInput_fileType = m_env->input()
+    (m_option_restartInput_fileType, m_restartInput_fileType);
+#else
+  m_restartInputFileName = m_env->input()
+    (m_option_restartInputFileName, m_restartInputFileName);
+  m_restartInputFileType = m_env->input()
+    (m_option_restartInputFileType, m_restartInputFileType);
+  m_restartChainSize = m_env->input()
+    (m_option_restartChainSize, m_restartChainSize);
+#endif
+  m_dataOutputFileName = m_env->input()
+    (m_option_dataOutputFileName, m_dataOutputFileName);
+
+  // UQ_ML_SAMPLING_DATA_OUTPUT_ALLOWED_SET_ODV is the empty set (string) by
+  // default
+  unsigned int size =
+    m_env->input().vector_variable_size(m_option_dataOutputAllowedSet);
+  for (unsigned int i = 0; i < size; i++) {
+    // We default to empty set, so the default values are actually never used
+    // here
+    unsigned int allowed = m_env->input()(m_option_dataOutputAllowedSet, i, i);
+    m_dataOutputAllowedSet.insert(allowed);
+  }
+
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+
+  checkOptions();
 }
 
 }  // End namespace QUESO

--- a/src/stats/src/MetropolisHastingsSGOptions.C
+++ b/src/stats/src/MetropolisHastingsSGOptions.C
@@ -50,6 +50,9 @@ MhOptionsValues::MhOptionsValues(
   )
   :
   m_env(NULL)
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+  , m_parser(new BoostInputOptionsParser())
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 {
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
   if (alternativeRawSsOptionsValues     ) m_alternativeRawSsOptionsValues      = *alternativeRawSsOptionsValues;

--- a/src/stats/src/MetropolisHastingsSGOptions.C
+++ b/src/stats/src/MetropolisHastingsSGOptions.C
@@ -49,138 +49,15 @@ MhOptionsValues::MhOptionsValues(
 #endif
   )
   :
-    m_prefix                                           ("mh_"),
-    m_help(UQ_MH_SG_HELP),
-    m_dataOutputFileName                       (UQ_MH_SG_DATA_OUTPUT_FILE_NAME_ODV),
-    m_dataOutputAllowAll                       (UQ_MH_SG_DATA_OUTPUT_ALLOW_ALL_ODV),
-  //m_dataOutputAllowedSet                     (),
-    m_totallyMute                              (UQ_MH_SG_TOTALLY_MUTE_ODV),
-    m_initialPositionDataInputFileName         (UQ_MH_SG_INITIAL_POSITION_DATA_INPUT_FILE_NAME_ODV),
-    m_initialPositionDataInputFileType         (UQ_MH_SG_INITIAL_POSITION_DATA_INPUT_FILE_TYPE_ODV),
-    m_initialProposalCovMatrixDataInputFileName(UQ_MH_SG_INITIAL_PROPOSAL_COV_MATRIX_DATA_INPUT_FILE_NAME_ODV),
-    m_initialProposalCovMatrixDataInputFileType(UQ_MH_SG_INITIAL_PROPOSAL_COV_MATRIX_DATA_INPUT_FILE_TYPE_ODV),
-  //m_parameterDisabledSet                     (),
-    m_rawChainDataInputFileName                (UQ_MH_SG_RAW_CHAIN_DATA_INPUT_FILE_NAME_ODV),
-    m_rawChainDataInputFileType                (UQ_MH_SG_RAW_CHAIN_DATA_INPUT_FILE_TYPE_ODV),
-    m_rawChainSize                             (UQ_MH_SG_RAW_CHAIN_SIZE_ODV),
-    m_rawChainGenerateExtra                    (UQ_MH_SG_RAW_CHAIN_GENERATE_EXTRA_ODV),
-    m_rawChainDisplayPeriod                    (UQ_MH_SG_RAW_CHAIN_DISPLAY_PERIOD_ODV),
-    m_rawChainMeasureRunTimes                  (UQ_MH_SG_RAW_CHAIN_MEASURE_RUN_TIMES_ODV),
-    m_rawChainDataOutputPeriod                 (UQ_MH_SG_RAW_CHAIN_DATA_OUTPUT_PERIOD_ODV),
-    m_rawChainDataOutputFileName               (UQ_MH_SG_RAW_CHAIN_DATA_OUTPUT_FILE_NAME_ODV),
-    m_rawChainDataOutputFileType               (UQ_MH_SG_RAW_CHAIN_DATA_OUTPUT_FILE_TYPE_ODV),
-    m_rawChainDataOutputAllowAll               (UQ_MH_SG_RAW_CHAIN_DATA_OUTPUT_ALLOW_ALL_ODV),
-  //m_rawChainDataOutputAllowedSet             (),
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-    m_rawChainComputeStats                     (UQ_MH_SG_RAW_CHAIN_COMPUTE_STATS_ODV),
-#endif
-    m_filteredChainGenerate                    (UQ_MH_SG_FILTERED_CHAIN_GENERATE_ODV),
-    m_filteredChainDiscardedPortion            (UQ_MH_SG_FILTERED_CHAIN_DISCARDED_PORTION_ODV),
-    m_filteredChainLag                         (UQ_MH_SG_FILTERED_CHAIN_LAG_ODV),
-    m_filteredChainDataOutputFileName          (UQ_MH_SG_FILTERED_CHAIN_DATA_OUTPUT_FILE_NAME_ODV),
-    m_filteredChainDataOutputFileType          (UQ_MH_SG_FILTERED_CHAIN_DATA_OUTPUT_FILE_TYPE_ODV),
-    m_filteredChainDataOutputAllowAll          (UQ_MH_SG_FILTERED_CHAIN_DATA_OUTPUT_ALLOW_ALL_ODV),
-  //m_filteredChainDataOutputAllowedSet        (),
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-    m_filteredChainComputeStats                (UQ_MH_SG_FILTERED_CHAIN_COMPUTE_STATS_ODV),
-#endif
-    m_displayCandidates                        (UQ_MH_SG_DISPLAY_CANDIDATES_ODV),
-    m_putOutOfBoundsInChain                    (UQ_MH_SG_PUT_OUT_OF_BOUNDS_IN_CHAIN_ODV),
-    m_tkUseLocalHessian                        (UQ_MH_SG_TK_USE_LOCAL_HESSIAN_ODV),
-    m_tkUseNewtonComponent                     (UQ_MH_SG_TK_USE_NEWTON_COMPONENT_ODV),
-    m_drMaxNumExtraStages                      (UQ_MH_SG_DR_MAX_NUM_EXTRA_STAGES_ODV),
-    m_drScalesForExtraStages                   (0),
-    m_drDuringAmNonAdaptiveInt                 (UQ_MH_SG_DR_DURING_AM_NON_ADAPTIVE_INT_ODV),
-    m_amKeepInitialMatrix                      (UQ_MH_SG_AM_KEEP_INITIAL_MATRIX_ODV),
-    m_amInitialNonAdaptInterval                (UQ_MH_SG_AM_INIT_NON_ADAPT_INT_ODV),
-    m_amAdaptInterval                          (UQ_MH_SG_AM_ADAPT_INTERVAL_ODV),
-    m_amAdaptedMatricesDataOutputPeriod        (UQ_MH_SG_AM_ADAPTED_MATRICES_DATA_OUTPUT_PERIOD_ODV),
-    m_amAdaptedMatricesDataOutputFileName      (UQ_MH_SG_AM_ADAPTED_MATRICES_DATA_OUTPUT_FILE_NAME_ODV),
-    m_amAdaptedMatricesDataOutputFileType      (UQ_MH_SG_AM_ADAPTED_MATRICES_DATA_OUTPUT_FILE_TYPE_ODV),
-    m_amAdaptedMatricesDataOutputAllowAll      (UQ_MH_SG_AM_ADAPTED_MATRICES_DATA_OUTPUT_ALLOW_ALL_ODV),
-  //m_amAdaptedMatricesDataOutputAllowedSet    (),
-    m_amEta                                    (UQ_MH_SG_AM_ETA_ODV),
-    m_amEpsilon                                (UQ_MH_SG_AM_EPSILON_ODV),
-    m_enableBrooksGelmanConvMonitor            (UQ_MH_SG_ENABLE_BROOKS_GELMAN_CONV_MONITOR),
-    m_BrooksGelmanLag                          (UQ_MH_SG_BROOKS_GELMAN_LAG),
-    m_outputLogLikelihood                      (UQ_MH_SG_OUTPUT_LOG_LIKELIHOOD),
-    m_outputLogTarget                          (UQ_MH_SG_OUTPUT_LOG_TARGET),
-    m_doLogitTransform                         (UQ_MH_SG_DO_LOGIT_TRANSFORM),
-    m_algorithm                                (UQ_MH_SG_ALGORITHM),
-    m_tk                                       (UQ_MH_SG_TK),
-    m_updateInterval                           (UQ_MH_SG_UPDATE_INTERVAL),
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-    m_alternativeRawSsOptionsValues            (),
-    m_alternativeFilteredSsOptionsValues       (),
-#endif
-    m_env(NULL),
-#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-    m_parser(),
-#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-    m_option_help                                      (m_prefix + "help"                                      ),
-    m_option_dataOutputFileName                        (m_prefix + "dataOutputFileName"                        ),
-    m_option_dataOutputAllowAll                        (m_prefix + "dataOutputAllowAll"                        ),
-    m_option_dataOutputAllowedSet                      (m_prefix + "dataOutputAllowedSet"                      ),
-    m_option_totallyMute                               (m_prefix + "totallyMute"                               ),
-    m_option_initialPosition_dataInputFileName         (m_prefix + "initialPosition_dataInputFileName"         ),
-    m_option_initialPosition_dataInputFileType         (m_prefix + "initialPosition_dataInputFileType"         ),
-    m_option_initialProposalCovMatrix_dataInputFileName(m_prefix + "initialProposalCovMatrix_dataInputFileName"),
-    m_option_initialProposalCovMatrix_dataInputFileType(m_prefix + "initialProposalCovMatrix_dataInputFileType"),
-    m_option_listOfDisabledParameters                  (m_prefix + "listOfDisabledParameters"                  ),
-    m_option_rawChain_dataInputFileName                (m_prefix + "rawChain_dataInputFileName"                ),
-    m_option_rawChain_dataInputFileType                (m_prefix + "rawChain_dataInputFileType"                ),
-    m_option_rawChain_size                             (m_prefix + "rawChain_size"                             ),
-    m_option_rawChain_generateExtra                    (m_prefix + "rawChain_generateExtra"                    ),
-    m_option_rawChain_displayPeriod                    (m_prefix + "rawChain_displayPeriod"                    ),
-    m_option_rawChain_measureRunTimes                  (m_prefix + "rawChain_measureRunTimes"                  ),
-    m_option_rawChain_dataOutputPeriod                 (m_prefix + "rawChain_dataOutputPeriod"                 ),
-    m_option_rawChain_dataOutputFileName               (m_prefix + "rawChain_dataOutputFileName"               ),
-    m_option_rawChain_dataOutputFileType               (m_prefix + "rawChain_dataOutputFileType"               ),
-    m_option_rawChain_dataOutputAllowAll               (m_prefix + "rawChain_dataOutputAllowAll"               ),
-    m_option_rawChain_dataOutputAllowedSet             (m_prefix + "rawChain_dataOutputAllowedSet"             ),
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-    m_option_rawChain_computeStats                     (m_prefix + "rawChain_computeStats"                     ),
-#endif
-    m_option_filteredChain_generate                    (m_prefix + "filteredChain_generate"                    ),
-    m_option_filteredChain_discardedPortion            (m_prefix + "filteredChain_discardedPortion"            ),
-    m_option_filteredChain_lag                         (m_prefix + "filteredChain_lag"                         ),
-    m_option_filteredChain_dataOutputFileName          (m_prefix + "filteredChain_dataOutputFileName"          ),
-    m_option_filteredChain_dataOutputFileType          (m_prefix + "filteredChain_dataOutputFileType"          ),
-    m_option_filteredChain_dataOutputAllowAll          (m_prefix + "filteredChain_dataOutputAllowAll"          ),
-    m_option_filteredChain_dataOutputAllowedSet        (m_prefix + "filteredChain_dataOutputAllowedSet"        ),
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-    m_option_filteredChain_computeStats                (m_prefix + "filteredChain_computeStats"                ),
-#endif
-    m_option_displayCandidates                         (m_prefix + "displayCandidates"                         ),
-    m_option_putOutOfBoundsInChain                     (m_prefix + "putOutOfBoundsInChain"                     ),
-    m_option_tk_useLocalHessian                        (m_prefix + "tk_useLocalHessian"                        ),
-    m_option_tk_useNewtonComponent                     (m_prefix + "tk_useNewtonComponent"                     ),
-    m_option_dr_maxNumExtraStages                      (m_prefix + "dr_maxNumExtraStages"                      ),
-    m_option_dr_listOfScalesForExtraStages             (m_prefix + "dr_listOfScalesForExtraStages"             ),
-    m_option_dr_duringAmNonAdaptiveInt                 (m_prefix + "dr_duringAmNonAdaptiveInt"                 ),
-    m_option_am_keepInitialMatrix                      (m_prefix + "am_keepInitialMatrix"                      ),
-    m_option_am_initialNonAdaptInterval                (m_prefix + "am_initialNonAdaptInterval"                ),
-    m_option_am_adaptInterval                          (m_prefix + "am_adaptInterval"                          ),
-    m_option_am_adaptedMatrices_dataOutputPeriod       (m_prefix + "am_adaptedMatrices_dataOutputPeriod"       ),
-    m_option_am_adaptedMatrices_dataOutputFileName     (m_prefix + "am_adaptedMatrices_dataOutputFileName"     ),
-    m_option_am_adaptedMatrices_dataOutputFileType     (m_prefix + "am_adaptedMatrices_dataOutputFileType"     ),
-    m_option_am_adaptedMatrices_dataOutputAllowAll     (m_prefix + "am_adaptedMatrices_dataOutputAllowAll"     ),
-    m_option_am_adaptedMatrices_dataOutputAllowedSet   (m_prefix + "am_adaptedMatrices_dataOutputAllowedSet"   ),
-    m_option_am_eta                                    (m_prefix + "am_eta"                                    ),
-    m_option_am_epsilon                                (m_prefix + "am_epsilon"                                ),
-    m_option_enableBrooksGelmanConvMonitor             (m_prefix + "enableBrooksGelmanConvMonitor"             ),
-    m_option_BrooksGelmanLag                           (m_prefix + "BrooksGelmanLag"                           ),
-    m_option_outputLogLikelihood                       (m_prefix + "outputLogLikelihood"                       ),
-    m_option_outputLogTarget                           (m_prefix + "outputLogTarget"                           ),
-    m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          ),
-    m_option_algorithm                                 (m_prefix + "algorithm"                                 ),
-    m_option_tk                                        (m_prefix + "tk"                                        ),
-    m_option_updateInterval                            (m_prefix + "updateInterval"                            )
+  m_env(NULL)
 {
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
   if (alternativeRawSsOptionsValues     ) m_alternativeRawSsOptionsValues      = *alternativeRawSsOptionsValues;
   if (alternativeFilteredSsOptionsValues) m_alternativeFilteredSsOptionsValues = *alternativeFilteredSsOptionsValues;
 #endif
+
+  this->set_defaults();
+  this->set_prefix("");
 }
 
 MhOptionsValues::MhOptionsValues(
@@ -191,381 +68,16 @@ MhOptionsValues::MhOptionsValues(
   const BaseEnvironment * env,
   const char * prefix
   )
-  :
-    m_prefix                                           ((std::string)(prefix) + "mh_"),
-    m_help(UQ_MH_SG_HELP),
-    m_dataOutputFileName                       (UQ_MH_SG_DATA_OUTPUT_FILE_NAME_ODV),
-    m_dataOutputAllowAll                       (UQ_MH_SG_DATA_OUTPUT_ALLOW_ALL_ODV),
-  //m_dataOutputAllowedSet                     (),
-    m_totallyMute                              (UQ_MH_SG_TOTALLY_MUTE_ODV),
-    m_initialPositionDataInputFileName         (UQ_MH_SG_INITIAL_POSITION_DATA_INPUT_FILE_NAME_ODV),
-    m_initialPositionDataInputFileType         (UQ_MH_SG_INITIAL_POSITION_DATA_INPUT_FILE_TYPE_ODV),
-    m_initialProposalCovMatrixDataInputFileName(UQ_MH_SG_INITIAL_PROPOSAL_COV_MATRIX_DATA_INPUT_FILE_NAME_ODV),
-    m_initialProposalCovMatrixDataInputFileType(UQ_MH_SG_INITIAL_PROPOSAL_COV_MATRIX_DATA_INPUT_FILE_TYPE_ODV),
-  //m_parameterDisabledSet                     (),
-    m_rawChainDataInputFileName                (UQ_MH_SG_RAW_CHAIN_DATA_INPUT_FILE_NAME_ODV),
-    m_rawChainDataInputFileType                (UQ_MH_SG_RAW_CHAIN_DATA_INPUT_FILE_TYPE_ODV),
-    m_rawChainSize                             (UQ_MH_SG_RAW_CHAIN_SIZE_ODV),
-    m_rawChainGenerateExtra                    (UQ_MH_SG_RAW_CHAIN_GENERATE_EXTRA_ODV),
-    m_rawChainDisplayPeriod                    (UQ_MH_SG_RAW_CHAIN_DISPLAY_PERIOD_ODV),
-    m_rawChainMeasureRunTimes                  (UQ_MH_SG_RAW_CHAIN_MEASURE_RUN_TIMES_ODV),
-    m_rawChainDataOutputPeriod                 (UQ_MH_SG_RAW_CHAIN_DATA_OUTPUT_PERIOD_ODV),
-    m_rawChainDataOutputFileName               (UQ_MH_SG_RAW_CHAIN_DATA_OUTPUT_FILE_NAME_ODV),
-    m_rawChainDataOutputFileType               (UQ_MH_SG_RAW_CHAIN_DATA_OUTPUT_FILE_TYPE_ODV),
-    m_rawChainDataOutputAllowAll               (UQ_MH_SG_RAW_CHAIN_DATA_OUTPUT_ALLOW_ALL_ODV),
-  //m_rawChainDataOutputAllowedSet             (),
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-    m_rawChainComputeStats                     (UQ_MH_SG_RAW_CHAIN_COMPUTE_STATS_ODV),
-#endif
-    m_filteredChainGenerate                    (UQ_MH_SG_FILTERED_CHAIN_GENERATE_ODV),
-    m_filteredChainDiscardedPortion            (UQ_MH_SG_FILTERED_CHAIN_DISCARDED_PORTION_ODV),
-    m_filteredChainLag                         (UQ_MH_SG_FILTERED_CHAIN_LAG_ODV),
-    m_filteredChainDataOutputFileName          (UQ_MH_SG_FILTERED_CHAIN_DATA_OUTPUT_FILE_NAME_ODV),
-    m_filteredChainDataOutputFileType          (UQ_MH_SG_FILTERED_CHAIN_DATA_OUTPUT_FILE_TYPE_ODV),
-    m_filteredChainDataOutputAllowAll          (UQ_MH_SG_FILTERED_CHAIN_DATA_OUTPUT_ALLOW_ALL_ODV),
-  //m_filteredChainDataOutputAllowedSet        (),
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-    m_filteredChainComputeStats                (UQ_MH_SG_FILTERED_CHAIN_COMPUTE_STATS_ODV),
-#endif
-    m_displayCandidates                        (UQ_MH_SG_DISPLAY_CANDIDATES_ODV),
-    m_putOutOfBoundsInChain                    (UQ_MH_SG_PUT_OUT_OF_BOUNDS_IN_CHAIN_ODV),
-    m_tkUseLocalHessian                        (UQ_MH_SG_TK_USE_LOCAL_HESSIAN_ODV),
-    m_tkUseNewtonComponent                     (UQ_MH_SG_TK_USE_NEWTON_COMPONENT_ODV),
-    m_drMaxNumExtraStages                      (UQ_MH_SG_DR_MAX_NUM_EXTRA_STAGES_ODV),
-    m_drScalesForExtraStages                   (0),
-    m_drDuringAmNonAdaptiveInt                 (UQ_MH_SG_DR_DURING_AM_NON_ADAPTIVE_INT_ODV),
-    m_amKeepInitialMatrix                      (UQ_MH_SG_AM_KEEP_INITIAL_MATRIX_ODV),
-    m_amInitialNonAdaptInterval                (UQ_MH_SG_AM_INIT_NON_ADAPT_INT_ODV),
-    m_amAdaptInterval                          (UQ_MH_SG_AM_ADAPT_INTERVAL_ODV),
-    m_amAdaptedMatricesDataOutputPeriod        (UQ_MH_SG_AM_ADAPTED_MATRICES_DATA_OUTPUT_PERIOD_ODV),
-    m_amAdaptedMatricesDataOutputFileName      (UQ_MH_SG_AM_ADAPTED_MATRICES_DATA_OUTPUT_FILE_NAME_ODV),
-    m_amAdaptedMatricesDataOutputFileType      (UQ_MH_SG_AM_ADAPTED_MATRICES_DATA_OUTPUT_FILE_TYPE_ODV),
-    m_amAdaptedMatricesDataOutputAllowAll      (UQ_MH_SG_AM_ADAPTED_MATRICES_DATA_OUTPUT_ALLOW_ALL_ODV),
-  //m_amAdaptedMatricesDataOutputAllowedSet    (),
-    m_amEta                                    (UQ_MH_SG_AM_ETA_ODV),
-    m_amEpsilon                                (UQ_MH_SG_AM_EPSILON_ODV),
-    m_enableBrooksGelmanConvMonitor            (UQ_MH_SG_ENABLE_BROOKS_GELMAN_CONV_MONITOR),
-    m_BrooksGelmanLag                          (UQ_MH_SG_BROOKS_GELMAN_LAG),
-    m_outputLogLikelihood                      (UQ_MH_SG_OUTPUT_LOG_LIKELIHOOD),
-    m_outputLogTarget                          (UQ_MH_SG_OUTPUT_LOG_TARGET),
-    m_doLogitTransform                         (UQ_MH_SG_DO_LOGIT_TRANSFORM),
-    m_algorithm                                (UQ_MH_SG_ALGORITHM),
-    m_tk                                       (UQ_MH_SG_TK),
-    m_updateInterval                           (UQ_MH_SG_UPDATE_INTERVAL),
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-    m_alternativeRawSsOptionsValues            (),
-    m_alternativeFilteredSsOptionsValues       (),
-#endif
-    m_env(env),
-#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-    m_parser(new BoostInputOptionsParser(env->optionsInputFileName())),
-#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-    m_option_help                                      (m_prefix + "help"                                      ),
-    m_option_dataOutputFileName                        (m_prefix + "dataOutputFileName"                        ),
-    m_option_dataOutputAllowAll                        (m_prefix + "dataOutputAllowAll"                        ),
-    m_option_dataOutputAllowedSet                      (m_prefix + "dataOutputAllowedSet"                      ),
-    m_option_totallyMute                               (m_prefix + "totallyMute"                               ),
-    m_option_initialPosition_dataInputFileName         (m_prefix + "initialPosition_dataInputFileName"         ),
-    m_option_initialPosition_dataInputFileType         (m_prefix + "initialPosition_dataInputFileType"         ),
-    m_option_initialProposalCovMatrix_dataInputFileName(m_prefix + "initialProposalCovMatrix_dataInputFileName"),
-    m_option_initialProposalCovMatrix_dataInputFileType(m_prefix + "initialProposalCovMatrix_dataInputFileType"),
-    m_option_listOfDisabledParameters                  (m_prefix + "listOfDisabledParameters"                  ),
-    m_option_rawChain_dataInputFileName                (m_prefix + "rawChain_dataInputFileName"                ),
-    m_option_rawChain_dataInputFileType                (m_prefix + "rawChain_dataInputFileType"                ),
-    m_option_rawChain_size                             (m_prefix + "rawChain_size"                             ),
-    m_option_rawChain_generateExtra                    (m_prefix + "rawChain_generateExtra"                    ),
-    m_option_rawChain_displayPeriod                    (m_prefix + "rawChain_displayPeriod"                    ),
-    m_option_rawChain_measureRunTimes                  (m_prefix + "rawChain_measureRunTimes"                  ),
-    m_option_rawChain_dataOutputPeriod                 (m_prefix + "rawChain_dataOutputPeriod"                 ),
-    m_option_rawChain_dataOutputFileName               (m_prefix + "rawChain_dataOutputFileName"               ),
-    m_option_rawChain_dataOutputFileType               (m_prefix + "rawChain_dataOutputFileType"               ),
-    m_option_rawChain_dataOutputAllowAll               (m_prefix + "rawChain_dataOutputAllowAll"               ),
-    m_option_rawChain_dataOutputAllowedSet             (m_prefix + "rawChain_dataOutputAllowedSet"             ),
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-    m_option_rawChain_computeStats                     (m_prefix + "rawChain_computeStats"                     ),
-#endif
-    m_option_filteredChain_generate                    (m_prefix + "filteredChain_generate"                    ),
-    m_option_filteredChain_discardedPortion            (m_prefix + "filteredChain_discardedPortion"            ),
-    m_option_filteredChain_lag                         (m_prefix + "filteredChain_lag"                         ),
-    m_option_filteredChain_dataOutputFileName          (m_prefix + "filteredChain_dataOutputFileName"          ),
-    m_option_filteredChain_dataOutputFileType          (m_prefix + "filteredChain_dataOutputFileType"          ),
-    m_option_filteredChain_dataOutputAllowAll          (m_prefix + "filteredChain_dataOutputAllowAll"          ),
-    m_option_filteredChain_dataOutputAllowedSet        (m_prefix + "filteredChain_dataOutputAllowedSet"        ),
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-    m_option_filteredChain_computeStats                (m_prefix + "filteredChain_computeStats"                ),
-#endif
-    m_option_displayCandidates                         (m_prefix + "displayCandidates"                         ),
-    m_option_putOutOfBoundsInChain                     (m_prefix + "putOutOfBoundsInChain"                     ),
-    m_option_tk_useLocalHessian                        (m_prefix + "tk_useLocalHessian"                        ),
-    m_option_tk_useNewtonComponent                     (m_prefix + "tk_useNewtonComponent"                     ),
-    m_option_dr_maxNumExtraStages                      (m_prefix + "dr_maxNumExtraStages"                      ),
-    m_option_dr_listOfScalesForExtraStages             (m_prefix + "dr_listOfScalesForExtraStages"             ),
-    m_option_dr_duringAmNonAdaptiveInt                 (m_prefix + "dr_duringAmNonAdaptiveInt"                 ),
-    m_option_am_keepInitialMatrix                      (m_prefix + "am_keepInitialMatrix"                      ),
-    m_option_am_initialNonAdaptInterval                (m_prefix + "am_initialNonAdaptInterval"                ),
-    m_option_am_adaptInterval                          (m_prefix + "am_adaptInterval"                          ),
-    m_option_am_adaptedMatrices_dataOutputPeriod       (m_prefix + "am_adaptedMatrices_dataOutputPeriod"       ),
-    m_option_am_adaptedMatrices_dataOutputFileName     (m_prefix + "am_adaptedMatrices_dataOutputFileName"     ),
-    m_option_am_adaptedMatrices_dataOutputFileType     (m_prefix + "am_adaptedMatrices_dataOutputFileType"     ),
-    m_option_am_adaptedMatrices_dataOutputAllowAll     (m_prefix + "am_adaptedMatrices_dataOutputAllowAll"     ),
-    m_option_am_adaptedMatrices_dataOutputAllowedSet   (m_prefix + "am_adaptedMatrices_dataOutputAllowedSet"   ),
-    m_option_am_eta                                    (m_prefix + "am_eta"                                    ),
-    m_option_am_epsilon                                (m_prefix + "am_epsilon"                                ),
-    m_option_enableBrooksGelmanConvMonitor             (m_prefix + "enableBrooksGelmanConvMonitor"             ),
-    m_option_BrooksGelmanLag                           (m_prefix + "BrooksGelmanLag"                           ),
-    m_option_outputLogLikelihood                       (m_prefix + "outputLogLikelihood"                       ),
-    m_option_outputLogTarget                           (m_prefix + "outputLogTarget"                           ),
-    m_option_doLogitTransform                          (m_prefix + "doLogitTransform"                          ),
-    m_option_algorithm                                 (m_prefix + "algorithm"                                 ),
-    m_option_tk                                        (m_prefix + "tk"                                        ),
-    m_option_updateInterval                            (m_prefix + "updateInterval"                            )
 {
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
   if (alternativeRawSsOptionsValues     ) m_alternativeRawSsOptionsValues      = *alternativeRawSsOptionsValues;
   if (alternativeFilteredSsOptionsValues) m_alternativeFilteredSsOptionsValues = *alternativeFilteredSsOptionsValues;
 #endif
 
-#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-  m_parser->registerOption<std::string >(m_option_help,                                       UQ_MH_SG_HELP,                                                 "produce help msg for Bayesian Metropolis-Hastings"          );
-  m_parser->registerOption<std::string >(m_option_dataOutputFileName,                         UQ_MH_SG_DATA_OUTPUT_FILE_NAME_ODV                           , "name of generic output file"                                );
-  m_parser->registerOption<bool        >(m_option_dataOutputAllowAll,                         UQ_MH_SG_DATA_OUTPUT_ALLOW_ALL_ODV                           , "allow all subEnvs write to a generic output file"           );
-  m_parser->registerOption<std::string >(m_option_dataOutputAllowedSet,                       UQ_MH_SG_DATA_OUTPUT_ALLOWED_SET_ODV                         , "subEnvs that will write to generic output file"             );
-  m_parser->registerOption<bool        >(m_option_totallyMute,                                UQ_MH_SG_TOTALLY_MUTE_ODV                                    , "totally mute (no printout msg)"                             );
-  m_parser->registerOption<std::string >(m_option_initialPosition_dataInputFileName,          UQ_MH_SG_INITIAL_POSITION_DATA_INPUT_FILE_NAME_ODV           , "name of input file for raw chain "                          );
-  m_parser->registerOption<std::string >(m_option_initialPosition_dataInputFileType,          UQ_MH_SG_INITIAL_POSITION_DATA_INPUT_FILE_TYPE_ODV           , "type of input file for raw chain "                          );
-  m_parser->registerOption<std::string >(m_option_initialProposalCovMatrix_dataInputFileName, UQ_MH_SG_INITIAL_PROPOSAL_COV_MATRIX_DATA_INPUT_FILE_NAME_ODV, "name of input file for raw chain "                          );
-  m_parser->registerOption<std::string >(m_option_initialProposalCovMatrix_dataInputFileType, UQ_MH_SG_INITIAL_PROPOSAL_COV_MATRIX_DATA_INPUT_FILE_TYPE_ODV, "type of input file for raw chain "                          );
-  m_parser->registerOption<std::string >(m_option_listOfDisabledParameters,                   UQ_MH_SG_LIST_OF_DISABLED_PARAMETERS_ODV                     , "list of disabled parameters"                                );
-  m_parser->registerOption<std::string >(m_option_rawChain_dataInputFileName,                 UQ_MH_SG_RAW_CHAIN_DATA_INPUT_FILE_NAME_ODV                  , "name of input file for raw chain "                          );
-  m_parser->registerOption<std::string >(m_option_rawChain_dataInputFileType,                 UQ_MH_SG_RAW_CHAIN_DATA_INPUT_FILE_TYPE_ODV                  , "type of input file for raw chain "                          );
-  m_parser->registerOption<unsigned int>(m_option_rawChain_size,                              UQ_MH_SG_RAW_CHAIN_SIZE_ODV                                  , "size of raw chain"                                          );
-  m_parser->registerOption<bool        >(m_option_rawChain_generateExtra,                     UQ_MH_SG_RAW_CHAIN_GENERATE_EXTRA_ODV                        , "generate extra information about raw chain"                 );
-  m_parser->registerOption<unsigned int>(m_option_rawChain_displayPeriod,                     UQ_MH_SG_RAW_CHAIN_DISPLAY_PERIOD_ODV                        , "period of msg display during raw chain generation"          );
-  m_parser->registerOption<bool        >(m_option_rawChain_measureRunTimes,                   UQ_MH_SG_RAW_CHAIN_MEASURE_RUN_TIMES_ODV                     , "measure run times"                                          );
-  m_parser->registerOption<unsigned int>(m_option_rawChain_dataOutputPeriod,                  UQ_MH_SG_RAW_CHAIN_DATA_OUTPUT_PERIOD_ODV                    , "period of msg display during raw chain generation"          );
-  m_parser->registerOption<std::string >(m_option_rawChain_dataOutputFileName,                UQ_MH_SG_RAW_CHAIN_DATA_OUTPUT_FILE_NAME_ODV                 , "name of output file for raw chain "                         );
-  m_parser->registerOption<std::string >(m_option_rawChain_dataOutputFileType,                UQ_MH_SG_RAW_CHAIN_DATA_OUTPUT_FILE_TYPE_ODV                 , "type of output file for raw chain "                         );
-  m_parser->registerOption<bool        >(m_option_rawChain_dataOutputAllowAll,                UQ_MH_SG_RAW_CHAIN_DATA_OUTPUT_ALLOW_ALL_ODV                 , "allow all subEnvs to write raw chain to an output file"     );
-  m_parser->registerOption<std::string >(m_option_rawChain_dataOutputAllowedSet,              UQ_MH_SG_RAW_CHAIN_DATA_OUTPUT_ALLOWED_SET_ODV               , "subEnvs that will write raw chain to output file"           );
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-  m_parser->registerOption<bool        >(m_option_rawChain_computeStats,                      UQ_MH_SG_RAW_CHAIN_COMPUTE_STATS_ODV                         , "compute statistics on raw chain"                            );
-#endif
-  m_parser->registerOption<bool        >(m_option_filteredChain_generate,                     UQ_MH_SG_FILTERED_CHAIN_GENERATE_ODV                         , "generate filtered chain"                                    );
-  m_parser->registerOption<double      >(m_option_filteredChain_discardedPortion,             UQ_MH_SG_FILTERED_CHAIN_DISCARDED_PORTION_ODV                , "initial discarded portion for chain filtering"              );
-  m_parser->registerOption<unsigned int>(m_option_filteredChain_lag,                          UQ_MH_SG_FILTERED_CHAIN_LAG_ODV                              , "spacing for chain filtering"                                );
-  m_parser->registerOption<std::string >(m_option_filteredChain_dataOutputFileName,           UQ_MH_SG_FILTERED_CHAIN_DATA_OUTPUT_FILE_NAME_ODV            , "name of output file for filtered chain"                     );
-  m_parser->registerOption<std::string >(m_option_filteredChain_dataOutputFileType,           UQ_MH_SG_FILTERED_CHAIN_DATA_OUTPUT_FILE_TYPE_ODV            , "type of output file for filtered chain"                     );
-  m_parser->registerOption<bool        >(m_option_filteredChain_dataOutputAllowAll,           UQ_MH_SG_FILTERED_CHAIN_DATA_OUTPUT_ALLOW_ALL_ODV            , "allow all subEnvs to write filt chain to an output file"    );
-  m_parser->registerOption<std::string >(m_option_filteredChain_dataOutputAllowedSet,         UQ_MH_SG_FILTERED_CHAIN_DATA_OUTPUT_ALLOWED_SET_ODV          , "subEnvs that will write filt chain to output file"          );
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-  m_parser->registerOption<bool        >(m_option_filteredChain_computeStats,                 UQ_MH_SG_FILTERED_CHAIN_COMPUTE_STATS_ODV                    , "compute statistics on filtered chain"                       );
-#endif
-  m_parser->registerOption<bool        >(m_option_displayCandidates,                          UQ_MH_SG_DISPLAY_CANDIDATES_ODV                              , "display candidates in the core MH algorithm"                );
-  m_parser->registerOption<bool        >(m_option_putOutOfBoundsInChain,                      UQ_MH_SG_PUT_OUT_OF_BOUNDS_IN_CHAIN_ODV                      , "put 'out of bound' candidates in chain as well"             );
-  m_parser->registerOption<bool        >(m_option_tk_useLocalHessian,                         UQ_MH_SG_TK_USE_LOCAL_HESSIAN_ODV                            , "'proposal' use local Hessian"                               );
-  m_parser->registerOption<bool        >(m_option_tk_useNewtonComponent,                      UQ_MH_SG_TK_USE_NEWTON_COMPONENT_ODV                         , "'proposal' use Newton component"                            );
-  m_parser->registerOption<unsigned int>(m_option_dr_maxNumExtraStages,                       UQ_MH_SG_DR_MAX_NUM_EXTRA_STAGES_ODV                         , "'dr' maximum number of extra stages"                        );
-  m_parser->registerOption<std::string >(m_option_dr_listOfScalesForExtraStages,              UQ_MH_SG_DR_LIST_OF_SCALES_FOR_EXTRA_STAGES_ODV              , "'dr' scales for prop cov matrices from 2nd stage on"        );
-  m_parser->registerOption<bool        >(m_option_dr_duringAmNonAdaptiveInt,                  UQ_MH_SG_DR_DURING_AM_NON_ADAPTIVE_INT_ODV                   , "'dr' used during 'am' non adaptive interval"                );
-  m_parser->registerOption<bool        >(m_option_am_keepInitialMatrix,                       UQ_MH_SG_AM_KEEP_INITIAL_MATRIX_ODV                          , "'am' keep initial (given) matrix"                           );
-  m_parser->registerOption<unsigned int>(m_option_am_initialNonAdaptInterval,                 UQ_MH_SG_AM_INIT_NON_ADAPT_INT_ODV                           , "'am' initial non adaptation interval"                       );
-  m_parser->registerOption<unsigned int>(m_option_am_adaptInterval,                           UQ_MH_SG_AM_ADAPT_INTERVAL_ODV                               , "'am' adaptation interval"                                   );
-  m_parser->registerOption<unsigned int>(m_option_am_adaptedMatrices_dataOutputPeriod,        UQ_MH_SG_AM_ADAPTED_MATRICES_DATA_OUTPUT_PERIOD_ODV          , "period for outputting 'am' adapted matrices"                );
-  m_parser->registerOption<std::string >(m_option_am_adaptedMatrices_dataOutputFileName,      UQ_MH_SG_AM_ADAPTED_MATRICES_DATA_OUTPUT_FILE_NAME_ODV       , "name of output file for 'am' adapted matrices"              );
-  m_parser->registerOption<std::string >(m_option_am_adaptedMatrices_dataOutputFileType,      UQ_MH_SG_AM_ADAPTED_MATRICES_DATA_OUTPUT_FILE_TYPE_ODV       , "type of output file for 'am' adapted matrices"              );
-  m_parser->registerOption<bool        >(m_option_am_adaptedMatrices_dataOutputAllowAll,      UQ_MH_SG_AM_ADAPTED_MATRICES_DATA_OUTPUT_ALLOW_ALL_ODV       , "type of output file for 'am' adapted matrices"              );
-  m_parser->registerOption<std::string >(m_option_am_adaptedMatrices_dataOutputAllowedSet,    UQ_MH_SG_AM_ADAPTED_MATRICES_DATA_OUTPUT_ALLOWED_SET_ODV     , "type of output file for 'am' adapted matrices"              );
-  m_parser->registerOption<double      >(m_option_am_eta,                                     UQ_MH_SG_AM_ETA_ODV                                          , "'am' eta"                                                   );
-  m_parser->registerOption<double      >(m_option_am_epsilon,                                 UQ_MH_SG_AM_EPSILON_ODV                                      , "'am' epsilon"                                               );
-  m_parser->registerOption<unsigned int>(m_option_enableBrooksGelmanConvMonitor,              UQ_MH_SG_ENABLE_BROOKS_GELMAN_CONV_MONITOR                   , "assess convergence using Brooks-Gelman metric"              );
-  m_parser->registerOption<unsigned int>(m_option_BrooksGelmanLag,                            UQ_MH_SG_BROOKS_GELMAN_LAG                                   , "number of chain positions before starting to compute metric");
-  m_parser->registerOption<bool        >(m_option_outputLogLikelihood,                        UQ_MH_SG_OUTPUT_LOG_LIKELIHOOD                               , "flag to toggle output of log likelihood values"             );
-  m_parser->registerOption<bool        >(m_option_outputLogTarget,                            UQ_MH_SG_OUTPUT_LOG_TARGET                                   , "flag to toggle output of log target values"                 );
-  m_parser->registerOption<bool        >(m_option_doLogitTransform,                           UQ_MH_SG_DO_LOGIT_TRANSFORM                                  , "flag to toggle logit transform for bounded domains"         );
-  m_parser->registerOption<std::string >(m_option_algorithm,                                  UQ_MH_SG_ALGORITHM                                           , "which MCMC algorithm to use"                                );
-  m_parser->registerOption<std::string >(m_option_tk,                                         UQ_MH_SG_TK                                                  , "which MCMC transition kernel to use"                        );
-  m_parser->registerOption<unsigned int>(m_option_updateInterval,                             UQ_MH_SG_UPDATE_INTERVAL                                     , "how often to call updateTK method"                          );
-
-  m_parser->scanInputFile();
-
-  m_parser->getOption<std::string >(m_option_help,                                       m_help);
-  m_parser->getOption<std::string >(m_option_dataOutputFileName,                         m_dataOutputFileName);
-  m_parser->getOption<bool        >(m_option_dataOutputAllowAll,                         m_dataOutputAllowAll);
-  m_parser->getOption<std::set<unsigned int> >(m_option_dataOutputAllowedSet,                       m_dataOutputAllowedSet);
-  m_parser->getOption<bool        >(m_option_totallyMute,                                m_totallyMute);
-  m_parser->getOption<std::string >(m_option_initialPosition_dataInputFileName,          m_initialPositionDataInputFileName);
-  m_parser->getOption<std::string >(m_option_initialPosition_dataInputFileType,          m_initialPositionDataInputFileType);
-  m_parser->getOption<std::string >(m_option_initialProposalCovMatrix_dataInputFileName, m_initialProposalCovMatrixDataInputFileName);
-  m_parser->getOption<std::string >(m_option_initialProposalCovMatrix_dataInputFileType, m_initialProposalCovMatrixDataInputFileType);
-  m_parser->getOption<std::set<unsigned int> >(m_option_listOfDisabledParameters,                   m_parameterDisabledSet);
-  m_parser->getOption<std::string >(m_option_rawChain_dataInputFileName,                 m_rawChainDataInputFileName);
-  m_parser->getOption<std::string >(m_option_rawChain_dataInputFileType,                 m_rawChainDataInputFileType);
-  m_parser->getOption<unsigned int>(m_option_rawChain_size,                              m_rawChainSize);
-  m_parser->getOption<bool        >(m_option_rawChain_generateExtra,                     m_rawChainGenerateExtra);
-  m_parser->getOption<unsigned int>(m_option_rawChain_displayPeriod,                     m_rawChainDisplayPeriod);
-  m_parser->getOption<bool        >(m_option_rawChain_measureRunTimes,                   m_rawChainMeasureRunTimes);
-  m_parser->getOption<unsigned int>(m_option_rawChain_dataOutputPeriod,                  m_rawChainDataOutputPeriod);
-  m_parser->getOption<std::string >(m_option_rawChain_dataOutputFileName,                m_rawChainDataOutputFileName);
-  m_parser->getOption<std::string >(m_option_rawChain_dataOutputFileType,                m_rawChainDataOutputFileType);
-  m_parser->getOption<bool        >(m_option_rawChain_dataOutputAllowAll,                m_rawChainDataOutputAllowAll);
-  m_parser->getOption<std::set<unsigned int> >(m_option_rawChain_dataOutputAllowedSet,              m_rawChainDataOutputAllowedSet);
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-  m_parser->getOption<bool        >(m_option_rawChain_computeStats,                      m_rawChain_computeStats);
-#endif
-  m_parser->getOption<bool        >(m_option_filteredChain_generate,                     m_filteredChainGenerate);
-  m_parser->getOption<double      >(m_option_filteredChain_discardedPortion,             m_filteredChainDiscardedPortion);
-  m_parser->getOption<unsigned int>(m_option_filteredChain_lag,                          m_filteredChainLag);
-  m_parser->getOption<std::string >(m_option_filteredChain_dataOutputFileName,           m_filteredChainDataOutputFileName);
-  m_parser->getOption<std::string >(m_option_filteredChain_dataOutputFileType,           m_filteredChainDataOutputFileType);
-  m_parser->getOption<bool        >(m_option_filteredChain_dataOutputAllowAll,           m_filteredChainDataOutputAllowAll);
-  m_parser->getOption<std::set<unsigned int> >(m_option_filteredChain_dataOutputAllowedSet,         m_filteredChainDataOutputAllowedSet);
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-  m_parser->getOption<bool        >(m_option_filteredChain_computeStats,                 m_filteredChain_computeStats);
-#endif
-  m_parser->getOption<bool        >(m_option_displayCandidates,                          m_displayCandidates);
-  m_parser->getOption<bool        >(m_option_putOutOfBoundsInChain,                      m_putOutOfBoundsInChain);
-  m_parser->getOption<bool        >(m_option_tk_useLocalHessian,                         m_tkUseLocalHessian);
-  m_parser->getOption<bool        >(m_option_tk_useNewtonComponent,                      m_tkUseNewtonComponent);
-  m_parser->getOption<unsigned int>(m_option_dr_maxNumExtraStages,                       m_drMaxNumExtraStages);
-  m_parser->getOption<std::vector<double> >(m_option_dr_listOfScalesForExtraStages,              m_drScalesForExtraStages);
-  m_parser->getOption<bool        >(m_option_dr_duringAmNonAdaptiveInt,                  m_drDuringAmNonAdaptiveInt);
-  m_parser->getOption<bool        >(m_option_am_keepInitialMatrix,                       m_amKeepInitialMatrix);
-  m_parser->getOption<unsigned int>(m_option_am_initialNonAdaptInterval,                 m_amInitialNonAdaptInterval);
-  m_parser->getOption<unsigned int>(m_option_am_adaptInterval,                           m_amAdaptInterval);
-  m_parser->getOption<unsigned int>(m_option_am_adaptedMatrices_dataOutputPeriod,        m_amAdaptedMatricesDataOutputPeriod);
-  m_parser->getOption<std::string >(m_option_am_adaptedMatrices_dataOutputFileName,      m_amAdaptedMatricesDataOutputFileName);
-  m_parser->getOption<std::string >(m_option_am_adaptedMatrices_dataOutputFileType,      m_amAdaptedMatricesDataOutputFileType);
-  m_parser->getOption<bool        >(m_option_am_adaptedMatrices_dataOutputAllowAll,      m_amAdaptedMatricesDataOutputAllowAll);
-  m_parser->getOption<std::set<unsigned int> >(m_option_am_adaptedMatrices_dataOutputAllowedSet,    m_amAdaptedMatricesDataOutputAllowedSet);
-  m_parser->getOption<double      >(m_option_am_eta,                                     m_amEta);
-  m_parser->getOption<double      >(m_option_am_epsilon,                                 m_amEpsilon);
-  m_parser->getOption<unsigned int>(m_option_enableBrooksGelmanConvMonitor,              m_enableBrooksGelmanConvMonitor);
-  m_parser->getOption<unsigned int>(m_option_BrooksGelmanLag,                            m_BrooksGelmanLag);
-  m_parser->getOption<bool        >(m_option_outputLogLikelihood,                        m_outputLogLikelihood);
-  m_parser->getOption<bool        >(m_option_outputLogTarget,                            m_outputLogTarget);
-  m_parser->getOption<bool        >(m_option_doLogitTransform,                           m_doLogitTransform);
-  m_parser->getOption<std::string >(m_option_algorithm,                                  m_algorithm);
-  m_parser->getOption<std::string >(m_option_tk,                                         m_tk);
-  m_parser->getOption<unsigned int>(m_option_updateInterval,                             m_updateInterval);
-#else
-  m_help = m_env->input()(m_option_help, UQ_MH_SG_HELP);
-  m_dataOutputFileName = m_env->input()(m_option_dataOutputFileName, UQ_MH_SG_DATA_OUTPUT_FILE_NAME_ODV);
-  m_dataOutputAllowAll = m_env->input()(m_option_dataOutputAllowAll, UQ_MH_SG_DATA_OUTPUT_ALLOW_ALL_ODV);
-
-  // UQ_MH_SG_DATA_OUTPUT_ALLOWED_SET_ODV is the empty set (string) by default
-  unsigned int size = m_env->input().vector_variable_size(m_option_dataOutputAllowedSet);
-  for (unsigned int i = 0; i < size; i++) {
-    // We default to empty set, so the default values are actually never used
-    // here
-    unsigned int allowed = m_env->input()(m_option_dataOutputAllowedSet, i, i);
-    m_dataOutputAllowedSet.insert(allowed);
-  }
-
-  m_totallyMute = m_env->input()(m_option_totallyMute, UQ_MH_SG_TOTALLY_MUTE_ODV);
-  m_initialPositionDataInputFileName = m_env->input()(m_option_initialPosition_dataInputFileName, UQ_MH_SG_INITIAL_POSITION_DATA_INPUT_FILE_NAME_ODV);
-  m_initialPositionDataInputFileType = m_env->input()(m_option_initialPosition_dataInputFileType, UQ_MH_SG_INITIAL_POSITION_DATA_INPUT_FILE_TYPE_ODV);
-  m_initialProposalCovMatrixDataInputFileName = m_env->input()(m_option_initialProposalCovMatrix_dataInputFileName, UQ_MH_SG_INITIAL_PROPOSAL_COV_MATRIX_DATA_INPUT_FILE_NAME_ODV);
-  m_initialProposalCovMatrixDataInputFileType = m_env->input()(m_option_initialProposalCovMatrix_dataInputFileType, UQ_MH_SG_INITIAL_PROPOSAL_COV_MATRIX_DATA_INPUT_FILE_TYPE_ODV);
-
-  // UQ_MH_SG_LIST_OF_DISABLED_PARAMETERS_ODV is the empty set (string) by
-  // default
-  size = m_env->input().vector_variable_size(m_option_listOfDisabledParameters);
-  for (unsigned int i = 0; i < size; i++) {
-    // We default to empty set, so the default values are actually never used
-    // here
-    unsigned int disabled = m_env->input()(m_option_listOfDisabledParameters, i, i);
-    m_parameterDisabledSet.insert(disabled);
-  }
-
-  m_rawChainDataInputFileName = m_env->input()(m_option_rawChain_dataInputFileName, UQ_MH_SG_RAW_CHAIN_DATA_INPUT_FILE_NAME_ODV);
-  m_rawChainDataInputFileType = m_env->input()(m_option_rawChain_dataInputFileType, UQ_MH_SG_RAW_CHAIN_DATA_INPUT_FILE_TYPE_ODV);
-  m_rawChainSize = m_env->input()(m_option_rawChain_size, UQ_MH_SG_RAW_CHAIN_SIZE_ODV);
-  m_rawChainGenerateExtra = m_env->input()(m_option_rawChain_generateExtra, UQ_MH_SG_RAW_CHAIN_GENERATE_EXTRA_ODV);
-  m_rawChainDisplayPeriod = m_env->input()(m_option_rawChain_displayPeriod, UQ_MH_SG_RAW_CHAIN_DISPLAY_PERIOD_ODV);
-  m_rawChainMeasureRunTimes = m_env->input()(m_option_rawChain_measureRunTimes, UQ_MH_SG_RAW_CHAIN_MEASURE_RUN_TIMES_ODV);
-  m_rawChainDataOutputPeriod = m_env->input()(m_option_rawChain_dataOutputPeriod, UQ_MH_SG_RAW_CHAIN_DATA_OUTPUT_PERIOD_ODV);
-  m_rawChainDataOutputFileName = m_env->input()(m_option_rawChain_dataOutputFileName, UQ_MH_SG_RAW_CHAIN_DATA_OUTPUT_FILE_NAME_ODV);
-  m_rawChainDataOutputFileType = m_env->input()(m_option_rawChain_dataOutputFileType, UQ_MH_SG_RAW_CHAIN_DATA_OUTPUT_FILE_TYPE_ODV);
-  m_rawChainDataOutputAllowAll = m_env->input()(m_option_rawChain_dataOutputAllowAll, UQ_MH_SG_RAW_CHAIN_DATA_OUTPUT_ALLOW_ALL_ODV);
-
-  // UQ_MH_SG_RAW_CHAIN_DATA_OUTPUT_ALLOWED_SET_ODV is the empty set (string) by default
-  size = m_env->input().vector_variable_size(m_option_rawChain_dataOutputAllowedSet);
-  for (unsigned int i = 0; i < size; i++) {
-    // We default to empty set, so the default values are actually never used
-    // here
-    unsigned int allowed = m_env->input()(m_option_rawChain_dataOutputAllowedSet, i, i);
-    m_rawChainDataOutputAllowedSet.insert(allowed);
-  }
-
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-  m_rawChain_computeStats = m_env->input()(m_option_rawChain_computeStats, UQ_MH_SG_RAW_CHAIN_COMPUTE_STATS_ODV);
-#endif
-  m_filteredChainGenerate = m_env->input()(m_option_filteredChain_generate, UQ_MH_SG_FILTERED_CHAIN_GENERATE_ODV);
-  m_filteredChainDiscardedPortion = m_env->input()(m_option_filteredChain_discardedPortion, UQ_MH_SG_FILTERED_CHAIN_DISCARDED_PORTION_ODV);
-  m_filteredChainLag = m_env->input()(m_option_filteredChain_lag, UQ_MH_SG_FILTERED_CHAIN_LAG_ODV);
-  m_filteredChainDataOutputFileName = m_env->input()(m_option_filteredChain_dataOutputFileName, UQ_MH_SG_FILTERED_CHAIN_DATA_OUTPUT_FILE_NAME_ODV);
-  m_filteredChainDataOutputFileType = m_env->input()(m_option_filteredChain_dataOutputFileType, UQ_MH_SG_FILTERED_CHAIN_DATA_OUTPUT_FILE_TYPE_ODV);
-  m_filteredChainDataOutputAllowAll = m_env->input()(m_option_filteredChain_dataOutputAllowAll, UQ_MH_SG_FILTERED_CHAIN_DATA_OUTPUT_ALLOW_ALL_ODV);
-
-  // UQ_MH_SG_FILTERED_CHAIN_DATA_OUTPUT_ALLOWED_SET_ODV is the empty set (string) by default
-  size = m_env->input().vector_variable_size(m_option_filteredChain_dataOutputAllowedSet);
-  for (unsigned int i = 0; i < size; i++) {
-    // We default to empty set, so the default values are actually never used
-    // here
-    unsigned int allowed = m_env->input()(m_option_filteredChain_dataOutputAllowedSet, i, i);
-    m_filteredChainDataOutputAllowedSet.insert(allowed);
-  }
-
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-  m_filteredChain_computeStats = m_env->input()(m_option_filteredChain_computeStats, UQ_MH_SG_FILTERED_CHAIN_COMPUTE_STATS_ODV);
-#endif
-  m_displayCandidates = m_env->input()(m_option_displayCandidates, UQ_MH_SG_DISPLAY_CANDIDATES_ODV);
-  m_putOutOfBoundsInChain = m_env->input()(m_option_putOutOfBoundsInChain, UQ_MH_SG_PUT_OUT_OF_BOUNDS_IN_CHAIN_ODV);
-  m_tkUseLocalHessian = m_env->input()(m_option_tk_useLocalHessian, UQ_MH_SG_TK_USE_LOCAL_HESSIAN_ODV);
-  m_tkUseNewtonComponent = m_env->input()(m_option_tk_useNewtonComponent, UQ_MH_SG_TK_USE_NEWTON_COMPONENT_ODV);
-  m_drMaxNumExtraStages = m_env->input()(m_option_dr_maxNumExtraStages, UQ_MH_SG_DR_MAX_NUM_EXTRA_STAGES_ODV);
-
-  // UQ_MH_SG_DR_LIST_OF_SCALES_FOR_EXTRA_STAGES_ODV is the empty set (string) by default
-  size = m_env->input().vector_variable_size(m_option_dr_listOfScalesForExtraStages);
-  for (unsigned int i = 0; i < size; i++) {
-    // We default to empty set, so the default values are actually never used
-    // here
-    unsigned int allowed = m_env->input()(m_option_dr_listOfScalesForExtraStages, i, i);
-    m_drScalesForExtraStages.push_back(allowed);
-  }
-
-  m_drDuringAmNonAdaptiveInt = m_env->input()(m_option_dr_duringAmNonAdaptiveInt, UQ_MH_SG_DR_DURING_AM_NON_ADAPTIVE_INT_ODV);
-  m_amKeepInitialMatrix = m_env->input()(m_option_am_keepInitialMatrix, UQ_MH_SG_AM_KEEP_INITIAL_MATRIX_ODV);
-  m_amInitialNonAdaptInterval = m_env->input()(m_option_am_initialNonAdaptInterval, UQ_MH_SG_AM_INIT_NON_ADAPT_INT_ODV);
-  m_amAdaptInterval = m_env->input()(m_option_am_adaptInterval, UQ_MH_SG_AM_ADAPT_INTERVAL_ODV);
-  m_amAdaptedMatricesDataOutputPeriod = m_env->input()(m_option_am_adaptedMatrices_dataOutputPeriod, UQ_MH_SG_AM_ADAPTED_MATRICES_DATA_OUTPUT_PERIOD_ODV);
-  m_amAdaptedMatricesDataOutputFileName = m_env->input()(m_option_am_adaptedMatrices_dataOutputFileName, UQ_MH_SG_AM_ADAPTED_MATRICES_DATA_OUTPUT_FILE_NAME_ODV);
-  m_amAdaptedMatricesDataOutputFileType = m_env->input()(m_option_am_adaptedMatrices_dataOutputFileType, UQ_MH_SG_AM_ADAPTED_MATRICES_DATA_OUTPUT_FILE_TYPE_ODV);
-  m_amAdaptedMatricesDataOutputAllowAll = m_env->input()(m_option_am_adaptedMatrices_dataOutputAllowAll, UQ_MH_SG_AM_ADAPTED_MATRICES_DATA_OUTPUT_ALLOW_ALL_ODV);
-
-  // UQ_MH_SG_AM_ADAPTED_MATRICES_DATA_OUTPUT_ALLOWED_SET_ODV is the empty set (string) by default
-  size = m_env->input().vector_variable_size(m_option_am_adaptedMatrices_dataOutputAllowedSet);
-  for (unsigned int i = 0; i < size; i++) {
-    // We default to empty set, so the default values are actually never used
-    // here
-    unsigned int allowed = m_env->input()(m_option_am_adaptedMatrices_dataOutputAllowedSet, i, i);
-    m_amAdaptedMatricesDataOutputAllowedSet.insert(allowed);
-  }
-
-  m_amEta = m_env->input()(m_option_am_eta, UQ_MH_SG_AM_ETA_ODV);
-  m_amEpsilon = m_env->input()(m_option_am_epsilon, UQ_MH_SG_AM_EPSILON_ODV);
-  m_enableBrooksGelmanConvMonitor = m_env->input()(m_option_enableBrooksGelmanConvMonitor, UQ_MH_SG_ENABLE_BROOKS_GELMAN_CONV_MONITOR);
-  m_BrooksGelmanLag = m_env->input()(m_option_BrooksGelmanLag, UQ_MH_SG_BROOKS_GELMAN_LAG);
-  m_outputLogLikelihood = m_env->input()(m_option_outputLogLikelihood, UQ_MH_SG_OUTPUT_LOG_LIKELIHOOD);
-  m_outputLogTarget = m_env->input()(m_option_outputLogTarget, UQ_MH_SG_OUTPUT_LOG_TARGET);
-  m_doLogitTransform = m_env->input()(m_option_doLogitTransform, UQ_MH_SG_DO_LOGIT_TRANSFORM);
-  m_algorithm = m_env->input()(m_option_algorithm, UQ_MH_SG_ALGORITHM);
-  m_tk = m_env->input()(m_option_tk, UQ_MH_SG_TK);
-  m_updateInterval = m_env->input()(m_option_updateInterval, UQ_MH_SG_UPDATE_INTERVAL);
-#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-
-  checkOptions(env);
+  this->set_defaults();
+  this->parse(*env, prefix);
 }
+
 // Copy constructor----------------------------------
 MhOptionsValues::MhOptionsValues(const MhOptionsValues& src)
 {
@@ -725,18 +237,18 @@ MhOptionsValues::operator=(const MhOptionsValues& rhs)
 }
 // Private methods-----------------------------------
 void
-MhOptionsValues::checkOptions(const BaseEnvironment * env)
+MhOptionsValues::checkOptions()
 {
   if (m_dataOutputAllowAll) {
     // So, ignore the 'set' option
     m_dataOutputAllowedSet.clear();
-    m_dataOutputAllowedSet.insert(env->subId());
+    m_dataOutputAllowedSet.insert(m_env->subId());
   }
 
   if (m_rawChainDataOutputAllowAll) {
     // Again, ignore the set
     m_rawChainDataOutputAllowedSet.clear();
-    m_rawChainDataOutputAllowedSet.insert(env->subId());
+    m_rawChainDataOutputAllowedSet.insert(m_env->subId());
   }
 
   if (m_filteredChainGenerate == true) {
@@ -745,7 +257,7 @@ MhOptionsValues::checkOptions(const BaseEnvironment * env)
 
   if (m_filteredChainDataOutputAllowAll) {
     m_filteredChainDataOutputAllowedSet.clear();
-    m_filteredChainDataOutputAllowedSet.insert(env->subId());
+    m_filteredChainDataOutputAllowedSet.insert(m_env->subId());
   }
 
   // If max is bigger than the list provided, then pad with ones
@@ -764,7 +276,7 @@ MhOptionsValues::checkOptions(const BaseEnvironment * env)
 
   if (m_amAdaptedMatricesDataOutputAllowAll) {
     m_amAdaptedMatricesDataOutputAllowedSet.clear();
-    m_amAdaptedMatricesDataOutputAllowedSet.insert(env->subId());
+    m_amAdaptedMatricesDataOutputAllowedSet.insert(m_env->subId());
   }
 
   if ((m_tk == "random_walk") && (m_algorithm == "logit_random_walk")) {
@@ -972,5 +484,386 @@ std::ostream & operator<<(std::ostream & os, const MhOptionsValues & obj)
   return os;
 }
 
+
+void MhOptionsValues::set_prefix(const std::string& prefix)
+{
+  m_prefix = prefix + "mh_";
+
+  m_option_help = m_prefix + "help";
+  m_option_dataOutputFileName = m_prefix + "dataOutputFileName";
+  m_option_dataOutputAllowAll = m_prefix + "dataOutputAllowAll";
+  m_option_dataOutputAllowedSet = m_prefix + "dataOutputAllowedSet";
+  m_option_totallyMute = m_prefix + "totallyMute";
+  m_option_initialPosition_dataInputFileName = m_prefix + "initialPosition_dataInputFileName";
+  m_option_initialPosition_dataInputFileType = m_prefix + "initialPosition_dataInputFileType";
+  m_option_initialProposalCovMatrix_dataInputFileName = m_prefix + "initialProposalCovMatrix_dataInputFileName";
+  m_option_initialProposalCovMatrix_dataInputFileType = m_prefix + "initialProposalCovMatrix_dataInputFileType";
+  m_option_listOfDisabledParameters = m_prefix + "listOfDisabledParameters";
+  m_option_rawChain_dataInputFileName = m_prefix + "rawChain_dataInputFileName";
+  m_option_rawChain_dataInputFileType = m_prefix + "rawChain_dataInputFileType";
+  m_option_rawChain_size = m_prefix + "rawChain_size";
+  m_option_rawChain_generateExtra = m_prefix + "rawChain_generateExtra";
+  m_option_rawChain_displayPeriod = m_prefix + "rawChain_displayPeriod";
+  m_option_rawChain_measureRunTimes = m_prefix + "rawChain_measureRunTimes";
+  m_option_rawChain_dataOutputPeriod = m_prefix + "rawChain_dataOutputPeriod";
+  m_option_rawChain_dataOutputFileName = m_prefix + "rawChain_dataOutputFileName";
+  m_option_rawChain_dataOutputFileType = m_prefix + "rawChain_dataOutputFileType";
+  m_option_rawChain_dataOutputAllowAll = m_prefix + "rawChain_dataOutputAllowAll";
+  m_option_rawChain_dataOutputAllowedSet = m_prefix + "rawChain_dataOutputAllowedSet";
+#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  m_option_rawChain_computeStats = m_prefix + "rawChain_computeStats";
+#endif
+  m_option_filteredChain_generate = m_prefix + "filteredChain_generate";
+  m_option_filteredChain_discardedPortion = m_prefix + "filteredChain_discardedPortion";
+  m_option_filteredChain_lag = m_prefix + "filteredChain_lag";
+  m_option_filteredChain_dataOutputFileName = m_prefix + "filteredChain_dataOutputFileName";
+  m_option_filteredChain_dataOutputFileType = m_prefix + "filteredChain_dataOutputFileType";
+  m_option_filteredChain_dataOutputAllowAll = m_prefix + "filteredChain_dataOutputAllowAll";
+  m_option_filteredChain_dataOutputAllowedSet = m_prefix + "filteredChain_dataOutputAllowedSet";
+#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  m_option_filteredChain_computeStats = m_prefix + "filteredChain_computeStats";
+#endif
+  m_option_displayCandidates = m_prefix + "displayCandidates";
+  m_option_putOutOfBoundsInChain = m_prefix + "putOutOfBoundsInChain";
+  m_option_tk_useLocalHessian = m_prefix + "tk_useLocalHessian";
+  m_option_tk_useNewtonComponent = m_prefix + "tk_useNewtonComponent";
+  m_option_dr_maxNumExtraStages = m_prefix + "dr_maxNumExtraStages";
+  m_option_dr_listOfScalesForExtraStages = m_prefix + "dr_listOfScalesForExtraStages";
+  m_option_dr_duringAmNonAdaptiveInt = m_prefix + "dr_duringAmNonAdaptiveInt";
+  m_option_am_keepInitialMatrix = m_prefix + "am_keepInitialMatrix";
+  m_option_am_initialNonAdaptInterval = m_prefix + "am_initialNonAdaptInterval";
+  m_option_am_adaptInterval = m_prefix + "am_adaptInterval";
+  m_option_am_adaptedMatrices_dataOutputPeriod = m_prefix + "am_adaptedMatrices_dataOutputPeriod";
+  m_option_am_adaptedMatrices_dataOutputFileName = m_prefix + "am_adaptedMatrices_dataOutputFileName";
+  m_option_am_adaptedMatrices_dataOutputFileType = m_prefix + "am_adaptedMatrices_dataOutputFileType";
+  m_option_am_adaptedMatrices_dataOutputAllowAll = m_prefix + "am_adaptedMatrices_dataOutputAllowAll";
+  m_option_am_adaptedMatrices_dataOutputAllowedSet = m_prefix + "am_adaptedMatrices_dataOutputAllowedSet";
+  m_option_am_eta = m_prefix + "am_eta";
+  m_option_am_epsilon = m_prefix + "am_epsilon";
+  m_option_enableBrooksGelmanConvMonitor = m_prefix + "enableBrooksGelmanConvMonitor";
+  m_option_BrooksGelmanLag = m_prefix + "BrooksGelmanLag";
+  m_option_outputLogLikelihood = m_prefix + "outputLogLikelihood";
+  m_option_outputLogTarget = m_prefix + "outputLogTarget";
+  m_option_doLogitTransform = m_prefix + "doLogitTransform";
+  m_option_algorithm = m_prefix + "algorithm";
+  m_option_tk = m_prefix + "tk";
+  m_option_updateInterval = m_prefix + "updateInterval";
+}
+
+
+void MhOptionsValues::set_defaults()
+{
+    m_help = UQ_MH_SG_HELP;
+    m_dataOutputFileName = UQ_MH_SG_DATA_OUTPUT_FILE_NAME_ODV;
+    m_dataOutputAllowAll = UQ_MH_SG_DATA_OUTPUT_ALLOW_ALL_ODV;
+  //m_dataOutputAllowedSet                     (),
+    m_totallyMute = UQ_MH_SG_TOTALLY_MUTE_ODV;
+    m_initialPositionDataInputFileName = UQ_MH_SG_INITIAL_POSITION_DATA_INPUT_FILE_NAME_ODV;
+    m_initialPositionDataInputFileType = UQ_MH_SG_INITIAL_POSITION_DATA_INPUT_FILE_TYPE_ODV;
+    m_initialProposalCovMatrixDataInputFileName = UQ_MH_SG_INITIAL_PROPOSAL_COV_MATRIX_DATA_INPUT_FILE_NAME_ODV;
+    m_initialProposalCovMatrixDataInputFileType = UQ_MH_SG_INITIAL_PROPOSAL_COV_MATRIX_DATA_INPUT_FILE_TYPE_ODV;
+  //m_parameterDisabledSet                     (),
+    m_rawChainDataInputFileName = UQ_MH_SG_RAW_CHAIN_DATA_INPUT_FILE_NAME_ODV;
+    m_rawChainDataInputFileType = UQ_MH_SG_RAW_CHAIN_DATA_INPUT_FILE_TYPE_ODV;
+    m_rawChainSize = UQ_MH_SG_RAW_CHAIN_SIZE_ODV;
+    m_rawChainGenerateExtra = UQ_MH_SG_RAW_CHAIN_GENERATE_EXTRA_ODV;
+    m_rawChainDisplayPeriod = UQ_MH_SG_RAW_CHAIN_DISPLAY_PERIOD_ODV;
+    m_rawChainMeasureRunTimes = UQ_MH_SG_RAW_CHAIN_MEASURE_RUN_TIMES_ODV;
+    m_rawChainDataOutputPeriod = UQ_MH_SG_RAW_CHAIN_DATA_OUTPUT_PERIOD_ODV;
+    m_rawChainDataOutputFileName = UQ_MH_SG_RAW_CHAIN_DATA_OUTPUT_FILE_NAME_ODV;
+    m_rawChainDataOutputFileType = UQ_MH_SG_RAW_CHAIN_DATA_OUTPUT_FILE_TYPE_ODV;
+    m_rawChainDataOutputAllowAll = UQ_MH_SG_RAW_CHAIN_DATA_OUTPUT_ALLOW_ALL_ODV;
+  //m_rawChainDataOutputAllowedSet             (),
+#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+    m_rawChainComputeStats = UQ_MH_SG_RAW_CHAIN_COMPUTE_STATS_ODV;
+#endif
+    m_filteredChainGenerate = UQ_MH_SG_FILTERED_CHAIN_GENERATE_ODV;
+    m_filteredChainDiscardedPortion = UQ_MH_SG_FILTERED_CHAIN_DISCARDED_PORTION_ODV;
+    m_filteredChainLag = UQ_MH_SG_FILTERED_CHAIN_LAG_ODV;
+    m_filteredChainDataOutputFileName = UQ_MH_SG_FILTERED_CHAIN_DATA_OUTPUT_FILE_NAME_ODV;
+    m_filteredChainDataOutputFileType = UQ_MH_SG_FILTERED_CHAIN_DATA_OUTPUT_FILE_TYPE_ODV;
+    m_filteredChainDataOutputAllowAll = UQ_MH_SG_FILTERED_CHAIN_DATA_OUTPUT_ALLOW_ALL_ODV;
+  //m_filteredChainDataOutputAllowedSet        (),
+#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+    m_filteredChainComputeStats = UQ_MH_SG_FILTERED_CHAIN_COMPUTE_STATS_ODV;
+#endif
+    m_displayCandidates = UQ_MH_SG_DISPLAY_CANDIDATES_ODV;
+    m_putOutOfBoundsInChain = UQ_MH_SG_PUT_OUT_OF_BOUNDS_IN_CHAIN_ODV;
+    m_tkUseLocalHessian = UQ_MH_SG_TK_USE_LOCAL_HESSIAN_ODV;
+    m_tkUseNewtonComponent = UQ_MH_SG_TK_USE_NEWTON_COMPONENT_ODV;
+    m_drMaxNumExtraStages = UQ_MH_SG_DR_MAX_NUM_EXTRA_STAGES_ODV;
+    m_drScalesForExtraStages.resize(0);
+    m_drDuringAmNonAdaptiveInt = UQ_MH_SG_DR_DURING_AM_NON_ADAPTIVE_INT_ODV;
+    m_amKeepInitialMatrix = UQ_MH_SG_AM_KEEP_INITIAL_MATRIX_ODV;
+    m_amInitialNonAdaptInterval = UQ_MH_SG_AM_INIT_NON_ADAPT_INT_ODV;
+    m_amAdaptInterval = UQ_MH_SG_AM_ADAPT_INTERVAL_ODV;
+    m_amAdaptedMatricesDataOutputPeriod = UQ_MH_SG_AM_ADAPTED_MATRICES_DATA_OUTPUT_PERIOD_ODV;
+    m_amAdaptedMatricesDataOutputFileName = UQ_MH_SG_AM_ADAPTED_MATRICES_DATA_OUTPUT_FILE_NAME_ODV;
+    m_amAdaptedMatricesDataOutputFileType = UQ_MH_SG_AM_ADAPTED_MATRICES_DATA_OUTPUT_FILE_TYPE_ODV;
+    m_amAdaptedMatricesDataOutputAllowAll = UQ_MH_SG_AM_ADAPTED_MATRICES_DATA_OUTPUT_ALLOW_ALL_ODV;
+  //m_amAdaptedMatricesDataOutputAllowedSet    (),
+    m_amEta = UQ_MH_SG_AM_ETA_ODV;
+    m_amEpsilon = UQ_MH_SG_AM_EPSILON_ODV;
+    m_enableBrooksGelmanConvMonitor = UQ_MH_SG_ENABLE_BROOKS_GELMAN_CONV_MONITOR;
+    m_BrooksGelmanLag = UQ_MH_SG_BROOKS_GELMAN_LAG;
+    m_outputLogLikelihood = UQ_MH_SG_OUTPUT_LOG_LIKELIHOOD;
+    m_outputLogTarget = UQ_MH_SG_OUTPUT_LOG_TARGET;
+    m_doLogitTransform = UQ_MH_SG_DO_LOGIT_TRANSFORM;
+    m_algorithm = UQ_MH_SG_ALGORITHM;
+    m_tk = UQ_MH_SG_TK;
+    m_updateInterval = UQ_MH_SG_UPDATE_INTERVAL;
+}
+
+void
+MhOptionsValues::parse(const BaseEnvironment& env, const std::string& prefix)
+{
+  m_env = &env;
+
+  this->set_prefix(prefix);
+
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+  m_parser.reset(new BoostInputOptionsParser(env.optionsInputFileName()));
+
+  m_parser->registerOption<std::string >(m_option_help,                                       m_help,                                       "produce help msg for Bayesian Metropolis-Hastings"          );
+  m_parser->registerOption<std::string >(m_option_dataOutputFileName,                         m_dataOutputFileName,                         "name of generic output file"                                );
+  m_parser->registerOption<bool        >(m_option_dataOutputAllowAll,                         m_dataOutputAllowAll,                         "allow all subEnvs write to a generic output file"           );
+  m_parser->registerOption<std::string >(m_option_dataOutputAllowedSet,                       container_to_string(m_dataOutputAllowedSet),  "subEnvs that will write to generic output file"             );
+  m_parser->registerOption<bool        >(m_option_totallyMute,                                m_totallyMute,                                "totally mute (no printout msg)"                             );
+  m_parser->registerOption<std::string >(m_option_initialPosition_dataInputFileName,          m_initialPositionDataInputFileName,          "name of input file for raw chain "                          );
+  m_parser->registerOption<std::string >(m_option_initialPosition_dataInputFileType,          m_initialPositionDataInputFileType,          "type of input file for raw chain "                          );
+  m_parser->registerOption<std::string >(m_option_initialProposalCovMatrix_dataInputFileName, m_initialProposalCovMatrixDataInputFileName, "name of input file for raw chain "                          );
+  m_parser->registerOption<std::string >(m_option_initialProposalCovMatrix_dataInputFileType, m_initialProposalCovMatrixDataInputFileType, "type of input file for raw chain "                          );
+  m_parser->registerOption<std::string >(m_option_listOfDisabledParameters,                   container_to_string(m_parameterDisabledSet), "list of disabled parameters"                                );
+  m_parser->registerOption<std::string >(m_option_rawChain_dataInputFileName,                 m_rawChainDataInputFileName,                 "name of input file for raw chain "                          );
+  m_parser->registerOption<std::string >(m_option_rawChain_dataInputFileType,                 m_rawChainDataInputFileType,                 "type of input file for raw chain "                          );
+  m_parser->registerOption<unsigned int>(m_option_rawChain_size,                              m_rawChainSize,                              "size of raw chain"                                          );
+  m_parser->registerOption<bool        >(m_option_rawChain_generateExtra,                     m_rawChainGenerateExtra,                     "generate extra information about raw chain"                 );
+  m_parser->registerOption<unsigned int>(m_option_rawChain_displayPeriod,                     m_rawChainDisplayPeriod,                     "period of msg display during raw chain generation"          );
+  m_parser->registerOption<bool        >(m_option_rawChain_measureRunTimes,                   m_rawChainMeasureRunTimes,                   "measure run times"                                          );
+  m_parser->registerOption<unsigned int>(m_option_rawChain_dataOutputPeriod,                  m_rawChainDataOutputPeriod,                  "period of msg display during raw chain generation"          );
+  m_parser->registerOption<std::string >(m_option_rawChain_dataOutputFileName,                m_rawChainDataOutputFileName,                "name of output file for raw chain "                         );
+  m_parser->registerOption<std::string >(m_option_rawChain_dataOutputFileType,                m_rawChainDataOutputFileType,                "type of output file for raw chain "                         );
+  m_parser->registerOption<bool        >(m_option_rawChain_dataOutputAllowAll,                m_rawChainDataOutputAllowAll,                "allow all subEnvs to write raw chain to an output file"     );
+  m_parser->registerOption<std::string >(m_option_rawChain_dataOutputAllowedSet,              container_to_string(m_rawChainDataOutputAllowedSet), "subEnvs that will write raw chain to output file"           );
+#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  m_parser->registerOption<bool        >(m_option_rawChain_computeStats,                      m_rawChain_computeStats,                      "compute statistics on raw chain"                            );
+#endif
+  m_parser->registerOption<bool        >(m_option_filteredChain_generate,                     m_filteredChainGenerate,                     "generate filtered chain"                                    );
+  m_parser->registerOption<double      >(m_option_filteredChain_discardedPortion,             m_filteredChainDiscardedPortion,             "initial discarded portion for chain filtering"              );
+  m_parser->registerOption<unsigned int>(m_option_filteredChain_lag,                          m_filteredChainLag,                          "spacing for chain filtering"                                );
+  m_parser->registerOption<std::string >(m_option_filteredChain_dataOutputFileName,           m_filteredChainDataOutputFileName,           "name of output file for filtered chain"                     );
+  m_parser->registerOption<std::string >(m_option_filteredChain_dataOutputFileType,           m_filteredChainDataOutputFileType,           "type of output file for filtered chain"                     );
+  m_parser->registerOption<bool        >(m_option_filteredChain_dataOutputAllowAll,           m_filteredChainDataOutputAllowAll,           "allow all subEnvs to write filt chain to an output file"    );
+  m_parser->registerOption<std::string >(m_option_filteredChain_dataOutputAllowedSet,         container_to_string(m_filteredChainDataOutputAllowedSet), "subEnvs that will write filt chain to output file"          );
+#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  m_parser->registerOption<bool        >(m_option_filteredChain_computeStats,                 m_filteredChainComputeStats,                 "compute statistics on filtered chain"                       );
+#endif
+  m_parser->registerOption<bool        >(m_option_displayCandidates,                          m_displayCandidates,                          "display candidates in the core MH algorithm"                );
+  m_parser->registerOption<bool        >(m_option_putOutOfBoundsInChain,                      m_putOutOfBoundsInChain,                      "put 'out of bound' candidates in chain as well"             );
+  m_parser->registerOption<bool        >(m_option_tk_useLocalHessian,                         m_tkUseLocalHessian,                         "'proposal' use local Hessian"                               );
+  m_parser->registerOption<bool        >(m_option_tk_useNewtonComponent,                      m_tkUseNewtonComponent,                      "'proposal' use Newton component"                            );
+  m_parser->registerOption<unsigned int>(m_option_dr_maxNumExtraStages,                       m_drMaxNumExtraStages,                       "'dr' maximum number of extra stages"                        );
+  m_parser->registerOption<std::string >(m_option_dr_listOfScalesForExtraStages,              container_to_string(m_drScalesForExtraStages), "'dr' scales for prop cov matrices from 2nd stage on"        );
+  m_parser->registerOption<bool        >(m_option_dr_duringAmNonAdaptiveInt,                  m_drDuringAmNonAdaptiveInt,                  "'dr' used during 'am' non adaptive interval"                );
+  m_parser->registerOption<bool        >(m_option_am_keepInitialMatrix,                       m_amKeepInitialMatrix,                       "'am' keep initial (given) matrix"                           );
+  m_parser->registerOption<unsigned int>(m_option_am_initialNonAdaptInterval,                 m_amInitialNonAdaptInterval,                 "'am' initial non adaptation interval"                       );
+  m_parser->registerOption<unsigned int>(m_option_am_adaptInterval,                           m_amAdaptInterval,                           "'am' adaptation interval"                                   );
+  m_parser->registerOption<unsigned int>(m_option_am_adaptedMatrices_dataOutputPeriod,        m_amAdaptedMatricesDataOutputPeriod,        "period for outputting 'am' adapted matrices"                );
+  m_parser->registerOption<std::string >(m_option_am_adaptedMatrices_dataOutputFileName,      m_amAdaptedMatricesDataOutputFileName,      "name of output file for 'am' adapted matrices"              );
+  m_parser->registerOption<std::string >(m_option_am_adaptedMatrices_dataOutputFileType,      m_amAdaptedMatricesDataOutputFileType,      "type of output file for 'am' adapted matrices"              );
+  m_parser->registerOption<bool        >(m_option_am_adaptedMatrices_dataOutputAllowAll,      m_amAdaptedMatricesDataOutputAllowAll,      "type of output file for 'am' adapted matrices"              );
+  m_parser->registerOption<std::string >(m_option_am_adaptedMatrices_dataOutputAllowedSet,    container_to_string(m_amAdaptedMatricesDataOutputAllowedSet), "type of output file for 'am' adapted matrices"              );
+  m_parser->registerOption<double      >(m_option_am_eta,                                     m_amEta,                                     "'am' eta"                                                   );
+  m_parser->registerOption<double      >(m_option_am_epsilon,                                 m_amEpsilon,                                 "'am' epsilon"                                               );
+  m_parser->registerOption<unsigned int>(m_option_enableBrooksGelmanConvMonitor,              m_enableBrooksGelmanConvMonitor,              "assess convergence using Brooks-Gelman metric"              );
+  m_parser->registerOption<unsigned int>(m_option_BrooksGelmanLag,                            m_BrooksGelmanLag,                            "number of chain positions before starting to compute metric");
+  m_parser->registerOption<bool        >(m_option_outputLogLikelihood,                        m_outputLogLikelihood,                        "flag to toggle output of log likelihood values"             );
+  m_parser->registerOption<bool        >(m_option_outputLogTarget,                            m_outputLogTarget,                            "flag to toggle output of log target values"                 );
+  m_parser->registerOption<bool        >(m_option_doLogitTransform,                           m_doLogitTransform,                           "flag to toggle logit transform for bounded domains"         );
+  m_parser->registerOption<std::string >(m_option_algorithm,                                  m_algorithm,                                  "which MCMC algorithm to use"                                );
+  m_parser->registerOption<std::string >(m_option_tk,                                         m_tk,                                         "which MCMC transition kernel to use"                        );
+  m_parser->registerOption<unsigned int>(m_option_updateInterval,                             m_updateInterval,                             "how often to call updateTK method"                          );
+
+  m_parser->scanInputFile();
+
+  m_parser->getOption<std::string >(m_option_help,                                       m_help);
+  m_parser->getOption<std::string >(m_option_dataOutputFileName,                         m_dataOutputFileName);
+  m_parser->getOption<bool        >(m_option_dataOutputAllowAll,                         m_dataOutputAllowAll);
+  m_parser->getOption<std::set<unsigned int> >(m_option_dataOutputAllowedSet,            m_dataOutputAllowedSet);
+  m_parser->getOption<bool        >(m_option_totallyMute,                                m_totallyMute);
+  m_parser->getOption<std::string >(m_option_initialPosition_dataInputFileName,          m_initialPositionDataInputFileName);
+  m_parser->getOption<std::string >(m_option_initialPosition_dataInputFileType,          m_initialPositionDataInputFileType);
+  m_parser->getOption<std::string >(m_option_initialProposalCovMatrix_dataInputFileName, m_initialProposalCovMatrixDataInputFileName);
+  m_parser->getOption<std::string >(m_option_initialProposalCovMatrix_dataInputFileType, m_initialProposalCovMatrixDataInputFileType);
+  m_parser->getOption<std::set<unsigned int> >(m_option_listOfDisabledParameters,        m_parameterDisabledSet);
+  m_parser->getOption<std::string >(m_option_rawChain_dataInputFileName,                 m_rawChainDataInputFileName);
+  m_parser->getOption<std::string >(m_option_rawChain_dataInputFileType,                 m_rawChainDataInputFileType);
+  m_parser->getOption<unsigned int>(m_option_rawChain_size,                              m_rawChainSize);
+  m_parser->getOption<bool        >(m_option_rawChain_generateExtra,                     m_rawChainGenerateExtra);
+  m_parser->getOption<unsigned int>(m_option_rawChain_displayPeriod,                     m_rawChainDisplayPeriod);
+  m_parser->getOption<bool        >(m_option_rawChain_measureRunTimes,                   m_rawChainMeasureRunTimes);
+  m_parser->getOption<unsigned int>(m_option_rawChain_dataOutputPeriod,                  m_rawChainDataOutputPeriod);
+  m_parser->getOption<std::string >(m_option_rawChain_dataOutputFileName,                m_rawChainDataOutputFileName);
+  m_parser->getOption<std::string >(m_option_rawChain_dataOutputFileType,                m_rawChainDataOutputFileType);
+  m_parser->getOption<bool        >(m_option_rawChain_dataOutputAllowAll,                m_rawChainDataOutputAllowAll);
+  m_parser->getOption<std::set<unsigned int> >(m_option_rawChain_dataOutputAllowedSet,   m_rawChainDataOutputAllowedSet);
+#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  m_parser->getOption<bool        >(m_option_rawChain_computeStats,                      m_rawChain_computeStats);
+#endif
+  m_parser->getOption<bool        >(m_option_filteredChain_generate,                     m_filteredChainGenerate);
+  m_parser->getOption<double      >(m_option_filteredChain_discardedPortion,             m_filteredChainDiscardedPortion);
+  m_parser->getOption<unsigned int>(m_option_filteredChain_lag,                          m_filteredChainLag);
+  m_parser->getOption<std::string >(m_option_filteredChain_dataOutputFileName,           m_filteredChainDataOutputFileName);
+  m_parser->getOption<std::string >(m_option_filteredChain_dataOutputFileType,           m_filteredChainDataOutputFileType);
+  m_parser->getOption<bool        >(m_option_filteredChain_dataOutputAllowAll,           m_filteredChainDataOutputAllowAll);
+  m_parser->getOption<std::set<unsigned int> >(m_option_filteredChain_dataOutputAllowedSet,         m_filteredChainDataOutputAllowedSet);
+#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  m_parser->getOption<bool        >(m_option_filteredChain_computeStats,                 m_filteredChain_computeStats);
+#endif
+  m_parser->getOption<bool        >(m_option_displayCandidates,                          m_displayCandidates);
+  m_parser->getOption<bool        >(m_option_putOutOfBoundsInChain,                      m_putOutOfBoundsInChain);
+  m_parser->getOption<bool        >(m_option_tk_useLocalHessian,                         m_tkUseLocalHessian);
+  m_parser->getOption<bool        >(m_option_tk_useNewtonComponent,                      m_tkUseNewtonComponent);
+  m_parser->getOption<unsigned int>(m_option_dr_maxNumExtraStages,                       m_drMaxNumExtraStages);
+  m_parser->getOption<std::vector<double> >(m_option_dr_listOfScalesForExtraStages,      m_drScalesForExtraStages);
+  m_parser->getOption<bool        >(m_option_dr_duringAmNonAdaptiveInt,                  m_drDuringAmNonAdaptiveInt);
+  m_parser->getOption<bool        >(m_option_am_keepInitialMatrix,                       m_amKeepInitialMatrix);
+  m_parser->getOption<unsigned int>(m_option_am_initialNonAdaptInterval,                 m_amInitialNonAdaptInterval);
+  m_parser->getOption<unsigned int>(m_option_am_adaptInterval,                           m_amAdaptInterval);
+  m_parser->getOption<unsigned int>(m_option_am_adaptedMatrices_dataOutputPeriod,        m_amAdaptedMatricesDataOutputPeriod);
+  m_parser->getOption<std::string >(m_option_am_adaptedMatrices_dataOutputFileName,      m_amAdaptedMatricesDataOutputFileName);
+  m_parser->getOption<std::string >(m_option_am_adaptedMatrices_dataOutputFileType,      m_amAdaptedMatricesDataOutputFileType);
+  m_parser->getOption<bool        >(m_option_am_adaptedMatrices_dataOutputAllowAll,      m_amAdaptedMatricesDataOutputAllowAll);
+  m_parser->getOption<std::set<unsigned int> >(m_option_am_adaptedMatrices_dataOutputAllowedSet,    m_amAdaptedMatricesDataOutputAllowedSet);
+  m_parser->getOption<double      >(m_option_am_eta,                                     m_amEta);
+  m_parser->getOption<double      >(m_option_am_epsilon,                                 m_amEpsilon);
+  m_parser->getOption<unsigned int>(m_option_enableBrooksGelmanConvMonitor,              m_enableBrooksGelmanConvMonitor);
+  m_parser->getOption<unsigned int>(m_option_BrooksGelmanLag,                            m_BrooksGelmanLag);
+  m_parser->getOption<bool        >(m_option_outputLogLikelihood,                        m_outputLogLikelihood);
+  m_parser->getOption<bool        >(m_option_outputLogTarget,                            m_outputLogTarget);
+  m_parser->getOption<bool        >(m_option_doLogitTransform,                           m_doLogitTransform);
+  m_parser->getOption<std::string >(m_option_algorithm,                                  m_algorithm);
+  m_parser->getOption<std::string >(m_option_tk,                                         m_tk);
+  m_parser->getOption<unsigned int>(m_option_updateInterval,                             m_updateInterval);
+#else
+  m_help = m_env->input()(m_option_help, m_help);
+  m_dataOutputFileName = m_env->input()(m_option_dataOutputFileName, m_dataOutputFileName);
+  m_dataOutputAllowAll = m_env->input()(m_option_dataOutputAllowAll, m_dataOutputAllowAll);
+
+  // UQ_MH_SG_DATA_OUTPUT_ALLOWED_SET_ODV is the empty set (string) by default
+  unsigned int size = m_env->input().vector_variable_size(m_option_dataOutputAllowedSet);
+  for (unsigned int i = 0; i < size; i++) {
+    // We default to empty set, so the default values are actually never used
+    // here
+    unsigned int allowed = m_env->input()(m_option_dataOutputAllowedSet, i, i);
+    m_dataOutputAllowedSet.insert(allowed);
+  }
+
+  m_totallyMute = m_env->input()(m_option_totallyMute, m_totallyMute);
+  m_initialPositionDataInputFileName = m_env->input()(m_option_initialPosition_dataInputFileName, m_initialPositionDataInputFileName);
+  m_initialPositionDataInputFileType = m_env->input()(m_option_initialPosition_dataInputFileType, m_initialPositionDataInputFileType);
+  m_initialProposalCovMatrixDataInputFileName = m_env->input()(m_option_initialProposalCovMatrix_dataInputFileName, m_initialProposalCovMatrixDataInputFileName);
+  m_initialProposalCovMatrixDataInputFileType = m_env->input()(m_option_initialProposalCovMatrix_dataInputFileType, m_initialProposalCovMatrixDataInputFileType);
+
+  // UQ_MH_SG_LIST_OF_DISABLED_PARAMETERS_ODV is the empty set (string) by
+  // default
+  size = m_env->input().vector_variable_size(m_option_listOfDisabledParameters);
+  for (unsigned int i = 0; i < size; i++) {
+    // We default to empty set, so the default values are actually never used
+    // here
+    unsigned int disabled = m_env->input()(m_option_listOfDisabledParameters, i, i);
+    m_parameterDisabledSet.insert(disabled);
+  }
+
+  m_rawChainDataInputFileName = m_env->input()(m_option_rawChain_dataInputFileName, m_rawChainDataInputFileName);
+  m_rawChainDataInputFileType = m_env->input()(m_option_rawChain_dataInputFileType, m_rawChainDataInputFileType);
+  m_rawChainSize = m_env->input()(m_option_rawChain_size, m_rawChainSize);
+  m_rawChainGenerateExtra = m_env->input()(m_option_rawChain_generateExtra, m_rawChainGenerateExtra);
+  m_rawChainDisplayPeriod = m_env->input()(m_option_rawChain_displayPeriod, m_rawChainDisplayPeriod);
+  m_rawChainMeasureRunTimes = m_env->input()(m_option_rawChain_measureRunTimes, m_rawChainMeasureRunTimes);
+  m_rawChainDataOutputPeriod = m_env->input()(m_option_rawChain_dataOutputPeriod, m_rawChainDataOutputPeriod);
+  m_rawChainDataOutputFileName = m_env->input()(m_option_rawChain_dataOutputFileName, m_rawChainDataOutputFileName);
+  m_rawChainDataOutputFileType = m_env->input()(m_option_rawChain_dataOutputFileType, m_rawChainDataOutputFileType);
+  m_rawChainDataOutputAllowAll = m_env->input()(m_option_rawChain_dataOutputAllowAll, m_rawChainDataOutputAllowAll);
+
+  // UQ_MH_SG_RAW_CHAIN_DATA_OUTPUT_ALLOWED_SET_ODV is the empty set (string) by default
+  size = m_env->input().vector_variable_size(m_option_rawChain_dataOutputAllowedSet);
+  for (unsigned int i = 0; i < size; i++) {
+    // We default to empty set, so the default values are actually never used
+    // here
+    unsigned int allowed = m_env->input()(m_option_rawChain_dataOutputAllowedSet, i, i);
+    m_rawChainDataOutputAllowedSet.insert(allowed);
+  }
+
+#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  m_rawChain_computeStats = m_env->input()(m_option_rawChain_computeStats, m_rawChainComputeStats);
+#endif
+  m_filteredChainGenerate = m_env->input()(m_option_filteredChain_generate, m_filteredChainGenerate);
+  m_filteredChainDiscardedPortion = m_env->input()(m_option_filteredChain_discardedPortion, m_filteredChainDiscardedPortion);
+  m_filteredChainLag = m_env->input()(m_option_filteredChain_lag, m_filteredChainLag);
+  m_filteredChainDataOutputFileName = m_env->input()(m_option_filteredChain_dataOutputFileName, m_filteredChainDataOutputFileName);
+  m_filteredChainDataOutputFileType = m_env->input()(m_option_filteredChain_dataOutputFileType, m_filteredChainDataOutputFileType);
+  m_filteredChainDataOutputAllowAll = m_env->input()(m_option_filteredChain_dataOutputAllowAll, m_filteredChainDataOutputAllowAll);
+
+  // UQ_MH_SG_FILTERED_CHAIN_DATA_OUTPUT_ALLOWED_SET_ODV is the empty set (string) by default
+  size = m_env->input().vector_variable_size(m_option_filteredChain_dataOutputAllowedSet);
+  for (unsigned int i = 0; i < size; i++) {
+    // We default to empty set, so the default values are actually never used
+    // here
+    unsigned int allowed = m_env->input()(m_option_filteredChain_dataOutputAllowedSet, i, i);
+    m_filteredChainDataOutputAllowedSet.insert(allowed);
+  }
+
+#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  m_filteredChain_computeStats = m_env->input()(m_option_filteredChain_computeStats, m_filteredChainComputeStats);
+#endif
+  m_displayCandidates = m_env->input()(m_option_displayCandidates, m_displayCandidates);
+  m_putOutOfBoundsInChain = m_env->input()(m_option_putOutOfBoundsInChain, m_putOutOfBoundsInChain);
+  m_tkUseLocalHessian = m_env->input()(m_option_tk_useLocalHessian, m_tkUseLocalHessian);
+  m_tkUseNewtonComponent = m_env->input()(m_option_tk_useNewtonComponent, m_tkUseNewtonComponent);
+  m_drMaxNumExtraStages = m_env->input()(m_option_dr_maxNumExtraStages, m_drMaxNumExtraStages);
+
+  // UQ_MH_SG_DR_LIST_OF_SCALES_FOR_EXTRA_STAGES_ODV is the empty set (string) by default
+  size = m_env->input().vector_variable_size(m_option_dr_listOfScalesForExtraStages);
+  for (unsigned int i = 0; i < size; i++) {
+    // We default to empty set, so the default values are actually never used
+    // here
+    unsigned int allowed = m_env->input()(m_option_dr_listOfScalesForExtraStages, i, i);
+    m_drScalesForExtraStages.push_back(allowed);
+  }
+
+  m_drDuringAmNonAdaptiveInt = m_env->input()(m_option_dr_duringAmNonAdaptiveInt, m_drDuringAmNonAdaptiveInt);
+  m_amKeepInitialMatrix = m_env->input()(m_option_am_keepInitialMatrix, m_amKeepInitialMatrix);
+  m_amInitialNonAdaptInterval = m_env->input()(m_option_am_initialNonAdaptInterval, m_amInitialNonAdaptInterval);
+  m_amAdaptInterval = m_env->input()(m_option_am_adaptInterval, m_amAdaptInterval);
+  m_amAdaptedMatricesDataOutputPeriod = m_env->input()(m_option_am_adaptedMatrices_dataOutputPeriod, m_amAdaptedMatricesDataOutputPeriod);
+  m_amAdaptedMatricesDataOutputFileName = m_env->input()(m_option_am_adaptedMatrices_dataOutputFileName, m_amAdaptedMatricesDataOutputFileName);
+  m_amAdaptedMatricesDataOutputFileType = m_env->input()(m_option_am_adaptedMatrices_dataOutputFileType, m_amAdaptedMatricesDataOutputFileType);
+  m_amAdaptedMatricesDataOutputAllowAll = m_env->input()(m_option_am_adaptedMatrices_dataOutputAllowAll, m_amAdaptedMatricesDataOutputAllowAll);
+
+  // UQ_MH_SG_AM_ADAPTED_MATRICES_DATA_OUTPUT_ALLOWED_SET_ODV is the empty set (string) by default
+  size = m_env->input().vector_variable_size(m_option_am_adaptedMatrices_dataOutputAllowedSet);
+  for (unsigned int i = 0; i < size; i++) {
+    // We default to empty set, so the default values are actually never used
+    // here
+    unsigned int allowed = m_env->input()(m_option_am_adaptedMatrices_dataOutputAllowedSet, i, i);
+    m_amAdaptedMatricesDataOutputAllowedSet.insert(allowed);
+  }
+
+  m_amEta = m_env->input()(m_option_am_eta, m_amEta);
+  m_amEpsilon = m_env->input()(m_option_am_epsilon, m_amEpsilon);
+  m_enableBrooksGelmanConvMonitor = m_env->input()(m_option_enableBrooksGelmanConvMonitor, m_enableBrooksGelmanConvMonitor);
+  m_BrooksGelmanLag = m_env->input()(m_option_BrooksGelmanLag, m_BrooksGelmanLag);
+  m_outputLogLikelihood = m_env->input()(m_option_outputLogLikelihood, m_outputLogLikelihood);
+  m_outputLogTarget = m_env->input()(m_option_outputLogTarget, m_outputLogTarget);
+  m_doLogitTransform = m_env->input()(m_option_doLogitTransform, m_doLogitTransform);
+  m_algorithm = m_env->input()(m_option_algorithm, m_algorithm);
+  m_tk = m_env->input()(m_option_tk, m_tk);
+  m_updateInterval = m_env->input()(m_option_updateInterval, m_updateInterval);
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+
+  checkOptions();
+
+}
 
 }  // End namespace QUESO

--- a/src/stats/src/MonteCarloSGOptions.C
+++ b/src/stats/src/MonteCarloSGOptions.C
@@ -48,63 +48,13 @@ McOptionsValues::McOptionsValues(
   const SsOptionsValues* alternativeQSsOptionsValues
 #endif
   )
-  :
-    m_prefix                          ("mc_"),
-    m_help                       (UQ_MOC_SG_HELP),
-    m_dataOutputFileName         (UQ_MOC_SG_DATA_OUTPUT_FILE_NAME_ODV     ),
-  //m_dataOutputAllowedSet       (),
-    m_pseqDataOutputPeriod       (UQ_MOC_SG_PSEQ_DATA_OUTPUT_PERIOD_ODV   ),
-    m_pseqDataOutputFileName     (UQ_MOC_SG_PSEQ_DATA_OUTPUT_FILE_NAME_ODV),
-    m_pseqDataOutputFileType     (UQ_MOC_SG_PSEQ_DATA_OUTPUT_FILE_TYPE_ODV),
-  //m_pseqDataOutputAllowedSet   (),
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-    m_pseqComputeStats           (UQ_MOC_SG_PSEQ_COMPUTE_STATS_ODV        ),
-#endif
-    m_qseqDataInputFileName      (UQ_MOC_SG_QSEQ_DATA_INPUT_FILE_NAME_ODV ),
-    m_qseqDataInputFileType      (UQ_MOC_SG_QSEQ_DATA_INPUT_FILE_TYPE_ODV ),
-    m_qseqSize                   (UQ_MOC_SG_QSEQ_SIZE_ODV                 ),
-    m_qseqDisplayPeriod          (UQ_MOC_SG_QSEQ_DISPLAY_PERIOD_ODV       ),
-    m_qseqMeasureRunTimes        (UQ_MOC_SG_QSEQ_MEASURE_RUN_TIMES_ODV    ),
-    m_qseqDataOutputPeriod       (UQ_MOC_SG_QSEQ_DATA_OUTPUT_PERIOD_ODV   ),
-    m_qseqDataOutputFileName     (UQ_MOC_SG_QSEQ_DATA_OUTPUT_FILE_NAME_ODV),
-    m_qseqDataOutputFileType     (UQ_MOC_SG_QSEQ_DATA_OUTPUT_FILE_TYPE_ODV),
-  //m_qseqDataOutputAllowedSet   (),
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-    m_qseqComputeStats           (UQ_MOC_SG_QSEQ_COMPUTE_STATS_ODV        ),
-    m_alternativePSsOptionsValues(),
-    m_alternativeQSsOptionsValues(),
-#endif
-#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-    m_parser(NULL),
-#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-    m_option_help                     (m_prefix + "help"                       ),
-    m_option_dataOutputFileName       (m_prefix + "dataOutputFileName"         ),
-    m_option_dataOutputAllowedSet     (m_prefix + "dataOutputAllowedSet"       ),
-    m_option_pseq_dataOutputPeriod    (m_prefix + "pseq_dataOutputPeriod"      ),
-    m_option_pseq_dataOutputFileName  (m_prefix + "pseq_dataOutputFileName"    ),
-    m_option_pseq_dataOutputFileType  (m_prefix + "pseq_dataOutputFileType"    ),
-    m_option_pseq_dataOutputAllowedSet(m_prefix + "pseq_dataOutputAllowedSet"  ),
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-    m_option_pseq_computeStats        (m_prefix + "pseq_computeStats"          ),
-#endif
-    m_option_qseq_dataInputFileName   (m_prefix + "qseq_dataInputFileName"     ),
-    m_option_qseq_dataInputFileType   (m_prefix + "qseq_dataInputFileType"     ),
-    m_option_qseq_size                (m_prefix + "qseq_size"                  ),
-    m_option_qseq_displayPeriod       (m_prefix + "qseq_displayPeriod"         ),
-    m_option_qseq_measureRunTimes     (m_prefix + "qseq_measureRunTimes"       ),
-    m_option_qseq_dataOutputPeriod    (m_prefix + "qseq_dataOutputPeriod"      ),
-    m_option_qseq_dataOutputFileName  (m_prefix + "qseq_dataOutputFileName"    ),
-    m_option_qseq_dataOutputFileType  (m_prefix + "qseq_dataOutputFileType"    ),
-    m_option_qseq_dataOutputAllowedSet(m_prefix + "qseq_dataOutputAllowedSet"  )
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-    ,
-    m_option_qseq_computeStats        (m_prefix + "qseq_computeStats"          )
-#endif
 {
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
   if (alternativePSsOptionsValues) m_alternativePSsOptionsValues = *alternativePSsOptionsValues;
   if (alternativeQSsOptionsValues) m_alternativeQSsOptionsValues = *alternativeQSsOptionsValues;
 #endif
+  this->set_defaults();
+  this->set_prefix("");
 }
 
 McOptionsValues::McOptionsValues(
@@ -114,163 +64,14 @@ McOptionsValues::McOptionsValues(
 #endif
   const BaseEnvironment * env, const char * prefix
   )
-  :
-    m_prefix                          ((std::string)(prefix) + "mc_"),
-    m_help                       (UQ_MOC_SG_HELP),
-    m_dataOutputFileName         (UQ_MOC_SG_DATA_OUTPUT_FILE_NAME_ODV     ),
-  //m_dataOutputAllowedSet       (),
-    m_pseqDataOutputPeriod       (UQ_MOC_SG_PSEQ_DATA_OUTPUT_PERIOD_ODV   ),
-    m_pseqDataOutputFileName     (UQ_MOC_SG_PSEQ_DATA_OUTPUT_FILE_NAME_ODV),
-    m_pseqDataOutputFileType     (UQ_MOC_SG_PSEQ_DATA_OUTPUT_FILE_TYPE_ODV),
-  //m_pseqDataOutputAllowedSet   (),
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-    m_pseqComputeStats           (UQ_MOC_SG_PSEQ_COMPUTE_STATS_ODV        ),
-#endif
-    m_qseqDataInputFileName      (UQ_MOC_SG_QSEQ_DATA_INPUT_FILE_NAME_ODV ),
-    m_qseqDataInputFileType      (UQ_MOC_SG_QSEQ_DATA_INPUT_FILE_TYPE_ODV ),
-    m_qseqSize                   (UQ_MOC_SG_QSEQ_SIZE_ODV                 ),
-    m_qseqDisplayPeriod          (UQ_MOC_SG_QSEQ_DISPLAY_PERIOD_ODV       ),
-    m_qseqMeasureRunTimes        (UQ_MOC_SG_QSEQ_MEASURE_RUN_TIMES_ODV    ),
-    m_qseqDataOutputPeriod       (UQ_MOC_SG_QSEQ_DATA_OUTPUT_PERIOD_ODV   ),
-    m_qseqDataOutputFileName     (UQ_MOC_SG_QSEQ_DATA_OUTPUT_FILE_NAME_ODV),
-    m_qseqDataOutputFileType     (UQ_MOC_SG_QSEQ_DATA_OUTPUT_FILE_TYPE_ODV),
-  //m_qseqDataOutputAllowedSet   (),
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-    m_qseqComputeStats           (UQ_MOC_SG_QSEQ_COMPUTE_STATS_ODV        ),
-    m_alternativePSsOptionsValues(),
-    m_alternativeQSsOptionsValues(),
-#endif
-#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-    m_parser(new BoostInputOptionsParser(env->optionsInputFileName())),
-#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-    m_option_help                     (m_prefix + "help"                       ),
-    m_option_dataOutputFileName       (m_prefix + "dataOutputFileName"         ),
-    m_option_dataOutputAllowedSet     (m_prefix + "dataOutputAllowedSet"       ),
-    m_option_pseq_dataOutputPeriod    (m_prefix + "pseq_dataOutputPeriod"      ),
-    m_option_pseq_dataOutputFileName  (m_prefix + "pseq_dataOutputFileName"    ),
-    m_option_pseq_dataOutputFileType  (m_prefix + "pseq_dataOutputFileType"    ),
-    m_option_pseq_dataOutputAllowedSet(m_prefix + "pseq_dataOutputAllowedSet"  ),
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-    m_option_pseq_computeStats        (m_prefix + "pseq_computeStats"          ),
-#endif
-    m_option_qseq_dataInputFileName   (m_prefix + "qseq_dataInputFileName"     ),
-    m_option_qseq_dataInputFileType   (m_prefix + "qseq_dataInputFileType"     ),
-    m_option_qseq_size                (m_prefix + "qseq_size"                  ),
-    m_option_qseq_displayPeriod       (m_prefix + "qseq_displayPeriod"         ),
-    m_option_qseq_measureRunTimes     (m_prefix + "qseq_measureRunTimes"       ),
-    m_option_qseq_dataOutputPeriod    (m_prefix + "qseq_dataOutputPeriod"      ),
-    m_option_qseq_dataOutputFileName  (m_prefix + "qseq_dataOutputFileName"    ),
-    m_option_qseq_dataOutputFileType  (m_prefix + "qseq_dataOutputFileType"    ),
-    m_option_qseq_dataOutputAllowedSet(m_prefix + "qseq_dataOutputAllowedSet"  )
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-    ,
-    m_option_qseq_computeStats        (m_prefix + "qseq_computeStats"          )
-#endif
 {
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
   if (alternativePSsOptionsValues) m_alternativePSsOptionsValues = *alternativePSsOptionsValues;
   if (alternativeQSsOptionsValues) m_alternativeQSsOptionsValues = *alternativeQSsOptionsValues;
 #endif
 
-#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-  m_parser->registerOption<std::string >(m_option_help,                      UQ_MOC_SG_HELP                            , "produce help message for Monte Carlo distribution calculator");
-  m_parser->registerOption<std::string >(m_option_dataOutputFileName,        UQ_MOC_SG_DATA_OUTPUT_FILE_NAME_ODV       , "name of generic data output file"                            );
-  m_parser->registerOption<std::string >(m_option_dataOutputAllowedSet,      UQ_MOC_SG_DATA_OUTPUT_ALLOWED_SET_ODV     , "subEnvs that will write to generic data output file"         );
-  m_parser->registerOption<unsigned int>(m_option_pseq_dataOutputPeriod,     UQ_MOC_SG_PSEQ_DATA_OUTPUT_PERIOD_ODV     , "period of message display during param sequence generation"  );
-  m_parser->registerOption<std::string >(m_option_pseq_dataOutputFileName,   UQ_MOC_SG_PSEQ_DATA_OUTPUT_FILE_NAME_ODV  , "name of data output file for parameters"                     );
-  m_parser->registerOption<std::string >(m_option_pseq_dataOutputFileType,   UQ_MOC_SG_PSEQ_DATA_OUTPUT_FILE_TYPE_ODV  , "type of data output file for parameters"                     );
-  m_parser->registerOption<std::string >(m_option_pseq_dataOutputAllowedSet, UQ_MOC_SG_PSEQ_DATA_OUTPUT_ALLOWED_SET_ODV, "subEnvs that will write to data output file for parameters"  );
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-  m_parser->registerOption<bool        >(m_option_pseq_computeStats,         UQ_MOC_SG_PSEQ_COMPUTE_STATS_ODV          , "compute statistics on sequence of parameter"                 );
-#endif
-  m_parser->registerOption<std::string >(m_option_qseq_dataInputFileName,    UQ_MOC_SG_QSEQ_DATA_INPUT_FILE_NAME_ODV   , "name of data input file for qois"                            );
-  m_parser->registerOption<std::string >(m_option_qseq_dataInputFileType,    UQ_MOC_SG_QSEQ_DATA_INPUT_FILE_TYPE_ODV   , "type of data input file for qois"                            );
-  m_parser->registerOption<unsigned int>(m_option_qseq_size,                 UQ_MOC_SG_QSEQ_SIZE_ODV                   , "size of qoi sequence"                                        );
-  m_parser->registerOption<unsigned int>(m_option_qseq_displayPeriod,        UQ_MOC_SG_QSEQ_DISPLAY_PERIOD_ODV         , "period of message display during qoi sequence generation"    );
-  m_parser->registerOption<bool        >(m_option_qseq_measureRunTimes,      UQ_MOC_SG_QSEQ_MEASURE_RUN_TIMES_ODV      , "measure run times"                                           );
-  m_parser->registerOption<unsigned int>(m_option_qseq_dataOutputPeriod,     UQ_MOC_SG_QSEQ_DATA_OUTPUT_PERIOD_ODV     , "period of message display during qoi sequence generation"    );
-  m_parser->registerOption<std::string >(m_option_qseq_dataOutputFileName,   UQ_MOC_SG_QSEQ_DATA_OUTPUT_FILE_NAME_ODV  , "name of data output file for qois"                           );
-  m_parser->registerOption<std::string >(m_option_qseq_dataOutputFileType,   UQ_MOC_SG_QSEQ_DATA_OUTPUT_FILE_TYPE_ODV  , "type of data output file for qois"                           );
-  m_parser->registerOption<std::string >(m_option_qseq_dataOutputAllowedSet, UQ_MOC_SG_QSEQ_DATA_OUTPUT_ALLOWED_SET_ODV, "subEnvs that will write to data output file for qois"        );
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-  m_parser->registerOption<bool        >(m_option_qseq_computeStats,         UQ_MOC_SG_QSEQ_COMPUTE_STATS_ODV          , "compute statistics on sequence of qoi"                       );
-#endif
-
-  m_parser->scanInputFile();
-
-  m_parser->getOption<std::string >(m_option_help,        m_help);
-  m_parser->getOption<std::string >(m_option_dataOutputFileName,        m_dataOutputFileName);
-  m_parser->getOption<std::set<unsigned int> >(m_option_dataOutputAllowedSet,      m_dataOutputAllowedSet);
-  m_parser->getOption<unsigned int>(m_option_pseq_dataOutputPeriod,     m_pseqDataOutputPeriod);
-  m_parser->getOption<std::string >(m_option_pseq_dataOutputFileName,   m_pseqDataOutputFileName);
-  m_parser->getOption<std::string >(m_option_pseq_dataOutputFileType,   m_pseqDataOutputFileType);
-  m_parser->getOption<std::set<unsigned int> >(m_option_pseq_dataOutputAllowedSet, m_pseqDataOutputAllowedSet);
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-  m_parser->getOption<bool        >(m_option_pseq_computeStats,         m_pseq_computeStats);
-#endif
-  m_parser->getOption<std::string >(m_option_qseq_dataInputFileName,    m_qseqDataInputFileName);
-  m_parser->getOption<std::string >(m_option_qseq_dataInputFileType,    m_qseqDataInputFileType);
-  m_parser->getOption<unsigned int>(m_option_qseq_size,                 m_qseqSize);
-  m_parser->getOption<unsigned int>(m_option_qseq_displayPeriod,        m_qseqDisplayPeriod);
-  m_parser->getOption<bool        >(m_option_qseq_measureRunTimes,      m_qseqMeasureRunTimes);
-  m_parser->getOption<unsigned int>(m_option_qseq_dataOutputPeriod,     m_qseqDataOutputPeriod);
-  m_parser->getOption<std::string >(m_option_qseq_dataOutputFileName,   m_qseqDataOutputFileName);
-  m_parser->getOption<std::string >(m_option_qseq_dataOutputFileType,   m_qseqDataOutputFileType);
-  m_parser->getOption<std::set<unsigned int> >(m_option_qseq_dataOutputAllowedSet, m_qseqDataOutputAllowedSet);
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-  m_parser->getOption<bool        >(m_option_qseq_computeStats,         m_qseq_computeStats);
-#endif
-#else
-  m_help = env->input()(m_option_help, UQ_MOC_SG_HELP);
-  m_dataOutputFileName = env->input()(m_option_dataOutputFileName, UQ_MOC_SG_DATA_OUTPUT_FILE_NAME_ODV);
-
-  // UQ_MOC_SG_DATA_OUTPUT_ALLOWED_SET_ODV is the empty set (string) by default
-  unsigned int size = env->input().vector_variable_size(m_option_dataOutputAllowedSet);
-  for (unsigned int i = 0; i < size; i++) {
-    // We default to empty set, so the default values are actually never
-    // used here
-    unsigned int allowed = env->input()(m_option_dataOutputAllowedSet, i, i);
-    m_dataOutputAllowedSet.insert(allowed);
-  }
-
-  m_pseqDataOutputPeriod = env->input()(m_option_pseq_dataOutputPeriod, UQ_MOC_SG_PSEQ_DATA_OUTPUT_PERIOD_ODV);
-  m_pseqDataOutputFileName = env->input()(m_option_pseq_dataOutputFileName, UQ_MOC_SG_PSEQ_DATA_OUTPUT_FILE_NAME_ODV);
-  m_pseqDataOutputFileType = env->input()(m_option_pseq_dataOutputFileType, UQ_MOC_SG_PSEQ_DATA_OUTPUT_FILE_TYPE_ODV);
-
-  // UQ_MOC_SG_PSEQ_DATA_OUTPUT_ALLOWED_SET_ODV is the empty set (string) by default
-  size = env->input().vector_variable_size(m_option_pseq_dataOutputAllowedSet);
-  for (unsigned int i = 0; i < size; i++) {
-    // We default to empty set, so the default values are actually never
-    // used here
-    unsigned int allowed = env->input()(m_option_pseq_dataOutputAllowedSet, i, i);
-    m_pseqDataOutputAllowedSet.insert(allowed);
-  }
-
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-  m_pseq_computeStats = env->input()(m_option_pseq_computeStats, UQ_MOC_SG_PSEQ_COMPUTE_STATS_ODV);
-#endif
-  m_qseqDataInputFileName = env->input()(m_option_qseq_dataInputFileName, UQ_MOC_SG_QSEQ_DATA_INPUT_FILE_NAME_ODV);
-  m_qseqDataInputFileType = env->input()(m_option_qseq_dataInputFileType, UQ_MOC_SG_QSEQ_DATA_INPUT_FILE_TYPE_ODV);
-  m_qseqSize = env->input()(m_option_qseq_size, UQ_MOC_SG_QSEQ_SIZE_ODV);
-  m_qseqDisplayPeriod = env->input()(m_option_qseq_displayPeriod, UQ_MOC_SG_QSEQ_DISPLAY_PERIOD_ODV);
-  m_qseqMeasureRunTimes = env->input()(m_option_qseq_measureRunTimes, UQ_MOC_SG_QSEQ_MEASURE_RUN_TIMES_ODV);
-  m_qseqDataOutputPeriod = env->input()(m_option_qseq_dataOutputPeriod, UQ_MOC_SG_QSEQ_DATA_OUTPUT_PERIOD_ODV);
-  m_qseqDataOutputFileName = env->input()(m_option_qseq_dataOutputFileName, UQ_MOC_SG_QSEQ_DATA_OUTPUT_FILE_NAME_ODV);
-  m_qseqDataOutputFileType = env->input()(m_option_qseq_dataOutputFileType, UQ_MOC_SG_QSEQ_DATA_OUTPUT_FILE_TYPE_ODV);
-
-  // UQ_MOC_SG_QSEQ_DATA_OUTPUT_ALLOWED_SET_ODV is the empty set (string) by default
-  size = env->input().vector_variable_size(m_option_qseq_dataOutputAllowedSet);
-  for (unsigned int i = 0; i < size; i++) {
-    // We default to empty set, so the default values are actually never
-    // used here
-    unsigned int allowed = env->input()(m_option_qseq_dataOutputAllowedSet, i, i);
-    m_qseqDataOutputAllowedSet.insert(allowed);
-  }
-
-#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
-  m_qseq_computeStats = env->input()(m_option_qseq_computeStats, UQ_MOC_SG_QSEQ_COMPUTE_STATS_ODV);
-#endif
-#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+  this->set_defaults();
+  this->parse(*env, prefix);
 }
 
 // Copy constructor --------------------------------
@@ -368,6 +169,207 @@ std::ostream & operator<<(std::ostream & os, const McOptionsValues & obj)
 #endif
 
   return os;
+}
+
+
+void McOptionsValues::set_defaults()
+{
+  m_help = UQ_MOC_SG_HELP;
+  m_dataOutputFileName = UQ_MOC_SG_DATA_OUTPUT_FILE_NAME_ODV;
+  //m_dataOutputAllowedSet
+  m_pseqDataOutputPeriod = UQ_MOC_SG_PSEQ_DATA_OUTPUT_PERIOD_ODV;
+  m_pseqDataOutputFileName = UQ_MOC_SG_PSEQ_DATA_OUTPUT_FILE_NAME_ODV;
+  m_pseqDataOutputFileType = UQ_MOC_SG_PSEQ_DATA_OUTPUT_FILE_TYPE_ODV;
+  //m_pseqDataOutputAllowedSet
+#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  m_pseqComputeStats = UQ_MOC_SG_PSEQ_COMPUTE_STATS_ODV;
+#endif
+  m_qseqDataInputFileName = UQ_MOC_SG_QSEQ_DATA_INPUT_FILE_NAME_ODV;
+  m_qseqDataInputFileType = UQ_MOC_SG_QSEQ_DATA_INPUT_FILE_TYPE_ODV;
+  m_qseqSize = UQ_MOC_SG_QSEQ_SIZE_ODV;
+  m_qseqDisplayPeriod = UQ_MOC_SG_QSEQ_DISPLAY_PERIOD_ODV;
+  m_qseqMeasureRunTimes = UQ_MOC_SG_QSEQ_MEASURE_RUN_TIMES_ODV;
+  m_qseqDataOutputPeriod = UQ_MOC_SG_QSEQ_DATA_OUTPUT_PERIOD_ODV;
+  m_qseqDataOutputFileName = UQ_MOC_SG_QSEQ_DATA_OUTPUT_FILE_NAME_ODV;
+  m_qseqDataOutputFileType = UQ_MOC_SG_QSEQ_DATA_OUTPUT_FILE_TYPE_ODV;
+  //m_qseqDataOutputAllowedSet
+#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  m_qseqComputeStats            = UQ_MOC_SG_QSEQ_COMPUTE_STATS_ODV;
+#endif
+}
+
+void McOptionsValues::set_prefix(const std::string& prefix)
+{
+  m_prefix = prefix + "mc_";
+
+  m_option_help = m_prefix + "help";
+  m_option_dataOutputFileName = m_prefix + "dataOutputFileName";
+  m_option_dataOutputAllowedSet = m_prefix + "dataOutputAllowedSet";
+  m_option_pseq_dataOutputPeriod = m_prefix + "pseq_dataOutputPeriod";
+  m_option_pseq_dataOutputFileName = m_prefix + "pseq_dataOutputFileName";
+  m_option_pseq_dataOutputFileType = m_prefix + "pseq_dataOutputFileType";
+  m_option_pseq_dataOutputAllowedSet = m_prefix + "pseq_dataOutputAllowedSet";
+#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  m_option_pseq_computeStats = m_prefix + "pseq_computeStats";
+#endif
+  m_option_qseq_dataInputFileName = m_prefix + "qseq_dataInputFileName";
+  m_option_qseq_dataInputFileType = m_prefix + "qseq_dataInputFileType";
+  m_option_qseq_size = m_prefix + "qseq_size";
+  m_option_qseq_displayPeriod = m_prefix + "qseq_displayPeriod";
+  m_option_qseq_measureRunTimes = m_prefix + "qseq_measureRunTimes";
+  m_option_qseq_dataOutputPeriod = m_prefix + "qseq_dataOutputPeriod";
+  m_option_qseq_dataOutputFileName = m_prefix + "qseq_dataOutputFileName";
+  m_option_qseq_dataOutputFileType = m_prefix + "qseq_dataOutputFileType";
+  m_option_qseq_dataOutputAllowedSet = m_prefix + "qseq_dataOutputAllowedSet";
+#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  m_option_qseq_computeStats = m_prefix + "qseq_computeStats";
+#endif
+}
+
+void McOptionsValues::parse(const BaseEnvironment& env, const std::string& prefix)
+{
+  this->set_prefix(prefix);
+
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+
+  m_parser.reset(new BoostInputOptionsParser(env.optionsInputFileName()));
+
+  m_parser->registerOption<std::string>
+    (m_option_help, m_help,
+     "produce help message for Monte Carlo distribution calculator");
+  m_parser->registerOption<std::string>
+    (m_option_dataOutputFileName, m_dataOutputFileName,
+     "name of generic data output file");
+  m_parser->registerOption<std::string>
+    (m_option_dataOutputAllowedSet, container_to_string(m_dataOutputAllowedSet),
+     "subEnvs that will write to generic data output file");
+  m_parser->registerOption<unsigned int>
+    (m_option_pseq_dataOutputPeriod, m_pseqDataOutputPeriod,
+     "period of message display during param sequence generation");
+  m_parser->registerOption<std::string>
+    (m_option_pseq_dataOutputFileName, m_pseqDataOutputFileName,
+     "name of data output file for parameters");
+  m_parser->registerOption<std::string>
+    (m_option_pseq_dataOutputFileType, m_pseqDataOutputFileType,
+     "type of data output file for parameters");
+  m_parser->registerOption<std::string>
+    (m_option_pseq_dataOutputAllowedSet,
+     container_to_string(m_pseqDataOutputAllowedSet),
+     "subEnvs that will write to data output file for parameters");
+#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  m_parser->registerOption<bool>
+    (m_option_pseq_computeStats, m_pseqComputeStats,
+    "compute statistics on sequence of parameter");
+#endif
+  m_parser->registerOption<std::string>
+    (m_option_qseq_dataInputFileName, m_qseqDataInputFileName,
+    "name of data input file for qois");
+  m_parser->registerOption<std::string>
+    (m_option_qseq_dataInputFileType, m_qseqDataInputFileType,
+    "type of data input file for qois");
+  m_parser->registerOption<unsigned int>
+    (m_option_qseq_size, m_qseqSize, "size of qoi sequence");
+  m_parser->registerOption<unsigned int>
+    (m_option_qseq_displayPeriod, m_qseqDisplayPeriod,
+    "period of message display during qoi sequence generation");
+  m_parser->registerOption<bool>
+    (m_option_qseq_measureRunTimes, m_qseqMeasureRunTimes, "measure run times");
+  m_parser->registerOption<unsigned int>
+    (m_option_qseq_dataOutputPeriod, m_qseqDataOutputPeriod,
+    "period of message display during qoi sequence generation");
+  m_parser->registerOption<std::string>
+    (m_option_qseq_dataOutputFileName, m_qseqDataOutputFileName,
+    "name of data output file for qois");
+  m_parser->registerOption<std::string>
+    (m_option_qseq_dataOutputFileType, m_qseqDataOutputFileType,
+    "type of data output file for qois");
+  m_parser->registerOption<std::string>
+    (m_option_qseq_dataOutputAllowedSet,
+     container_to_string(m_qseqDataOutputAllowedSet),
+    "subEnvs that will write to data output file for qois");
+#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  m_parser->registerOption<bool>
+    (m_option_qseq_computeStats, m_qseqComputeStats,
+     "compute statistics on sequence of qoi");
+#endif
+
+  m_parser->scanInputFile();
+
+  m_parser->getOption<std::string>(m_option_help, m_help);
+  m_parser->getOption<std::string>(m_option_dataOutputFileName, m_dataOutputFileName);
+  m_parser->getOption<std::set<unsigned int> >(m_option_dataOutputAllowedSet, m_dataOutputAllowedSet);
+  m_parser->getOption<unsigned int>(m_option_pseq_dataOutputPeriod, m_pseqDataOutputPeriod);
+  m_parser->getOption<std::string>(m_option_pseq_dataOutputFileName, m_pseqDataOutputFileName);
+  m_parser->getOption<std::string>(m_option_pseq_dataOutputFileType, m_pseqDataOutputFileType);
+  m_parser->getOption<std::set<unsigned int> >(m_option_pseq_dataOutputAllowedSet, m_pseqDataOutputAllowedSet);
+#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  m_parser->getOption<bool>(m_option_pseq_computeStats, m_pseq_computeStats);
+#endif
+  m_parser->getOption<std::string>(m_option_qseq_dataInputFileName, m_qseqDataInputFileName);
+  m_parser->getOption<std::string>(m_option_qseq_dataInputFileType, m_qseqDataInputFileType);
+  m_parser->getOption<unsigned int>(m_option_qseq_size, m_qseqSize);
+  m_parser->getOption<unsigned int>(m_option_qseq_displayPeriod, m_qseqDisplayPeriod);
+  m_parser->getOption<bool>(m_option_qseq_measureRunTimes, m_qseqMeasureRunTimes);
+  m_parser->getOption<unsigned int>(m_option_qseq_dataOutputPeriod, m_qseqDataOutputPeriod);
+  m_parser->getOption<std::string>(m_option_qseq_dataOutputFileName, m_qseqDataOutputFileName);
+  m_parser->getOption<std::string>(m_option_qseq_dataOutputFileType, m_qseqDataOutputFileType);
+  m_parser->getOption<std::set<unsigned int> >(m_option_qseq_dataOutputAllowedSet, m_qseqDataOutputAllowedSet);
+#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  m_parser->getOption<bool>(m_option_qseq_computeStats, m_qseq_computeStats);
+#endif
+#else
+  m_help = env.input()(m_option_help, m_help);
+  m_dataOutputFileName = env.input()(m_option_dataOutputFileName, m_dataOutputFileName);
+
+  // UQ_MOC_SG_DATA_OUTPUT_ALLOWED_SET_ODV is the empty set (string) by default
+  unsigned int size = env.input().vector_variable_size(m_option_dataOutputAllowedSet);
+  for (unsigned int i = 0; i < size; i++) {
+    // We default to empty set, so the default values are actually never
+    // used here
+    unsigned int allowed = env.input()(m_option_dataOutputAllowedSet, i, i);
+    m_dataOutputAllowedSet.insert(allowed);
+  }
+
+  m_pseqDataOutputPeriod = env.input()(m_option_pseq_dataOutputPeriod, m_pseqDataOutputPeriod);
+  m_pseqDataOutputFileName = env.input()(m_option_pseq_dataOutputFileName, m_pseqDataOutputFileName);
+  m_pseqDataOutputFileType = env.input()(m_option_pseq_dataOutputFileType, m_pseqDataOutputFileType);
+
+  // UQ_MOC_SG_PSEQ_DATA_OUTPUT_ALLOWED_SET_ODV is the empty set (string) by default
+  size = env.input().vector_variable_size(m_option_pseq_dataOutputAllowedSet);
+  for (unsigned int i = 0; i < size; i++) {
+    // We default to empty set, so the default values are actually never
+    // used here
+    unsigned int allowed = env.input()(m_option_pseq_dataOutputAllowedSet, i, i);
+    m_pseqDataOutputAllowedSet.insert(allowed);
+  }
+
+#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  m_pseq_computeStats = env.input()(m_option_pseq_computeStats, m_pseq_computeStats);
+#endif
+  m_qseqDataInputFileName = env.input()(m_option_qseq_dataInputFileName, m_qseqDataInputFileName);
+  m_qseqDataInputFileType = env.input()(m_option_qseq_dataInputFileType, m_qseqDataInputFileType);
+  m_qseqSize = env.input()(m_option_qseq_size, m_qseqSize);
+  m_qseqDisplayPeriod = env.input()(m_option_qseq_displayPeriod, m_qseqDisplayPeriod);
+  m_qseqMeasureRunTimes = env.input()(m_option_qseq_measureRunTimes, m_qseqMeasureRunTimes);
+  m_qseqDataOutputPeriod = env.input()(m_option_qseq_dataOutputPeriod, m_qseqDataOutputPeriod);
+  m_qseqDataOutputFileName = env.input()(m_option_qseq_dataOutputFileName, m_qseqDataOutputFileName);
+  m_qseqDataOutputFileType = env.input()(m_option_qseq_dataOutputFileType, m_qseqDataOutputFileType);
+
+  // UQ_MOC_SG_QSEQ_DATA_OUTPUT_ALLOWED_SET_ODV is the empty set (string) by default
+  size = env.input().vector_variable_size(m_option_qseq_dataOutputAllowedSet);
+  for (unsigned int i = 0; i < size; i++) {
+    // We default to empty set, so the default values are actually never
+    // used here
+    unsigned int allowed = env.input()(m_option_qseq_dataOutputAllowedSet, i, i);
+    m_qseqDataOutputAllowedSet.insert(allowed);
+  }
+
+#ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
+  m_qseq_computeStats = env.input()(m_option_qseq_computeStats, m_qseq_computeStats);
+#endif
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+
+  checkOptions();
 }
 
 }  // End namespace QUESO

--- a/src/stats/src/MonteCarloSGOptions.C
+++ b/src/stats/src/MonteCarloSGOptions.C
@@ -48,6 +48,9 @@ McOptionsValues::McOptionsValues(
   const SsOptionsValues* alternativeQSsOptionsValues
 #endif
   )
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+  : m_parser(new BoostInputOptionsParser())
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 {
 #ifdef QUESO_USES_SEQUENCE_STATISTICAL_OPTIONS
   if (alternativePSsOptionsValues) m_alternativePSsOptionsValues = *alternativePSsOptionsValues;

--- a/src/stats/src/StatisticalForwardProblemOptions.C
+++ b/src/stats/src/StatisticalForwardProblemOptions.C
@@ -43,98 +43,15 @@ namespace QUESO {
 
 // Default constructor -----------------------------
 SfpOptionsValues::SfpOptionsValues()
-  :
-    m_prefix                     ("fp_"),
-    m_help(UQ_SFP_HELP),
-    m_computeSolution     (UQ_SFP_COMPUTE_SOLUTION_ODV     ),
-    m_computeCovariances  (UQ_SFP_COMPUTE_COVARIANCES_ODV  ),
-    m_computeCorrelations (UQ_SFP_COMPUTE_CORRELATIONS_ODV ),
-    m_dataOutputFileName  (UQ_SFP_DATA_OUTPUT_FILE_NAME_ODV),
-    //m_dataOutputAllowedSet(),
-#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-    m_parser(NULL),
-#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-    m_option_help                (m_prefix + "help"                ),
-    m_option_computeSolution     (m_prefix + "computeSolution"     ),
-    m_option_computeCovariances  (m_prefix + "computeCovariances"  ),
-    m_option_computeCorrelations (m_prefix + "computeCorrelations" ),
-    m_option_dataOutputFileName  (m_prefix + "dataOutputFileName"  ),
-    m_option_dataOutputAllowedSet(m_prefix + "dataOutputAllowedSet")
-#ifdef UQ_SFP_READS_SOLVER_OPTION
-    m_option_solver              (m_prefix + "solver"              ),
-    m_solverString        (UQ_SFP_SOLVER_ODV               )
-#endif
 {
+  this->set_defaults();
+  this->set_prefix("");
 }
 
-SfpOptionsValues::SfpOptionsValues(const BaseEnvironment * env, const char *
-    prefix)
-  :
-    m_prefix                     ((std::string)(prefix) + "fp_"),
-    m_help(UQ_SFP_HELP),
-    m_computeSolution     (UQ_SFP_COMPUTE_SOLUTION_ODV     ),
-    m_computeCovariances  (UQ_SFP_COMPUTE_COVARIANCES_ODV  ),
-    m_computeCorrelations (UQ_SFP_COMPUTE_CORRELATIONS_ODV ),
-    m_dataOutputFileName  (UQ_SFP_DATA_OUTPUT_FILE_NAME_ODV),
-    //m_dataOutputAllowedSet(),
-#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-    m_parser(new BoostInputOptionsParser(env->optionsInputFileName())),
-#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-    m_option_help                (m_prefix + "help"                ),
-    m_option_computeSolution     (m_prefix + "computeSolution"     ),
-    m_option_computeCovariances  (m_prefix + "computeCovariances"  ),
-    m_option_computeCorrelations (m_prefix + "computeCorrelations" ),
-    m_option_dataOutputFileName  (m_prefix + "dataOutputFileName"  ),
-    m_option_dataOutputAllowedSet(m_prefix + "dataOutputAllowedSet")
-#ifdef UQ_SFP_READS_SOLVER_OPTION
-    m_option_solver              (m_prefix + "solver"              ),
-    m_solverString        (UQ_SFP_SOLVER_ODV               )
-#endif
+SfpOptionsValues::SfpOptionsValues(const BaseEnvironment* env, const char* prefix)
 {
-#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-  m_parser->registerOption<std::string>(m_option_help,                 UQ_SFP_HELP,                        "produce help message for statistical forward problem");
-  m_parser->registerOption<bool       >(m_option_computeSolution,      UQ_SFP_COMPUTE_SOLUTION_ODV       , "compute solution process"                            );
-  m_parser->registerOption<bool       >(m_option_computeCovariances,   UQ_SFP_COMPUTE_COVARIANCES_ODV    , "compute pq covariances"                              );
-  m_parser->registerOption<bool       >(m_option_computeCorrelations,  UQ_SFP_COMPUTE_CORRELATIONS_ODV   , "compute pq correlations"                             );
-  m_parser->registerOption<std::string>(m_option_dataOutputFileName,   UQ_SFP_DATA_OUTPUT_FILE_NAME_ODV  , "name of data output file"                            );
-  m_parser->registerOption<std::string>(m_option_dataOutputAllowedSet, UQ_SFP_DATA_OUTPUT_ALLOWED_SET_ODV, "subEnvs that will write to data output file"         );
-#ifdef UQ_SFP_READS_SOLVER_OPTION
-  m_parser->registerOption<std::string>(m_option_solver,               UQ_SFP_SOLVER_ODV                 , "algorithm for propagation"                           );
-#endif
-
-  m_parser->scanInputFile();
-
-  m_parser->getOption<std::string>(m_option_help,                 m_help);
-  m_parser->getOption<bool       >(m_option_computeSolution,      m_computeSolution);
-  m_parser->getOption<bool       >(m_option_computeCovariances,   m_computeCovariances);
-  m_parser->getOption<bool       >(m_option_computeCorrelations,  m_computeCorrelations);
-  m_parser->getOption<std::string>(m_option_dataOutputFileName,   m_dataOutputFileName);
-  m_parser->getOption<std::set<unsigned int> >(m_option_dataOutputAllowedSet, m_dataOutputAllowedSet);
-#ifdef UQ_SFP_READS_SOLVER_OPTION
-  m_parser->getOption<std::string>(m_option_solver,               m_solver);
-#endif
-#else
-  m_help = env->input()(m_option_help, UQ_SFP_HELP);
-  m_computeSolution = env->input()(m_option_computeSolution, UQ_SFP_COMPUTE_SOLUTION_ODV);
-  m_computeCovariances = env->input()(m_option_computeCovariances, UQ_SFP_COMPUTE_COVARIANCES_ODV);
-  m_computeCorrelations = env->input()(m_option_computeCorrelations, UQ_SFP_COMPUTE_CORRELATIONS_ODV);
-  m_dataOutputFileName = env->input()(m_option_dataOutputFileName, UQ_SFP_DATA_OUTPUT_FILE_NAME_ODV);
-
-  // UQ_SFP_DATA_OUTPUT_ALLOWED_SET_ODV is the empty set (string) by default
-  unsigned int size = env->input().vector_variable_size(m_option_dataOutputAllowedSet);
-  for (unsigned int i = 0; i < size; i++) {
-    // We default to empty set, so the default values are actually never
-    // used here
-    unsigned int allowed = env->input()(m_option_dataOutputAllowedSet, i, i);
-    m_dataOutputAllowedSet.insert(allowed);
-  }
-
-#ifdef UQ_SFP_READS_SOLVER_OPTION
-  m_solver = env->input()(m_option_solver, UQ_SFP_SOLVER_ODV);
-#endif
-#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-
-  checkOptions();
+  this->set_defaults();
+  this->parse(*env, prefix);
 }
 
 // Copy constructor----------------------------------
@@ -198,6 +115,109 @@ operator<<(std::ostream & os, const SfpOptionsValues & obj)
 #endif
   os << std::endl;
   return os;
+}
+
+void
+SfpOptionsValues::set_defaults()
+{
+  m_help = UQ_SFP_HELP;
+  m_computeSolution = UQ_SFP_COMPUTE_SOLUTION_ODV;
+  m_computeCovariances = UQ_SFP_COMPUTE_COVARIANCES_ODV ;
+  m_computeCorrelations = UQ_SFP_COMPUTE_CORRELATIONS_ODV;
+  m_dataOutputFileName = UQ_SFP_DATA_OUTPUT_FILE_NAME_ODV;
+#ifdef UQ_SFP_READS_SOLVER_OPTION
+  m_solverString = UQ_SFP_SOLVER_ODV;
+#endif
+}
+
+void
+SfpOptionsValues::set_prefix(const std::string& prefix)
+{
+  m_prefix = prefix + "fp_";
+
+  m_option_help = m_prefix + "help";
+  m_option_computeSolution = m_prefix + "computeSolution";
+  m_option_computeCovariances = m_prefix + "computeCovariances";
+  m_option_computeCorrelations = m_prefix + "computeCorrelations";
+  m_option_dataOutputFileName = m_prefix + "dataOutputFileName";
+  m_option_dataOutputAllowedSet = m_prefix + "dataOutputAllowedSet";
+#ifdef UQ_SFP_READS_SOLVER_OPTION
+  m_option_solver = m_prefix + "solver";
+#endif
+}
+
+void
+SfpOptionsValues::parse(const BaseEnvironment& env, const std::string& prefix)
+{
+  this->set_prefix(prefix);
+
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+
+  m_parser.reset(new BoostInputOptionsParser(env.optionsInputFileName()));
+
+  m_parser->registerOption<std::string>
+    (m_option_help, m_help,
+     "produce help message for statistical forward problem");
+  m_parser->registerOption<bool>
+    (m_option_computeSolution, m_computeSolution,
+     "compute solution process");
+  m_parser->registerOption<bool>
+    (m_option_computeCovariances, m_computeCovariances,
+     "compute pq covariances");
+  m_parser->registerOption<bool>
+    (m_option_computeCorrelations, m_computeCorrelations,
+     "compute pq correlations");
+  m_parser->registerOption<std::string>
+    (m_option_dataOutputFileName, m_dataOutputFileName,
+     "name of data output file");
+  m_parser->registerOption<std::string>
+    (m_option_dataOutputAllowedSet, container_to_string(m_dataOutputAllowedSet),
+     "subEnvs that will write to data output file");
+#ifdef UQ_SFP_READS_SOLVER_OPTION
+  m_parser->registerOption<std::string>
+    (m_option_solver, m_solver,
+     "algorithm for propagation");
+#endif
+
+  m_parser->scanInputFile();
+
+  m_parser->getOption<std::string>(m_option_help, m_help);
+  m_parser->getOption<bool>(m_option_computeSolution, m_computeSolution);
+  m_parser->getOption<bool>(m_option_computeCovariances, m_computeCovariances);
+  m_parser->getOption<bool>(m_option_computeCorrelations, m_computeCorrelations);
+  m_parser->getOption<std::string>
+    (m_option_dataOutputFileName, m_dataOutputFileName);
+  m_parser->getOption<std::set<unsigned int> >
+    (m_option_dataOutputAllowedSet, m_dataOutputAllowedSet);
+#ifdef UQ_SFP_READS_SOLVER_OPTION
+  m_parser->getOption<std::string>(m_option_solver, m_solver);
+#endif
+#else
+  m_help = env.input()(m_option_help, UQ_SFP_HELP);
+  m_computeSolution = env.input()(m_option_computeSolution, m_computeSolution);
+  m_computeCovariances = env.input()
+    (m_option_computeCovariances, m_computeCovariances);
+  m_computeCorrelations = env.input()
+    (m_option_computeCorrelations, m_computeCorrelations);
+  m_dataOutputFileName = env.input()
+    (m_option_dataOutputFileName, m_dataOutputFileName);
+
+  // UQ_SFP_DATA_OUTPUT_ALLOWED_SET_ODV is the empty set (string) by default
+  unsigned int size =
+    env.input().vector_variable_size(m_option_dataOutputAllowedSet);
+  for (unsigned int i = 0; i < size; i++) {
+    // We default to empty set, so the default values are actually never
+    // used here
+    unsigned int allowed = env.input()(m_option_dataOutputAllowedSet, i, i);
+    m_dataOutputAllowedSet.insert(allowed);
+  }
+
+#ifdef UQ_SFP_READS_SOLVER_OPTION
+  m_solver = env.input()(m_option_solver, m_solver);
+#endif
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+
+  checkOptions();
 }
 
 }  // End namespace QUESO

--- a/src/stats/src/StatisticalForwardProblemOptions.C
+++ b/src/stats/src/StatisticalForwardProblemOptions.C
@@ -43,6 +43,9 @@ namespace QUESO {
 
 // Default constructor -----------------------------
 SfpOptionsValues::SfpOptionsValues()
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+  : m_parser(new BoostInputOptionsParser())
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 {
   this->set_defaults();
   this->set_prefix("");

--- a/src/stats/src/StatisticalInverseProblemOptions.C
+++ b/src/stats/src/StatisticalInverseProblemOptions.C
@@ -43,99 +43,18 @@ namespace QUESO {
 
 // Default constructor -----------------------------
 SipOptionsValues::SipOptionsValues()
-  :
-  m_prefix("ip_"),
-  m_help(UQ_SIP_HELP),
-  m_computeSolution     (UQ_SIP_COMPUTE_SOLUTION_ODV     ),
-  m_dataOutputFileName  (UQ_SIP_DATA_OUTPUT_FILE_NAME_ODV),
-  m_seedWithMAPEstimator(UQ_SIP_SEEDWITHMAPESTIMATOR),
-  m_useOptimizerMonitor(UQ_SIP_USEOPTIMIZERMONITOR),
-//m_dataOutputAllowedSet(),
-#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-  m_parser(),
-#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-  m_option_help                (m_prefix + "help"                ),
-  m_option_computeSolution     (m_prefix + "computeSolution"     ),
-  m_option_dataOutputFileName  (m_prefix + "dataOutputFileName"  ),
-  m_option_dataOutputAllowedSet(m_prefix + "dataOutputAllowedSet"),
-#ifdef UQ_SIP_READS_SOLVER_OPTION
-  m_option_solver              (m_prefix + "solver"              ),
-  m_solverString        (UQ_SIP_SOLVER_ODV)
-#endif
-  m_option_seedWithMAPEstimator(m_prefix + "seedWithMAPEstimator"),
-  m_option_useOptimizerMonitor(m_prefix + "useOptimizerMonitor")
 {
+  this->set_defaults();
+  this->set_prefix("");
 }
 
-SipOptionsValues::SipOptionsValues(const BaseEnvironment * env, const char *
-    prefix)
-  :
-  m_prefix((std::string)(prefix) + "ip_"),
-  m_help(UQ_SIP_HELP),
-  m_computeSolution     (UQ_SIP_COMPUTE_SOLUTION_ODV     ),
-  m_dataOutputFileName  (UQ_SIP_DATA_OUTPUT_FILE_NAME_ODV),
-  m_seedWithMAPEstimator(UQ_SIP_SEEDWITHMAPESTIMATOR),
-  m_useOptimizerMonitor(UQ_SIP_USEOPTIMIZERMONITOR),
-//m_dataOutputAllowedSet(),
-#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-  m_parser(new BoostInputOptionsParser(env->optionsInputFileName())),
-#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-  m_option_help                (m_prefix + "help"                ),
-  m_option_computeSolution     (m_prefix + "computeSolution"     ),
-  m_option_dataOutputFileName  (m_prefix + "dataOutputFileName"  ),
-  m_option_dataOutputAllowedSet(m_prefix + "dataOutputAllowedSet"),
-#ifdef UQ_SIP_READS_SOLVER_OPTION
-  m_option_solver              (m_prefix + "solver"              ),
-  m_solverString        (UQ_SIP_SOLVER_ODV)
-#endif
-  m_option_seedWithMAPEstimator(m_prefix + "seedWithMAPEstimator"),
-  m_option_useOptimizerMonitor(m_prefix + "useOptimizerMonitor")
+SipOptionsValues::SipOptionsValues(const BaseEnvironment* env,
+				   const char* prefix)
 {
-#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-  m_parser->registerOption<std::string>(m_option_help, UQ_SIP_HELP, "produce help message for statistical inverse problem");
-  m_parser->registerOption<bool       >(m_option_computeSolution,      UQ_SIP_COMPUTE_SOLUTION_ODV       , "compute solution process"                            );
-  m_parser->registerOption<std::string>(m_option_dataOutputFileName,   UQ_SIP_DATA_OUTPUT_FILE_NAME_ODV  , "name of data output file"                            );
-  m_parser->registerOption<std::string>(m_option_dataOutputAllowedSet, UQ_SIP_DATA_OUTPUT_ALLOWED_SET_ODV, "subEnvs that will write to data output file"         );
-#ifdef UQ_SIP_READS_SOLVER_OPTION
-  m_parser->registerOption<std::string>(m_option_solver,               UQ_SIP_SOLVER_ODV                 , "algorithm for calibration"                           );
-#endif
-  m_parser->registerOption<bool       >(m_option_seedWithMAPEstimator, UQ_SIP_SEEDWITHMAPESTIMATOR       , "toggle for seeding chain at MAP"                     );
-  m_parser->registerOption<bool       >(m_option_useOptimizerMonitor,  UQ_SIP_USEOPTIMIZERMONITOR        , "toggle for using optimizer monitor (prints diagnostics");
-
-  m_parser->scanInputFile();
-
-  m_parser->getOption<std::string>(m_option_help, m_help);
-  m_parser->getOption<bool       >(m_option_computeSolution,      m_computeSolution);
-  m_parser->getOption<std::string>(m_option_dataOutputFileName,   m_dataOutputFileName);
-  m_parser->getOption<std::set<unsigned int> >(m_option_dataOutputAllowedSet, m_dataOutputAllowedSet);
-#ifdef UQ_SIP_READS_SOLVER_OPTION
-  m_parser->getOption<std::string>(m_option_solver,               m_solver);
-#endif
-  m_parser->getOption<bool       >(m_option_seedWithMAPEstimator, m_seedWithMAPEstimator);
-  m_parser->getOption<bool       >(m_option_useOptimizerMonitor,  m_useOptimizerMonitor);
-#else
-  m_help = env->input()(m_option_help, UQ_SIP_HELP);
-  m_computeSolution = env->input()(m_option_computeSolution, UQ_SIP_COMPUTE_SOLUTION_ODV);
-  m_dataOutputFileName = env->input()(m_option_dataOutputFileName, UQ_SIP_DATA_OUTPUT_FILE_NAME_ODV);
-
-  // UQ_SIP_DATA_OUTPUT_ALLOWED_SET_ODV is the empty set (string) by default
-  unsigned int size = env->input().vector_variable_size(m_option_dataOutputAllowedSet);
-  for (unsigned int i = 0; i < size; i++) {
-    // We default to empty set, so the default values are actually never
-    // used here
-    unsigned int allowed = env->input()(m_option_dataOutputAllowedSet, i, i);
-    m_dataOutputAllowedSet.insert(allowed);
-  }
-
-#ifdef UQ_SIP_READS_SOLVER_OPTION
-  m_solver = env->input()(m_option_solver, UQ_SIP_SOLVER_ODV);
-#endif
-  m_seedWithMAPEstimator = env->input()(m_option_seedWithMAPEstimator, UQ_SIP_SEEDWITHMAPESTIMATOR);
-  m_useOptimizerMonitor = env->input()(m_option_useOptimizerMonitor,  UQ_SIP_USEOPTIMIZERMONITOR);
-#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
-
-  checkOptions();
+  this->set_defaults();
+  this->parse(*env, prefix);
 }
+
 // Copy constructor - -----------------------------
 SipOptionsValues::SipOptionsValues(const SipOptionsValues& src)
 {
@@ -187,6 +106,115 @@ operator<<(std::ostream& os, const SipOptionsValues & obj)
 #endif
   os << std::endl;
   return os;
+}
+
+
+void
+SipOptionsValues::set_defaults()
+{
+  m_help = UQ_SIP_HELP;
+  m_computeSolution = UQ_SIP_COMPUTE_SOLUTION_ODV;
+  m_dataOutputFileName = UQ_SIP_DATA_OUTPUT_FILE_NAME_ODV;
+  m_seedWithMAPEstimator = UQ_SIP_SEEDWITHMAPESTIMATOR;
+  m_useOptimizerMonitor = UQ_SIP_USEOPTIMIZERMONITOR;
+//m_dataOutputAllowedSet()
+#ifdef UQ_SIP_READS_SOLVER_OPTION
+  m_solverString = UQ_SIP_SOLVER_ODV;
+#endif
+}
+
+void
+SipOptionsValues::set_prefix(const std::string& prefix)
+{
+  m_prefix = prefix + "ip_";
+
+  m_option_help = m_prefix + "help";
+  m_option_computeSolution = m_prefix + "computeSolution";
+  m_option_dataOutputFileName = m_prefix + "dataOutputFileName";
+  m_option_dataOutputAllowedSet = m_prefix + "dataOutputAllowedSet";
+#ifdef UQ_SIP_READS_SOLVER_OPTION
+  m_option_solver = m_prefix + "solver";
+#endif
+  m_option_seedWithMAPEstimator = m_prefix + "seedWithMAPEstimator";
+  m_option_useOptimizerMonitor = m_prefix + "useOptimizerMonitor";
+}
+
+void
+SipOptionsValues::parse(const BaseEnvironment& env, const std::string& prefix)
+{
+  this->set_prefix(prefix);
+
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+
+  m_parser.reset(new BoostInputOptionsParser(env.optionsInputFileName()));
+
+  m_parser->registerOption<std::string>
+    (m_option_help, m_help,
+    "produce help message for statistical inverse problem");
+  m_parser->registerOption<bool>
+    (m_option_computeSolution, m_computeSolution,
+    "compute solution process");
+  m_parser->registerOption<std::string>
+    (m_option_dataOutputFileName, m_dataOutputFileName,
+    "name of data output file");
+  m_parser->registerOption<std::string>
+    (m_option_dataOutputAllowedSet, container_to_string(m_dataOutputAllowedSet),
+    "subEnvs that will write to data output file");
+#ifdef UQ_SIP_READS_SOLVER_OPTION
+  m_parser->registerOption<std::string>
+    (m_option_solver, m_solver,
+    "algorithm for calibration");
+#endif
+  m_parser->registerOption<bool>
+    (m_option_seedWithMAPEstimator, m_seedWithMAPEstimator,
+    "toggle for seeding chain at MAP");
+  m_parser->registerOption<bool>
+    (m_option_useOptimizerMonitor, m_useOptimizerMonitor,
+    "toggle for using optimizer monitor (prints diagnostics");
+
+  m_parser->scanInputFile();
+
+  m_parser->getOption<std::string>(m_option_help, m_help);
+  m_parser->getOption<bool>(m_option_computeSolution, m_computeSolution);
+  m_parser->getOption<std::string>
+    (m_option_dataOutputFileName, m_dataOutputFileName);
+  m_parser->getOption<std::set<unsigned int> >
+    (m_option_dataOutputAllowedSet, m_dataOutputAllowedSet);
+#ifdef UQ_SIP_READS_SOLVER_OPTION
+  m_parser->getOption<std::string>(m_option_solver, m_solver);
+#endif
+  m_parser->getOption<bool>
+    (m_option_seedWithMAPEstimator, m_seedWithMAPEstimator);
+  m_parser->getOption<bool>
+    (m_option_useOptimizerMonitor, m_useOptimizerMonitor);
+
+#else
+
+  m_help = env.input()(m_option_help, m_help);
+  m_computeSolution = env.input()(m_option_computeSolution, m_computeSolution);
+  m_dataOutputFileName = env.input()
+    (m_option_dataOutputFileName, m_dataOutputFileName);
+
+  // UQ_SIP_DATA_OUTPUT_ALLOWED_SET_ODV is the empty set (string) by default
+  unsigned int size =
+    env.input().vector_variable_size(m_option_dataOutputAllowedSet);
+  for (unsigned int i = 0; i < size; i++) {
+    // We default to empty set, so the default values are actually never
+    // used here
+    unsigned int allowed = env.input()(m_option_dataOutputAllowedSet, i, i);
+    m_dataOutputAllowedSet.insert(allowed);
+  }
+
+#ifdef UQ_SIP_READS_SOLVER_OPTION
+  m_solver = env.input()(m_option_solver, m_solver);
+#endif
+  m_seedWithMAPEstimator = env.input()
+    (m_option_seedWithMAPEstimator, m_seedWithMAPEstimator);
+  m_useOptimizerMonitor = env.input()
+    (m_option_useOptimizerMonitor, m_useOptimizerMonitor);
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+
+  checkOptions();
 }
 
 }  // End namespace QUESO

--- a/src/stats/src/StatisticalInverseProblemOptions.C
+++ b/src/stats/src/StatisticalInverseProblemOptions.C
@@ -43,6 +43,9 @@ namespace QUESO {
 
 // Default constructor -----------------------------
 SipOptionsValues::SipOptionsValues()
+#ifndef QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
+  : m_parser(new BoostInputOptionsParser())
+#endif  // QUESO_DISABLE_BOOST_PROGRAM_OPTIONS
 {
   this->set_defaults();
   this->set_prefix("");


### PR DESCRIPTION
I'm seeking preliminary feedback on this before forging ahead.

Tests break when Boost Program Options are enabled, but they seem to on dev as well.  Guidance?
  FAIL: test_BoostInputOptionsParser
  FAIL: t01_valid_cycle/rtest01.sh
  (HANGS or SLOW): test_mala

I'm going to mark up the code myself with questions.  Also these general ones:
 * Should I further condense code shared between FullEnvironment::construct(...) variants?
 * Do we anticipate a need for options_have_been_used checking as in GPMSA?
