### PR TITLE
Verify surrogate evaluation point

### DIFF
--- a/src/surrogates/inc/InterpolationSurrogateBase.h
+++ b/src/surrogates/inc/InterpolationSurrogateBase.h
@@ -27,6 +27,9 @@
 
 #include <queso/SurrogateBase.h>
 
+#include <vector>
+
+
 namespace QUESO
 {
   // Forward declarations
@@ -36,7 +39,7 @@ namespace QUESO
   class GslMatrix;
 
   //! Base class for interpolation-based surrogates
-  /*! This class is used for surrogoate approximations of a model using interpolation.
+  /*! This class is used for surrogate approximations of a model using interpolation.
       These surrogates map an \f$ n\f$ dimensional parameter space to the reals.
       That is \f$ f: \mathbb{R}^n \rightarrow \mathbb{R} \f$.
       Subclasses will define behavior of interpolant, but common assumptions
@@ -64,6 +67,8 @@ namespace QUESO
   protected:
 
     const InterpolationSurrogateData<V,M>& m_data;
+
+    void verify_bounds(const V & domainVector) const;
 
   private:
 

--- a/src/surrogates/src/InterpolationSurrogateBase.C
+++ b/src/surrogates/src/InterpolationSurrogateBase.C
@@ -32,6 +32,8 @@
 
 // C++
 #include <sstream>
+#include <vector>
+#include <cmath>
 
 namespace QUESO
 {
@@ -40,6 +42,22 @@ namespace QUESO
     : SurrogateBase<V>(),
     m_data(data)
     {}
+
+  template<class V, class M>
+  void InterpolationSurrogateBase<V,M>::verify_bounds(const V & domainVector) const
+  {
+    for (unsigned int i=0; i<domainVector.sizeGlobal(); ++i)
+      {
+        if ( (std::isnan(domainVector[i])) || (domainVector[i] > this->m_data.x_max(i)) || (domainVector[i] < this->m_data.x_min(i)) )
+          {
+            std::stringstream ss;
+            ss  <<"ERROR: Cannot evaluate surrogate outside bounds for parameter " <<i
+                <<", value requested: " <<domainVector[i] <<std::endl;
+
+            queso_error_msg(ss.str());
+          }
+      }
+  }
 
 } // end namespace QUESO
 

--- a/src/surrogates/src/LinearLagrangeInterpolationSurrogate.C
+++ b/src/surrogates/src/LinearLagrangeInterpolationSurrogate.C
@@ -41,6 +41,9 @@ namespace QUESO
   template<class V, class M>
   double LinearLagrangeInterpolationSurrogate<V,M>::evaluate(const V & domainVector) const
   {
+    // Verify that the requested evaluation point is within the data bounds
+    this->verify_bounds(domainVector);
+
     /* Populate indices. These are the lower bound global indices for the
        "element" containing the domainVector */
     std::vector<unsigned int> indices(this->m_data.dim());


### PR DESCRIPTION
Adds a helper function to `InterpolationSurrogateBase` to make sure each component of the surrogate evaluation point is within the proper bounds and is not NaN.

This was not checked before. When the `domainVector` was outside the surrogate bounds, it would just return garbage values and lead to difficult to diagnose issues upstream.

Also, what's a "surrogoate"? ;-p