### PR TITLE
Use old codecov script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ script:
   - make lcov-report
   - make -j4 distcheck
 after_success:
-    - bash <(curl -s https://codecov.io/bash)
+  - bash <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/0b376529f626b50b7d4a9fb734e0e50d28b9b91e/codecov)


### PR DESCRIPTION
As in https://github.com/codecov/codecov-bash/issues/162 their newest
script was giving us a bunch of "no executable lines" (and in our case
at least "no branches", "no calls"), flooding the Travis CI output so
badly it killed the job.