### PR TITLE
Fix for "make distcheck" with MPI+HDF5 enabled

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -374,6 +374,7 @@ EXTRA_DIST += test_StatisticalInverseProblem/targetout_input.txt
 EXTRA_DIST += test_StatisticalInverseProblem/neither_input.txt
 EXTRA_DIST += test_StatisticalInverseProblem/test_LlhdTargetOutput.sh
 EXTRA_DIST += test_StatisticalInverseProblem/output_test_parallel_h5_expected.h5
+EXTRA_DIST += test_StatisticalInverseProblem/input_test_parallel_h5.txt
 EXTRA_DIST += test_Regression/jeffreys_input.txt
 EXTRA_DIST += test_Regression/test_jeffreys_samples_diff.sh
 EXTRA_DIST += test_Regression/test_jeffreys_samples.m


### PR DESCRIPTION
I suppose Travis doesn't cover that case, so we never noticed the
failure until I was running distcheck manually to fix #626