### PR TITLE
Fix libMesh header, namespace usage

### DIFF
--- a/src/core/src/LibMeshFunction.C
+++ b/src/core/src/LibMeshFunction.C
@@ -58,6 +58,7 @@
 #include <libmesh/string_to_enum.h>
 #include <libmesh/enum_order.h>
 #include <libmesh/enum_fe_family.h>
+#include <libmesh/enum_norm_type.h>
 
 namespace QUESO {
 
@@ -69,8 +70,8 @@ LibMeshFunction::LibMeshFunction(
 {
   this->equation_systems->add_system<libMesh::ExplicitSystem>("Function");
   this->equation_systems->get_system("Function").add_variable("u",
-      libMesh::Utility::string_to_enum<libMeshEnums::Order>(this->builder.order),
-      libMesh::Utility::string_to_enum<libMeshEnums::FEFamily>(this->builder.family));
+      libMesh::Utility::string_to_enum<libMesh::Order>(this->builder.order),
+      libMesh::Utility::string_to_enum<libMesh::FEFamily>(this->builder.family));
   this->equation_systems->init();
 }
 
@@ -131,7 +132,7 @@ double LibMeshFunction::L2_norm() const {
     this->equation_systems->get_system<libMesh::ExplicitSystem>("Function");
 
   double norm = system.calculate_norm(*system.solution,
-                                      libMesh::SystemNorm(libMeshEnums::L2));
+                                      libMesh::SystemNorm(libMesh::L2));
   return norm;
 }
 

--- a/src/core/src/LibMeshNegativeLaplacianOperator.C
+++ b/src/core/src/LibMeshNegativeLaplacianOperator.C
@@ -48,8 +48,9 @@
 #include <libmesh/dirichlet_boundaries.h>
 #include <libmesh/utility.h>
 #include <libmesh/string_to_enum.h>
-#include <libmesh/enum_order.h>
+#include <libmesh/enum_eigen_solver_type.h>
 #include <libmesh/enum_fe_family.h>
+#include <libmesh/enum_order.h>
 
 namespace QUESO {
 
@@ -68,8 +69,8 @@ LibMeshNegativeLaplacianOperator::LibMeshNegativeLaplacianOperator(
   // Adds the variable "u" to "Eigensystem".   "u"
   // will be approximated using second-order approximation.
   unsigned int u_var = eigen_system.add_variable("u",
-      libMesh::Utility::string_to_enum<libMeshEnums::Order>(this->builder.order),
-      libMesh::Utility::string_to_enum<libMeshEnums::FEFamily>(this->builder.family));
+      libMesh::Utility::string_to_enum<libMesh::Order>(this->builder.order),
+      libMesh::Utility::string_to_enum<libMesh::FEFamily>(this->builder.family));
 
   // This works because *this is a subclass of System::Assembly
   // and requires the class to implement an 'assemble'
@@ -89,12 +90,12 @@ LibMeshNegativeLaplacianOperator::LibMeshNegativeLaplacianOperator(
 
   // Set the type of the problem, here we deal with
   // a generalized Hermitian problem.
-  eigen_system.set_eigenproblem_type(libMeshEnums::GHEP);
+  eigen_system.set_eigenproblem_type(libMesh::GHEP);
 
   // Order the eigenvalues "smallest first"
   // This hoses performance?
   eigen_system.eigen_solver->set_position_of_spectrum
-    (libMeshEnums::SMALLEST_MAGNITUDE);
+    (libMesh::SMALLEST_MAGNITUDE);
 
   // Set up the boundary (only works if this->m is a square)
   // We'll just the whole boundary to be Dirichlet, because why not

--- a/test/test_infinite/test_inf_gaussian.C
+++ b/test/test_infinite/test_inf_gaussian.C
@@ -46,7 +46,7 @@ int main(int argc, char **argv)
 
   libMesh::Mesh mesh(init.comm());
   libMesh::MeshTools::Generation::build_square(mesh,
-      20, 20, 0.0, 1.0, 0.0, 1.0, libMeshEnums::QUAD4);
+      20, 20, 0.0, 1.0, 0.0, 1.0, libMesh::QUAD4);
 
   QUESO::FunctionOperatorBuilder fobuilder;
 

--- a/test/test_infinite/test_inf_options.C
+++ b/test/test_infinite/test_inf_options.C
@@ -72,7 +72,7 @@ int main(int argc, char **argv)
 
   libMesh::Mesh mesh(init.comm());
   libMesh::MeshTools::Generation::build_square(mesh,
-      20, 20, 0.0, 1.0, 0.0, 1.0, libMeshEnums::QUAD4);
+      20, 20, 0.0, 1.0, 0.0, 1.0, libMesh::QUAD4);
 
   QUESO::FunctionOperatorBuilder fobuilder;
 

--- a/test/test_infinite/test_operator.C
+++ b/test/test_infinite/test_operator.C
@@ -16,6 +16,7 @@
 #include <libmesh/elem.h>
 #include <libmesh/dof_map.h>
 #include <libmesh/system_norm.h>
+#include <libmesh/enum_norm_type.h>
 #include <queso/EnvironmentOptions.h>
 #include <queso/FunctionOperatorBuilder.h>
 #include <queso/LibMeshFunction.h>
@@ -53,7 +54,7 @@ int main(int argc, char **argv)
 
   libMesh::Mesh mesh(init.comm());
   libMesh::MeshTools::Generation::build_square(mesh,
-      20, 20, 0.0, 1.0, 0.0, 1.0, libMeshEnums::QUAD4);
+      20, 20, 0.0, 1.0, 0.0, 1.0, libMesh::QUAD4);
 
   QUESO::FunctionOperatorBuilder builder;
 
@@ -72,7 +73,7 @@ int main(int argc, char **argv)
   for (i = 0; i < builder.num_req_eigenpairs; i++) {
     eig_sys.get_eigenpair(i);
     norms[i] = eig_sys.calculate_norm(*eig_sys.solution,
-                                      libMesh::SystemNorm(libMeshEnums::L2));
+                                      libMesh::SystemNorm(libMesh::L2));
     if (abs(norms[i] - 1.0) > TEST_TOL) {
       return 1;
     }
@@ -82,7 +83,7 @@ int main(int argc, char **argv)
   const libMesh::DofMap & dof_map = eig_sys.get_dof_map();
   libMesh::FEType fe_type = dof_map.variable_type(0);
   libMesh::UniquePtr<libMesh::FEBase> fe(libMesh::FEBase::build(dim, fe_type));
-  libMesh::QGauss qrule(dim, libMeshEnums::FIFTH);
+  libMesh::QGauss qrule(dim, libMesh::FIFTH);
   fe->attach_quadrature_rule(&qrule);
   const std::vector<libMesh::Real> & JxW = fe->get_JxW();
   const std::vector<std::vector<libMesh::Real> >& phi = fe->get_phi();


### PR DESCRIPTION
I ran into a build failure incidentally while looking at some other
code, but it's an easy set of fixes.  This breaks pre-2014 libMesh
support but adds current (and post-2014?) support.  Not sure why the
libMeshEnums shim namespace in libmesh_common.h didn't workaround the
namespace issues, but there was no workaround for the need to
directly include some enum headers that had previously been indirectly
included.